### PR TITLE
Fix /training: no Strava data, and a page two-thirds the size of the phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,11 @@ handlers are exercised through Node's global `Request`/`Response` with
 A handful of [Playwright](https://playwright.dev) smoke tests in `e2e/`
 (`*.e2e.js`) guard the lowest-risk/highest-value flows — the homepage boots,
 `/dashboard` mounts its widget grid, `/gallery` renders and its photo fetch
-settles. They run against `vite preview` (the static build, no Functions), so
-they assert routes render rather than live data. Install the browser once with
+settles, and `/training` renders its sections without any of them growing wider
+than a phone screen. They run against `vite preview` (the static build, no
+Functions), so they assert routes render rather than live data; `/training`
+needs a payload before it draws anything wide, so it gets one from the real
+metrics engine (`e2e/fixtures/trainingPayload.js`) via a route stub. Install the browser once with
 `npx playwright install chromium`, then `npm run test:e2e`. A full Bach round is
 deliberately **not** an E2E: it spans multiple concurrent clients and external
 OpenAI/TTS/image calls, so its logic is covered by unit tests instead.

--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -1,0 +1,91 @@
+// A full /training payload, built without Strava or Blobs.
+//
+// The E2E suite runs against `vite preview`, which serves no Netlify Functions,
+// so /training would otherwise render its "couldn't load" state — and the parts
+// of the page most likely to break a phone (the charts, the week grid, the run
+// log) are exactly the parts that only exist once there's data. The metrics
+// engine is a pure function of (activities, plan, today), so a synthetic block
+// run through the real engine gives the page a realistic payload to lay out.
+
+import { shapeActivities } from "../../netlify/functions/_shared/training/shape.js";
+import { buildDashboard } from "../../netlify/functions/_shared/training/metrics.js";
+import { loadPlan } from "../../netlify/functions/_shared/training/planFile.js";
+
+// A deterministic generator, so a layout assertion can never fail on a Tuesday
+// only because that week's random distances happened to be long.
+function sequence(seed = 42) {
+	let value = seed;
+	return () => {
+		value = (value * 1103515245 + 12345) % 2147483648;
+		return value / 2147483648;
+	};
+}
+
+const NAMES = [
+	"Morning Run",
+	"Lunch Run",
+	"Evening Run",
+	"Tempo — On Off Ks",
+	"Recovery Shakeout",
+];
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.today] day key the dashboard is built against.
+ * @returns {object} the same shape trainingData serves.
+ */
+export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
+	const plan = loadPlan();
+	const next = sequence();
+	const raw = [];
+	let id = 900000;
+
+	const start = new Date(`${plan.weeks[0].start}T00:00:00Z`);
+	const end = new Date(`${today}T00:00:00Z`);
+	for (const day = new Date(start); day <= end; day.setUTCDate(day.getUTCDate() + 1)) {
+		const dow = day.getUTCDay();
+		if (dow === 1 || dow === 6) continue; // strength / rest
+		const isLong = dow === 0;
+		const distance = isLong ? 16000 + next() * 8000 : 6000 + next() * 6000;
+		const paceSecPerKm = isLong ? 330 + next() * 25 : 300 + next() * 40;
+		const movingTime = Math.round((distance / 1000) * paceSecPerKm);
+		const date = day.toISOString().slice(0, 10);
+
+		raw.push({
+			id: id++,
+			// Deliberately long enough to test that a run title truncates
+			// rather than widening the log.
+			name: isLong ? "Long Run Along the Lakeshore Trail" : NAMES[Math.floor(next() * NAMES.length)],
+			type: "Run",
+			sport_type: "Run",
+			private: false,
+			start_date_local: `${date}T07:12:00Z`,
+			distance,
+			moving_time: movingTime,
+			elapsed_time: movingTime + 90,
+			total_elevation_gain: Math.round(next() * 120),
+			average_heartrate: 138 + next() * 22,
+			max_heartrate: 172 + next() * 15,
+			workout_type: isLong ? 2 : dow === 5 ? 3 : 0,
+			splits_metric: Array.from({ length: Math.floor(distance / 1000) }, () => ({
+				distance: 1000,
+				moving_time: Math.round(paceSecPerKm + (next() - 0.5) * 20),
+				elevation_difference: Math.round((next() - 0.5) * 12),
+				average_heartrate: 140 + next() * 20,
+			})),
+			best_efforts: [
+				{ name: "5k", distance: 5000, elapsed_time: Math.round(paceSecPerKm * 5 * 0.92) },
+				{ name: "10k", distance: 10000, elapsed_time: Math.round(paceSecPerKm * 10 * 0.95) },
+			],
+		});
+	}
+
+	return {
+		...buildDashboard({
+			activities: shapeActivities(raw, { thresholds: plan.thresholds }),
+			plan,
+			today,
+		}),
+		sync: { lastRunAt: `${today}T12:00:00.000Z`, hasSynced: true, outstanding: 0, backfilling: false },
+	};
+}

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -1,0 +1,58 @@
+import { test, expect } from "@playwright/test";
+import { buildTrainingFixture } from "./fixtures/trainingPayload.js";
+
+// /training is the one page on the site built out of charts and dense tables,
+// which makes it the one page that can quietly get wider than a phone. That
+// matters more than it sounds: index.html sets `width=device-width,
+// initial-scale=1`, and without the initial-scale mobile Safari's shrink-to-fit
+// would zoom the WHOLE page out to fit the widest element on it — a single
+// overflowing axis row rendering every other section at ~60% size. Either way
+// the fix is the same: nothing on the page may exceed the viewport width.
+//
+// The suite runs against `vite preview` with no Netlify Functions, so the
+// dashboard payload is stubbed from the real metrics engine (see
+// fixtures/trainingPayload.js) — the page needs data before it draws the wide
+// parts at all.
+
+const PHONE = { width: 390, height: 844 };
+const NARROW_PHONE = { width: 360, height: 800 };
+
+test.beforeEach(async ({ page }) => {
+	const payload = buildTrainingFixture();
+	await page.route("**/.netlify/functions/trainingData*", (route) =>
+		route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(payload) }),
+	);
+});
+
+test("training route renders its sections", async ({ page }) => {
+	await page.goto("/training");
+	await expect(page).toHaveTitle(/Road to Chicago/i);
+	await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Weekly volume" })).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Recent runs" })).toBeVisible();
+});
+
+for (const viewport of [PHONE, NARROW_PHONE]) {
+	test(`training page fits a ${viewport.width}px viewport`, async ({ page }) => {
+		await page.setViewportSize(viewport);
+		await page.goto("/training");
+		await expect(page.getByRole("heading", { name: "Weekly volume" })).toBeVisible();
+
+		const overflow = await page.evaluate(() => {
+			const root = document.documentElement;
+			const widest = [...document.querySelectorAll("main.training *")]
+				.map((el) => ({
+					el,
+					right: el.getBoundingClientRect().right + window.scrollX,
+				}))
+				.filter(({ right }) => right > root.clientWidth + 1)
+				// Name the culprit in the failure message rather than just
+				// reporting a number that doesn't say where to look.
+				.map(({ el, right }) => `${el.tagName.toLowerCase()}.${el.className} → ${Math.round(right)}px`);
+			return { scrollWidth: root.scrollWidth, clientWidth: root.clientWidth, widest };
+		});
+
+		expect(overflow.widest).toEqual([]);
+		expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+	});
+}

--- a/index.html
+++ b/index.html
@@ -34,7 +34,13 @@ https://github.com/maxeisen/
     <meta name="twitter:image" content="https://res.cloudinary.com/meisen-gallery/image/upload/c_fill,h_630,w_1200/c_fit,co_rgb:ffffff,l_text:Georgia_84_bold:Max%20Eisen,w_980/fl_layer_apply,g_center,y_-8/co_rgb:8fc7a9,l_text:Verdana_30_bold_letter_spacing_6:MAXEISEN.ME/fl_layer_apply,g_south,y_66/og/backdrop.png"/>
     <meta charset="UTF-8">
     <meta name="author" content="Max Eisen">
-    <meta name="viewport" content="width=device-width"/>
+    <!-- initial-scale=1 pins the layout viewport to the device width. Without
+         it, mobile Safari falls back to shrink-to-fit: one element wider than
+         the screen zooms the ENTIRE page out to match, so a single overflowing
+         row makes every route it appears on render at ~60% size. Overflow
+         should show up as a scrollbar on the offending element, not as a
+         silently shrunken page. -->
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="description" content="Max Eisen's personal portfolio website."/>
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <!-- Kept in sync with the active light/dark theme by setTheme() below. -->

--- a/netlify.toml
+++ b/netlify.toml
@@ -60,8 +60,8 @@
 
 # Strava sync for /training. Netlify caps scheduled functions at 30s;
 # trainingSync bounds its own work to fit (see DETAIL_BUDGET) and defers the
-# remainder to the next run, so a cold-start backfill fills in over a few hours.
-# The hourly schedule itself is declared in the function's own `config` export.
+# remainder to the next run, so a cold-start backfill fills in over the first
+# hour. The schedule itself is declared in the function's own `config` export.
 [functions."trainingSync"]
   timeout = 30
 

--- a/netlify/functions/_shared/strava.js
+++ b/netlify/functions/_shared/strava.js
@@ -43,3 +43,70 @@ export async function getAccessToken() {
 	cachedToken = { token: data.access_token, expiresAt: data.expires_at * 1000 };
 	return cachedToken.token;
 }
+
+// Strava reports quota usage on every response, as "short,daily" pairs:
+//   x-ratelimit-limit: 200,2000     x-ratelimit-usage: 12,345
+// and read-only equivalents (x-readratelimit-*) covering GETs alone. The
+// short window is 15 minutes. Limits differ per app and Strava has changed
+// the defaults over time, so reading them beats hard-coding a guess.
+function quotaPair(value) {
+	const parts = String(value ?? "")
+		.split(",")
+		.map((n) => Number(n.trim()));
+	return parts.length === 2 && parts.every(Number.isFinite) ? parts : null;
+}
+
+function spentFraction(quota) {
+	const short = quota.shortLimit > 0 ? quota.shortUsage / quota.shortLimit : 0;
+	const daily = quota.dailyLimit > 0 ? quota.dailyUsage / quota.dailyLimit : 0;
+	return Math.max(short, daily);
+}
+
+/**
+ * Read the quota headers off a Strava response.
+ *
+ * When both the overall and read-only buckets are present, the more depleted
+ * one wins — that's the one that will start returning 429s.
+ *
+ * @param {Headers} headers
+ * @returns {{shortUsage: number, shortLimit: number, dailyUsage: number, dailyLimit: number}|null}
+ *   null when the headers are absent or malformed.
+ */
+export function readQuota(headers) {
+	const header = (name) => headers?.get?.(name) ?? null;
+	let worst = null;
+	for (const prefix of ["x-ratelimit", "x-readratelimit"]) {
+		const usage = quotaPair(header(`${prefix}-usage`));
+		const limit = quotaPair(header(`${prefix}-limit`));
+		if (!usage || !limit) continue;
+		const quota = {
+			shortUsage: usage[0],
+			shortLimit: limit[0],
+			dailyUsage: usage[1],
+			dailyLimit: limit[1],
+		};
+		if (!worst || spentFraction(quota) > spentFraction(worst)) worst = quota;
+	}
+	return worst;
+}
+
+/**
+ * How many more requests a caller may make against the quota it last observed.
+ *
+ * The shares exist because one Strava app backs several endpoints here — the
+ * /training sync is a background job and must leave room for the /dashboard
+ * widgets, which are in a visitor's request path.
+ *
+ * @param {object|null} quota from readQuota(); null before the first response.
+ * @param {{shortShare?: number, dailyShare?: number}} [options]
+ * @returns {number} Infinity when no quota has been observed, so callers fall
+ *   back to whatever budget they set for themselves.
+ */
+export function callsRemaining(quota, { shortShare = 1, dailyShare = 1 } = {}) {
+	if (!quota) return Infinity;
+	const short =
+		quota.shortLimit > 0 ? Math.floor(quota.shortLimit * shortShare) - quota.shortUsage : Infinity;
+	const daily =
+		quota.dailyLimit > 0 ? Math.floor(quota.dailyLimit * dailyShare) - quota.dailyUsage : Infinity;
+	return Math.max(0, Math.min(short, daily));
+}

--- a/netlify/functions/_shared/strava.test.js
+++ b/netlify/functions/_shared/strava.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { callsRemaining, readQuota } from "./strava.js";
+
+function headers(map) {
+	return new Headers(map);
+}
+
+describe("readQuota", () => {
+	it("reads the short and daily buckets off a response", () => {
+		expect(
+			readQuota(headers({ "x-ratelimit-limit": "200,2000", "x-ratelimit-usage": "12,345" })),
+		).toEqual({ shortUsage: 12, shortLimit: 200, dailyUsage: 345, dailyLimit: 2000 });
+	});
+
+	// Strava reports an overall bucket and a read-only one. The read bucket is
+	// usually the tighter of the two for this app, and it's the one that will
+	// start refusing first, so it has to win.
+	it("reports whichever bucket is closest to its limit", () => {
+		const quota = readQuota(
+			headers({
+				"x-ratelimit-limit": "200,2000",
+				"x-ratelimit-usage": "20,100",
+				"x-readratelimit-limit": "100,1000",
+				"x-readratelimit-usage": "80,100",
+			}),
+		);
+		expect(quota.shortUsage).toBe(80);
+		expect(quota.shortLimit).toBe(100);
+	});
+
+	it("is null when the headers are missing or malformed", () => {
+		expect(readQuota(headers({}))).toBeNull();
+		expect(readQuota(headers({ "x-ratelimit-limit": "200", "x-ratelimit-usage": "12" }))).toBeNull();
+		expect(readQuota(undefined)).toBeNull();
+	});
+});
+
+describe("callsRemaining", () => {
+	// Nothing observed yet is not the same as nothing left — the caller's own
+	// budget has to stay in charge, or a first request would never be made.
+	it("is unbounded before any quota has been seen", () => {
+		expect(callsRemaining(null)).toBe(Infinity);
+	});
+
+	it("leaves the rest of the window for everything else on the same app", () => {
+		const quota = { shortUsage: 40, shortLimit: 200, dailyUsage: 0, dailyLimit: 2000 };
+		expect(callsRemaining(quota, { shortShare: 0.5 })).toBe(60);
+	});
+
+	it("is bounded by whichever window is tighter", () => {
+		const quota = { shortUsage: 0, shortLimit: 200, dailyUsage: 1990, dailyLimit: 2000 };
+		expect(callsRemaining(quota)).toBe(10);
+	});
+
+	it("never goes negative once a share is already overspent", () => {
+		const quota = { shortUsage: 180, shortLimit: 200, dailyUsage: 0, dailyLimit: 2000 };
+		expect(callsRemaining(quota, { shortShare: 0.5 })).toBe(0);
+	});
+});

--- a/netlify/functions/_tests/trainingData.test.js
+++ b/netlify/functions/_tests/trainingData.test.js
@@ -49,8 +49,12 @@ function rawRun(overrides = {}) {
 
 const PLAN_THRESHOLDS = { maxHr: 195, restingHr: 47, thresholdPaceSecPerKm: 288 };
 
-function seed(records) {
-	store.get.mockImplementation(async (key) => (key === "index.json" ? records : null));
+function seed(records, cursor = null) {
+	store.get.mockImplementation(async (key) => {
+		if (key === "index.json") return records;
+		if (key === "cursor.json") return cursor;
+		return null;
+	});
 }
 
 // Read the body once, as text, and parse from that — the raw JSON is what the
@@ -168,6 +172,33 @@ describe("trainingData behaviour", () => {
 		seed("not an array");
 		const { body } = await payload();
 		expect(body.runs).toEqual([]);
+	});
+
+	// Every metric on the page reads the whole block, so a half-synced index
+	// doesn't produce slightly-off numbers — it produces numbers for training
+	// that didn't happen. The page can only say so if the payload tells it.
+	it("reports that the history is still being imported", async () => {
+		seed(shapeActivities([rawRun()], { thresholds: PLAN_THRESHOLDS }), {
+			lastRunAt: "2026-08-09T12:00:00.000Z",
+			outstanding: 42,
+			stored: 15,
+		});
+		const { body } = await payload();
+		expect(body.sync).toMatchObject({ hasSynced: true, outstanding: 42, backfilling: true });
+	});
+
+	it("distinguishes a complete history from one that has never synced", async () => {
+		seed(shapeActivities([rawRun()], { thresholds: PLAN_THRESHOLDS }), {
+			lastRunAt: "2026-08-09T12:00:00.000Z",
+			outstanding: 0,
+		});
+		expect((await payload()).body.sync).toMatchObject({ hasSynced: true, backfilling: false });
+
+		vi.resetModules();
+		// No cursor at all: the scheduled sync has not completed even once,
+		// which is exactly the state a freshly deployed dashboard is in.
+		seed([], null);
+		expect((await payload()).body.sync).toMatchObject({ hasSynced: false, backfilling: false });
 	});
 
 	it("reports the race it is counting down to", async () => {

--- a/netlify/functions/_tests/trainingSync.test.js
+++ b/netlify/functions/_tests/trainingSync.test.js
@@ -1,0 +1,264 @@
+// The scheduled Strava sync.
+//
+// This is the only writer of the /training history, it can't be invoked over
+// HTTP, and it has to make progress in bounded batches without exhausting a
+// rate limit shared with the /dashboard widgets — so the properties worth
+// asserting are about convergence: every invocation stores something, no
+// invocation loses track of what it didn't get to, and a repeated run finishes
+// the job rather than picking the same newest activities forever.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const blobs = new Map();
+const store = {
+	get: vi.fn(async (key) => blobs.get(key) ?? null),
+	setJSON: vi.fn(async (key, value) => {
+		blobs.set(key, value);
+	}),
+};
+vi.mock("@netlify/blobs", () => ({ getStore: () => store }));
+
+import { SHAPE_VERSION } from "../_shared/training/shape.js";
+
+// A day per activity walking back from the most recent, so "newest first" is
+// unambiguous in the assertions below.
+function summaries(count, overrides = () => ({})) {
+	return Array.from({ length: count }, (_, i) => {
+		const day = new Date(Date.UTC(2026, 6, 1) + (count - i) * 86_400_000)
+			.toISOString()
+			.slice(0, 10);
+		return {
+			id: 1000 + i,
+			name: `Run ${i}`,
+			type: "Run",
+			sport_type: "Run",
+			private: false,
+			start_date_local: `${day}T07:00:00Z`,
+			distance: 10000,
+			moving_time: 3000,
+			...overrides(i),
+		};
+	});
+}
+
+function detailFor(summary) {
+	return {
+		...summary,
+		elapsed_time: 3100,
+		total_elevation_gain: 40,
+		average_heartrate: 150,
+		max_heartrate: 175,
+		splits_metric: [{ distance: 1000, moving_time: 300, elevation_difference: 3 }],
+		best_efforts: [{ name: "5k", distance: 5000, elapsed_time: 1450 }],
+	};
+}
+
+// Stand in for Strava. `quota` is echoed back as rate-limit headers so the
+// budget logic can be driven from a test.
+function mockStrava({ activities = [], quota = null, failStreams = false } = {}) {
+	const calls = [];
+	globalThis.fetch = vi.fn(async (url) => {
+		const target = String(url);
+		calls.push(target);
+		const headers = quota
+			? { "x-ratelimit-limit": quota.limit, "x-ratelimit-usage": quota.usage }
+			: {};
+		const reply = (body, status = 200) =>
+			new Response(JSON.stringify(body), { status, headers });
+
+		if (target.includes("/oauth/token")) {
+			return reply({ access_token: "tok", expires_at: Math.floor(Date.now() / 1000) + 3600 });
+		}
+		if (target.includes("/athlete/activities")) {
+			const page = Number(new URL(target).searchParams.get("page"));
+			return reply(page === 1 ? activities : []);
+		}
+		if (target.includes("/athlete/zones")) {
+			return reply({ heart_rate: { zones: [{ min: 0, max: 130 }] } });
+		}
+		if (/\/activities\/\d+\/streams/.test(target)) {
+			return failStreams ? reply({ message: "no streams" }, 404) : reply({});
+		}
+		const match = target.match(/\/activities\/(\d+)/);
+		if (match) {
+			const summary = activities.find((a) => String(a.id) === match[1]);
+			return reply(detailFor(summary));
+		}
+		throw new Error(`unexpected fetch ${target}`);
+	});
+	return calls;
+}
+
+async function sync(query = "") {
+	const { default: handler } = await import("../trainingSync.js");
+	const res = await handler(
+		new Request(`https://maxeisen.me/.netlify/functions/trainingSync${query}`),
+	);
+	return { res, body: await res.json() };
+}
+
+const index = () => blobs.get("index.json") || [];
+const cursor = () => blobs.get("cursor.json") || {};
+
+beforeEach(() => {
+	vi.resetModules();
+	blobs.clear();
+	store.get.mockClear();
+	store.setJSON.mockClear();
+	process.env.STRAVA_CLIENT_ID = "id";
+	process.env.STRAVA_CLIENT_SECRET = "secret";
+	process.env.STRAVA_REFRESH_TOKEN = "refresh";
+});
+
+describe("trainingSync", () => {
+	it("stores shaped runs on a cold start", async () => {
+		mockStrava({ activities: summaries(3) });
+		const { body } = await sync();
+
+		expect(body.ok).toBe(true);
+		expect(body.synced).toBe(3);
+		expect(index()).toHaveLength(3);
+		expect(index()[0].v).toBe(SHAPE_VERSION);
+		// Oldest first, which is what the metrics engine expects.
+		expect(index().map((a) => a.startDateLocal)).toEqual(
+			[...index().map((a) => a.startDateLocal)].sort(),
+		);
+	});
+
+	it("never enriches other people's business: private runs and rides are dropped", async () => {
+		mockStrava({
+			activities: [
+				...summaries(1),
+				{ ...summaries(1)[0], id: 5001, private: true },
+				{ ...summaries(1)[0], id: 5002, sport_type: "Ride", type: "Ride" },
+			],
+		});
+		const { body } = await sync();
+
+		expect(body.runs).toBe(1);
+		expect(index().map((a) => a.id)).toEqual([1000]);
+	});
+
+	// The budget is what keeps an invocation inside Netlify's 30s cap for
+	// scheduled functions; the cursor is what stops the deferred remainder
+	// being skipped past and never fetched again.
+	it("defers what it can't finish and holds the cursor back until it has", async () => {
+		mockStrava({ activities: summaries(40) });
+		const first = await sync();
+
+		expect(first.body.synced).toBe(30);
+		expect(first.body.outstanding).toBe(10);
+		expect(cursor().lastActivityEpoch).toBeNull();
+
+		const second = await sync();
+		expect(second.body.synced).toBe(10);
+		expect(second.body.outstanding).toBe(0);
+		expect(index()).toHaveLength(40);
+		expect(cursor().lastActivityEpoch).toBeGreaterThan(0);
+	});
+
+	it("fills the most recent weeks first, so a partial page is a current one", async () => {
+		mockStrava({ activities: summaries(40) });
+		await sync();
+
+		const newest = summaries(40)
+			.map((a) => a.start_date_local)
+			.sort()
+			.slice(-30);
+		expect(index().map((a) => a.startDateLocal)).toEqual(newest);
+	});
+
+	// A backfill shares its rate limit with the /dashboard widgets, which are
+	// in a visitor's request path. Stopping short of the limit is the only
+	// thing that keeps those working while this catches up.
+	it("stops enriching once its share of the rate limit is spent", async () => {
+		const calls = mockStrava({
+			activities: summaries(30),
+			quota: { limit: "100,1000", usage: "59,100" },
+		});
+		const { body } = await sync();
+
+		expect(body.quotaPaused).toBe(true);
+		expect(body.synced).toBeLessThan(30);
+		expect(body.outstanding).toBeGreaterThan(0);
+		expect(calls.filter((c) => /\/activities\/\d+\?/.test(c)).length).toBeLessThan(30);
+	});
+
+	it("publishes how much is left so the page can say it's still filling in", async () => {
+		mockStrava({ activities: summaries(40) });
+		await sync();
+
+		expect(cursor()).toMatchObject({ outstanding: 10, stored: 30 });
+		expect(cursor().lastRunAt).toEqual(expect.any(String));
+	});
+
+	// A completed run never changes, so re-listing the block must not re-fetch
+	// what's already stored at the current shape version.
+	it("does no upstream work when it is already caught up", async () => {
+		mockStrava({ activities: summaries(3) });
+		await sync();
+
+		const calls = mockStrava({ activities: summaries(3) });
+		const { body } = await sync();
+
+		expect(body.synced).toBe(0);
+		expect(calls.some((c) => /\/activities\/\d+\?/.test(c))).toBe(false);
+		// Zones don't change on their own either, and every skipped call is
+		// quota left for the widgets.
+		expect(calls.some((c) => c.includes("/athlete/zones"))).toBe(false);
+	});
+
+	// Bumping SHAPE_VERSION is the only way stored records get corrected, since
+	// the derived fields come from streams that aren't kept.
+	it("re-enriches records left behind by an older shape version", async () => {
+		mockStrava({ activities: summaries(2) });
+		await sync();
+		blobs.set(
+			"index.json",
+			index().map((a) => ({ ...a, v: SHAPE_VERSION - 1 })),
+		);
+
+		const { body } = await sync();
+		expect(body.rescan).toBe(true);
+		expect(body.synced).toBe(2);
+		expect(index().every((a) => a.v === SHAPE_VERSION)).toBe(true);
+	});
+
+	it("stores a manual entry that has no streams rather than dropping it", async () => {
+		mockStrava({ activities: summaries(1), failStreams: true });
+		const { body } = await sync();
+
+		expect(body.synced).toBe(1);
+		expect(index()[0].zoneSeconds).toBeNull();
+	});
+
+	it("reports missing credentials instead of writing an empty history", async () => {
+		delete process.env.STRAVA_REFRESH_TOKEN;
+		mockStrava({ activities: summaries(1) });
+
+		const { res, body } = await sync();
+		expect(res.status).toBe(503);
+		expect(body.error).toBe("not_configured");
+		expect(store.setJSON).not.toHaveBeenCalled();
+	});
+
+	it("leaves the stored history alone when Strava can't be listed", async () => {
+		mockStrava({ activities: summaries(2) });
+		await sync();
+		const before = index();
+
+		globalThis.fetch = vi.fn(async (url) =>
+			String(url).includes("/oauth/token")
+				? new Response(
+						JSON.stringify({ access_token: "tok", expires_at: Math.floor(Date.now() / 1000) + 3600 }),
+						{ status: 200 },
+					)
+				: new Response("nope", { status: 500 }),
+		);
+		const { res, body } = await sync();
+
+		expect(res.status).toBe(502);
+		expect(body.error).toBe("strava_failed");
+		expect(index()).toEqual(before);
+	});
+});

--- a/netlify/functions/trainingData.js
+++ b/netlify/functions/trainingData.js
@@ -15,7 +15,7 @@ import { createJsonResponder, cacheControl } from "./_shared/http.js";
 import { createMemo } from "./_shared/memo.js";
 import { buildDashboard } from "./_shared/training/metrics.js";
 import { loadPlan } from "./_shared/training/planFile.js";
-import { INDEX_KEY, getTrainingStore, readJson } from "./_shared/training/store.js";
+import { CURSOR_KEY, INDEX_KEY, getTrainingStore, readJson } from "./_shared/training/store.js";
 import { toDayKey } from "./_shared/training/dates.js";
 
 // The underlying data only changes when the hourly sync runs, so a 10-minute
@@ -26,14 +26,40 @@ const errResponse = createJsonResponder(cacheControl.none);
 // Absorb bursts that get past a cold edge cache.
 const memo = createMemo(60_000);
 
+// Where the sync has got to, in the terms the page needs.
+//
+// Every metric here is a function of the whole history — fitness is a 42-day
+// average, and the race prediction reads the block's best efforts — so a
+// half-filled index doesn't produce slightly-off numbers, it produces numbers
+// for a training block the athlete didn't do. Until the backfill lands, that
+// has to be said out loud rather than left to look like a bad month.
+function syncState(cursor) {
+	const outstanding = Number(cursor?.outstanding);
+	const pending = Number.isFinite(outstanding) ? Math.max(0, outstanding) : 0;
+	return {
+		lastRunAt: cursor?.lastRunAt || null,
+		// No cursor at all means the scheduled sync has never completed —
+		// on a fresh deploy the page is live before the first tick fires.
+		hasSynced: Boolean(cursor?.lastRunAt),
+		outstanding: pending,
+		backfilling: pending > 0,
+	};
+}
+
 async function build(today) {
 	const store = getTrainingStore();
-	const activities = await readJson(store, INDEX_KEY, []);
-	return buildDashboard({
-		activities: Array.isArray(activities) ? activities : [],
-		plan: loadPlan(),
-		today,
-	});
+	const [activities, cursor] = await Promise.all([
+		readJson(store, INDEX_KEY, []),
+		readJson(store, CURSOR_KEY, null),
+	]);
+	return {
+		...buildDashboard({
+			activities: Array.isArray(activities) ? activities : [],
+			plan: loadPlan(),
+			today,
+		}),
+		sync: syncState(cursor),
+	};
 }
 
 export default async function handler() {

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -1,21 +1,29 @@
 // Scheduled incremental sync of Strava runs into the training Blobs store.
 //
-// Runs hourly. The /training page reads only from Blobs, so nothing here is in
-// a user's request path and it can afford to be slow and careful.
+// The /training page reads only from Blobs, so nothing here is in a user's
+// request path and it can afford to be slow and careful.
 //
 // Why a sync at all, rather than fetching on demand: the dashboard needs the
 // whole training block with per-activity detail and streams, which is hundreds
-// of upstream calls. Strava allows roughly 200 requests per 15 minutes, so
-// that can't happen per page load — and the streams are only needed once,
-// since a completed run never changes.
+// of upstream calls. Strava rate-limits per 15 minutes, so that can't happen
+// per page load — and the streams are only needed once, since a completed run
+// never changes.
 //
 // Backfill is handled by the same code path as the incremental case. Each
-// invocation enriches at most DETAIL_BUDGET activities, so a cold start walks
-// backwards through the block over several hours instead of blowing the rate
-// limit in one go. That's deliberate: the first deploy fills in gradually.
+// invocation enriches a bounded number of activities and defers the rest, so a
+// cold start walks backwards through the block over a few invocations instead
+// of blowing the rate limit in one go.
+//
+// Until that backfill finishes the dashboard is showing a truncated history —
+// fitness is a 42-day average, so a partial index reads as a much lower CTL
+// than the athlete actually has. Two things follow from that, and both are
+// load-bearing: the schedule is frequent enough that a cold start converges in
+// under an hour, and the cursor's `outstanding` count is published so
+// trainingData can tell the page it's still filling in rather than letting
+// provisional numbers pass for final ones.
 
 import { createJsonResponder, cacheControl } from "./_shared/http.js";
-import { STRAVA_API_BASE, getAccessToken } from "./_shared/strava.js";
+import { STRAVA_API_BASE, callsRemaining, getAccessToken, readQuota } from "./_shared/strava.js";
 import { SHAPE_VERSION, isTrackableRun, shapeActivity } from "./_shared/training/shape.js";
 import { loadPlan } from "./_shared/training/planFile.js";
 import {
@@ -30,15 +38,20 @@ import {
 
 const jsonResponse = createJsonResponder(cacheControl.none);
 
-// Netlify caps scheduled functions at 30 seconds, which is the real
-// constraint here rather than Strava's rate limit. Detail + streams is 2
-// upstream calls per activity, so this budget is 30 calls per invocation —
-// well inside the ~200-per-15-minutes allowance, and fast enough to finish
-// comfortably within the timeout at the concurrency below.
-const DETAIL_BUDGET = 15;
-const FETCH_CONCURRENCY = 4;
+// Detail + streams is 2 upstream calls per activity, so this budget is 60
+// calls per invocation. Three things bound the work and the smallest wins:
+// this count, the wall-clock deadline below, and Strava's own reported quota
+// (QUOTA_SHARE). A block plus its run-up is on the order of 70 runs, so a cold
+// start now converges in two or three invocations rather than a working day.
+const DETAIL_BUDGET = 30;
+const FETCH_CONCURRENCY = 5;
 const PER_PAGE = 100;
 const MAX_PAGES = 4;
+
+// The most of each Strava rate-limit window this job will spend. The same app
+// credentials serve the /dashboard widgets, which are in a visitor's request
+// path, so a backfill must not be able to starve them into 429s.
+const QUOTA_SHARE = { shortShare: 0.6, dailyShare: 0.6 };
 
 // Stop enriching with time to spare and write what we have. Overrunning the
 // 30s limit doesn't just truncate the work — the invocation is killed before
@@ -85,16 +98,28 @@ async function mapWithConcurrency(items, limit, mapper) {
 // coordinates, and gap.js for why GAP doesn't need them.
 const STREAM_KEYS = "time,distance,heartrate,velocity_smooth,altitude,grade_smooth";
 
+// Last quota Strava reported, updated on every response (including errors —
+// a 429 carries the headers that say how long we've overshot by).
+let quota = null;
+
 async function stravaGet(path, token) {
 	const res = await fetch(`${STRAVA_API_BASE}${path}`, {
 		headers: { Authorization: `Bearer ${token}` },
 	});
+	quota = readQuota(res.headers) ?? quota;
 	if (!res.ok) {
 		const err = new Error(`Strava ${path} failed: ${res.status}`);
 		err.status = res.status;
 		throw err;
 	}
 	return res.json();
+}
+
+// Enough headroom left for one more activity? Two calls each. Infinity when
+// Strava hasn't told us anything, in which case DETAIL_BUDGET is the only
+// bound — which is what the tests and local runs see.
+function hasQuotaForOneMore() {
+	return callsRemaining(quota, QUOTA_SHARE) >= 2;
 }
 
 // The athlete's configured HR zones. Optional — falls back to percentages of
@@ -138,6 +163,11 @@ async function fetchStreams(id, token) {
 }
 
 export default async function handler(req) {
+	// Netlify reuses warm instances, and a quota reading from a previous
+	// invocation describes a window that has almost certainly rolled over
+	// since. Start blind and let this run's first response say where we are.
+	quota = null;
+
 	let token;
 	try {
 		token = await getAccessToken();
@@ -174,7 +204,6 @@ export default async function handler(req) {
 		return jsonResponse({ error: "strava_failed" }, 502);
 	}
 
-	const zones = (await fetchAthleteZones(token)) || (await readJson(store, ATHLETE_KEY, null));
 	const thresholds = plan.thresholds;
 
 	// Private runs and other sports are dropped here, before we spend any
@@ -199,13 +228,29 @@ export default async function handler(req) {
 		.sort((a, b) => String(b.start_date_local).localeCompare(String(a.start_date_local)));
 	const needsDetail = pending.slice(0, DETAIL_BUDGET);
 
+	// Zones only move when the athlete edits them, and every avoidable call is
+	// quota the dashboard widgets can have instead. Refresh them when there's
+	// enrichment to spend them on, or when we've never managed to store any.
+	const storedZones = await readJson(store, ATHLETE_KEY, null);
+	const zones =
+		needsDetail.length > 0 || !storedZones
+			? (await fetchAthleteZones(token)) || storedZones
+			: storedZones;
+
 	const deadline = Date.now() + WORK_DEADLINE_MS;
 	let rateLimited = false;
 	let timedOut = false;
+	let quotaPaused = false;
 	const fetched = await mapWithConcurrency(needsDetail, FETCH_CONCURRENCY, async (summary) => {
 		if (rateLimited) return null;
 		if (Date.now() > deadline) {
 			timedOut = true;
+			return null;
+		}
+		// Stop before Strava has to say no: a 429 costs a call and, if we kept
+		// going, would eat into the window the /dashboard widgets need.
+		if (!hasQuotaForOneMore()) {
+			quotaPaused = true;
 			return null;
 		}
 		try {
@@ -249,6 +294,8 @@ export default async function handler(req) {
 			lastRunAt: new Date().toISOString(),
 			lastActivityEpoch: outstanding.length === 0 ? latestEpoch : cursor?.lastActivityEpoch || null,
 			outstanding: outstanding.length,
+			// What the page needs to describe a partial history honestly.
+			stored: merged.length,
 		}),
 	]);
 
@@ -262,10 +309,17 @@ export default async function handler(req) {
 		shapeVersion: SHAPE_VERSION,
 		rescan,
 		rateLimited,
+		quotaPaused,
 		timedOut,
 	});
 }
 
+// Every 20 minutes. Once caught up an invocation is two upstream calls (a
+// token refresh and one activity listing), so the steady-state cost of this
+// cadence is negligible; what it buys is the cold start. A schedule is also
+// the ONLY thing that ever writes this store — a scheduled function can't be
+// invoked over HTTP — so the gap between deploying and the first tick is
+// exactly how long the dashboard has no runs on it at all.
 export const config = {
-	schedule: "@hourly",
+	schedule: "*/20 * * * *",
 };

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -15,6 +15,7 @@
     import { fetchJsonSwr } from "../../lib/data/swrCache.js";
     import { createPoller } from "../../lib/data/poller.js";
     import RaceHeader from "./sections/RaceHeader.svelte";
+    import SyncNotice from "./sections/SyncNotice.svelte";
     import Recommendations from "./sections/Recommendations.svelte";
     import VolumeChart from "./sections/VolumeChart.svelte";
     import FitnessChart from "./sections/FitnessChart.svelte";
@@ -93,6 +94,8 @@
         </div>
     {:else}
         <RaceHeader summary={data.summary} />
+
+        <SyncNotice sync={data.sync} runCount={data.runs?.length ?? 0} />
 
         <div class="grid">
             <div class="col-wide">

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -158,6 +158,10 @@
         .grid { grid-template-columns: minmax(0, 1fr); }
         .training { padding: var(--space-5) var(--space-4) var(--space-7); }
     }
+    /* 24px of card padding either side costs a seventh of a phone screen. */
+    @media (max-width: 540px) {
+        .training :global(.card) { padding: var(--space-4); }
+    }
 
     /* Shared card shell for every section. Declared once here and applied to
        the children via :global so each section doesn't restate it. */

--- a/src/components/Training/sections/RunLog.svelte
+++ b/src/components/Training/sections/RunLog.svelte
@@ -170,4 +170,27 @@
         opacity: 0.7;
         margin: 0;
     }
+
+    /* On a phone the two stat columns leave the run name barely 40px, which
+       ellipses every title down to a word. Give the name the full width and
+       drop the numbers onto a second line under it. */
+    @media (max-width: 540px) {
+        .row {
+            flex-wrap: wrap;
+            justify-content: space-between;
+            gap: var(--space-1) var(--space-4);
+        }
+        .row-main { flex-basis: 100%; }
+        /* Distance/time to the left edge, pace/GAP to the right, on a line of
+           their own under the name. */
+        .row-stat {
+            min-width: 0;
+            align-items: flex-start;
+            text-align: left;
+        }
+        .row-stat + .row-stat {
+            align-items: flex-end;
+            text-align: right;
+        }
+    }
 </style>

--- a/src/components/Training/sections/SyncNotice.svelte
+++ b/src/components/Training/sections/SyncNotice.svelte
@@ -1,0 +1,87 @@
+<!--
+    Says so when the numbers below aren't the whole story.
+
+    Only the scheduled sync writes the Strava history, and it fills the block in
+    batches, so there are two states where the dashboard renders perfectly well
+    while describing a block that didn't happen: before the first sync (every
+    metric zero) and during a backfill (a truncated history, which reads as a
+    much lower CTL than the athlete has). Both used to look exactly like a
+    finished page reporting bad training.
+-->
+<script>
+    let { sync = null, runCount = 0 } = $props();
+
+    const state = $derived.by(() => {
+        if (!sync) return null;
+        if (!sync.hasSynced && runCount === 0) {
+            return {
+                title: "Waiting for the first sync",
+                detail:
+                    "Strava history is imported on a schedule rather than on page load, so nothing has landed here yet. This page fills in within about 20 minutes of going live.",
+            };
+        }
+        if (sync.backfilling) {
+            const runs = sync.outstanding === 1 ? "1 run" : `${sync.outstanding} runs`;
+            return {
+                title: `Still importing — ${runs} to go`,
+                detail:
+                    "Fitness, form and the race projection all read the whole block, so treat them as provisional until the import finishes. The most recent weeks are already accurate.",
+            };
+        }
+        return null;
+    });
+</script>
+
+{#if state}
+    <div class="notice" role="status">
+        <span class="dot" aria-hidden="true"></span>
+        <div>
+            <strong>{state.title}</strong>
+            <p>{state.detail}</p>
+        </div>
+    </div>
+{/if}
+
+<style>
+    .notice {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-3);
+        padding: var(--space-4);
+        margin-bottom: var(--space-5);
+        border-radius: var(--radius-md);
+        background: var(--inner-background);
+        border: 1px solid var(--main-green-translucent);
+    }
+    .dot {
+        flex: none;
+        width: 8px;
+        height: 8px;
+        margin-top: 6px;
+        border-radius: 50%;
+        background: var(--main-green);
+        animation: pulse 1.8s ease-in-out infinite;
+    }
+    @keyframes pulse {
+        0%, 100% { opacity: 0.35; }
+        50% { opacity: 1; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+        .dot { animation: none; opacity: 0.8; }
+    }
+    strong {
+        display: block;
+        font-family: var(--font-serif);
+        font-size: var(--font-sm);
+        font-weight: 600;
+        color: var(--header-colour);
+    }
+    p {
+        font-size: var(--font-xs);
+        line-height: 1.6;
+        color: var(--paragraph-colour);
+        opacity: 0.75;
+        margin: var(--space-1) 0 0 0;
+        max-width: 70ch;
+    }
+</style>

--- a/src/components/Training/sections/VolumeChart.svelte
+++ b/src/components/Training/sections/VolumeChart.svelte
@@ -38,6 +38,27 @@
             return { ...slot, y: HEIGHT - (week.targetKm / ceiling) * HEIGHT, target: week.targetKm };
         }),
     );
+
+    // Only the weeks that get a date label, positioned as a percentage of the
+    // chart width. They're placed rather than laid out because a label per bar
+    // in normal flow can't shrink below its own text: sixteen nowrap dates set
+    // a ~540px floor on the card, which on a phone is wider than the viewport
+    // and drags the whole page out with it. Absolute + clipped means the axis
+    // is exactly as wide as the chart at every size.
+    const ticks = $derived(
+        shown
+            .map((week, i) => ({ week, i }))
+            .filter(({ i }) => i === 0 || i === shown.length - 1 || i % 4 === 0)
+            .map(({ week, i }) => ({
+                key: week.start,
+                label: axisDate(week.start),
+                // Centre of the bar's slot.
+                pct: ((i + 0.5) / shown.length) * 100,
+                // The end labels would be half-clipped if centred, so they
+                // anchor to the edges instead.
+                anchor: i === 0 ? "start" : i === shown.length - 1 ? "end" : "middle",
+            })),
+    );
 </script>
 
 <section class="card">
@@ -79,8 +100,15 @@
         </svg>
 
         <div class="axis">
-            {#each shown as week, i}
-                <span class:show={i === 0 || i === shown.length - 1 || i % 4 === 0}>{axisDate(week.start)}</span>
+            {#each ticks as tick (tick.key)}
+                <span
+                    class="tick {tick.anchor}"
+                    style={tick.anchor === "start"
+                        ? "left: 0"
+                        : tick.anchor === "end"
+                          ? "right: 0"
+                          : `left: ${tick.pct}%`}
+                >{tick.label}</span>
             {/each}
         </div>
     {/if}
@@ -152,18 +180,22 @@
     }
 
     .axis {
-        display: flex;
+        position: relative;
+        height: 1.2em;
         margin-top: var(--space-2);
+        /* Belt and braces: a label can never widen the card, whatever the
+           week count or the locale's date length. */
+        overflow: hidden;
     }
-    .axis span {
-        flex: 1;
-        text-align: center;
+    .tick {
+        position: absolute;
+        top: 0;
         font-size: var(--font-2xs);
         color: var(--paragraph-colour);
-        opacity: 0;
+        opacity: 0.6;
         white-space: nowrap;
     }
-    .axis span.show { opacity: 0.6; }
+    .tick.middle { transform: translateX(-50%); }
 
     .empty {
         font-size: var(--font-sm);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two separate faults on the new `/training` dashboard, one per commit.

## Why there was no Strava data

Nothing had written any. The history is only ever written by `trainingSync`, a **scheduled** function — Netlify won't let one be invoked over HTTP (its URL returns 403), so the cron tick is the only thing that can fill the store. `/training` deployed at 21:30 UTC and the first `@hourly` tick was 22:00 UTC, so for half an hour the page served the plan (which is bundled into the function) with an empty run history. Confirmed live: the endpoint returned `totals.runs: 0` before 22:00 and `totals.runs: 15` immediately after.

15 is not a coincidence — it's `DETAIL_BUDGET`. Each invocation enriches at most 15 activities, so at one tick an hour a block plus the 120-day run-up that CTL needs (~70 runs) takes most of a working day to land. That interim state is worse than an empty one: every number on the page reads the whole history, so a truncated index doesn't give slightly-off numbers, it gives numbers for training that didn't happen. Production is sitting at `ctl: 12.3` right now on 15 of ~70 runs, and the page presents that exactly like a final figure.

Three changes:

- **Schedule every 20 minutes, budget 30 activities per invocation.** A cold start converges in two or three ticks instead of a day. Once caught up an invocation is two upstream calls (token refresh + one activity listing), so the cadence costs almost nothing.
- **Bound the work by Strava's reported quota instead of a guess.** `readQuota`/`callsRemaining` parse the `x-ratelimit-*` and `x-readratelimit-*` headers and stop the sync at 60% of a window. The same app credentials serve the `/dashboard` widgets, which are in a visitor's request path, so a backfill must not be able to starve them into 429s. The `/athlete/zones` call is also skipped when there's nothing to enrich.
- **Publish how much is left.** The cursor's `outstanding` count now reaches the page through `trainingData`, and `SyncNotice` says either "waiting for the first sync" or "still importing — 42 runs to go", with the caveat that fitness and the projection are provisional until it finishes.

`trainingSync` had no tests, being the one piece that couldn't run without Strava and Blobs. It now has coverage of the properties that matter for a bounded, resumable job: it defers what it can't finish, holds the cursor back until it has, fills the most recent weeks first, drops private runs and rides before spending any budget, re-enriches records left behind by a `SHAPE_VERSION` bump, and leaves the stored history alone when Strava is down.

## Why the page didn't scale on mobile

It is in the SPA — the cause was ordinary horizontal overflow, and the viewport meta turned it into a whole-page problem.

The weekly volume chart drew one date label per week as a flex item, and a flex item can't shrink below its own content. Sixteen `white-space: nowrap` dates set a 539px floor on the card, making the document **588px wide on a 390px screen**. `index.html` asked for `width=device-width` with no `initial-scale`, so mobile Safari resolved that with shrink-to-fit: zoom the entire page out until the widest element fits. One overflowing row therefore read as "the whole dashboard is tiny" rather than as one chart with a scrollbar — and because no other route overflows (measured: `/`, `/dashboard`, `/gallery`, `/toronto` all land at exactly 390px), the rest of the site was unaffected.

The axis labels are now placed as a percentage of the chart width inside a clipped, relatively positioned track, so the axis is exactly as wide as the chart at any size. `initial-scale=1` makes the next such bug local: a stray wide element scrolls instead of silently zooming out every route it appears on. The run log also gets a phone layout — two 82px stat columns left the run name 42px, ellipsing every title down to a word — and cards lose some padding below 540px.

New E2E spec asserts nothing inside `main.training` exceeds the viewport at 390px and 360px, and names the offending element when something does. It stubs the payload from the real metrics engine (`e2e/fixtures/trainingPayload.js`), since the page draws none of the wide content without data.

| Before (390px) | After (390px) | Backfilling |
| --- | --- | --- |
| [Before: content occupies two-thirds of the width](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftraining-before-390.png) | [After: content fills the viewport](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftraining-after-390.png) | [Sync notice while the history is still importing](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftraining-backfilling-390.png) |

## Testing

- `npm run test:run` — 438 passing, including 18 new unit tests for the sync and the quota parser.
- `npx playwright test` — 6 passing, including the two new overflow assertions.
- Verified against production: the endpoint went from 0 to 15 runs across the 22:00 UTC tick, and the pre-fix build measures `documentElement.scrollWidth` 588 vs 390 where this branch measures 390.

## Note

The 20-minute cadence still means a first deploy has an empty dashboard for up to 20 minutes, since a scheduled function cannot be triggered on demand. Closing that fully would mean an HTTP-invokable sync entry point, which is a public trigger against a shared rate limit — the notice seemed the better trade than that.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

