### PR TITLE
Rearrangeable training panels, centred icons, week ranges, run log spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ src/
                           player/ modals/ layout/) and feature logic (lib/).
   lib/              Cross-feature code, NOT tied to one route:
     ui/             Shared presentational components (BackLink, Button, Card,
-                    CloseButton, GateOverlay, Spinner)
+                    CloseButton, GateOverlay, Spinner) + reorder (drag-to-
+                    rearrange) and its storage half, layoutStore
     data/           Client data layer (fetchJson, swrCache, concurrent)
     strava.js       Promoted feature-agnostic helpers (format/decode)
     tilt.js         Reusable Svelte action
@@ -74,6 +75,22 @@ feature's folder; once a **second** feature needs it, promote it to `src/lib/`.
 `/dashboard` widget shell, plus a header and an optional "i" disclosure that
 explains the panel's metrics. Every `/training` section is built on it, so the
 card chrome is defined once rather than restated per section.
+
+`lib/ui/reorder.svelte.js` is the drag-to-rearrange behaviour shared by
+`/dashboard` and `/training`. The model is slots, not lists: positions are
+fixed and sized by the page, and a drop swaps the two panels involved, so
+nothing reflows under the cursor mid-drag. Two details are load-bearing and
+commented as such — no `setPointerCapture` (it redirects the synthesized click
+away from anchors inside a panel), and `draggingId` is only set once the
+pointer passes the threshold (the `dragging` class carries
+`pointer-events: none`, which would otherwise swallow ordinary clicks). The
+pure parts — validating a stored layout, swapping slots — live in
+`lib/ui/layoutStore.js` so they're testable without compiling runes.
+
+The two pages gate it differently. `/dashboard` drags freely on desktop and
+behind an Edit toggle once responsive; `/training` is always behind its
+Rearrange toggle, because those panels are full of links and scrollable lists
+and a stray drag would cost you a text selection or a tap.
 
 ### Netlify function re-export pattern
 
@@ -157,8 +174,8 @@ A handful of [Playwright](https://playwright.dev) smoke tests in `e2e/`
 (`*.e2e.js`) guard the lowest-risk/highest-value flows — the homepage boots,
 `/dashboard` mounts its widget grid, `/gallery` renders and its photo fetch
 settles, and `/training` renders its sections — labelled axes, plan-matched run
-log, working "i" disclosures — without any of them growing wider than a phone
-screen. They run against `vite preview` (the static build, no
+log, working "i" disclosures, panels that rearrange and stay rearranged —
+without any of them growing wider than a phone screen. They run against `vite preview` (the static build, no
 Functions), so they assert routes render rather than live data; `/training`
 needs a payload before it draws anything wide, so it gets one from the real
 metrics engine (`e2e/fixtures/trainingPayload.js`) via a route stub. Install the browser once with

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -65,6 +65,76 @@ test("the charts are labelled with the values they plot", async ({ page }) => {
 	expect(labels.some((text) => Number(text) > 0)).toBe(true);
 });
 
+// Rearranging shares its machinery with /dashboard (lib/ui/reorder), but this
+// page gates it behind the Rearrange button, so the interesting part is that
+// the gate opens, a drop lands in the right slot, and the choice survives a
+// reload.
+test.describe("rearranging the panels", () => {
+	const panelAt = (page, idx) => page.locator(`[data-slot-index="${idx}"] .panel`);
+
+	async function dragPanel(page, fromIdx, toIdx) {
+		const source = await panelAt(page, fromIdx).boundingBox();
+		const target = await page.locator(`[data-slot-index="${toIdx}"]`).boundingBox();
+		await page.mouse.move(source.x + source.width / 2, source.y + 24);
+		await page.mouse.down();
+		await page.mouse.move(target.x + target.width / 2, target.y + 24, { steps: 14 });
+		await page.mouse.up();
+	}
+
+	test("panels stay put until you ask to rearrange them", async ({ page }) => {
+		await page.goto("/training");
+		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
+
+		await dragPanel(page, 0, 4);
+		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
+	});
+
+	test("a drag swaps the two panels and the layout is remembered", async ({ page }) => {
+		await page.goto("/training");
+		const displaced = await panelAt(page, 4).getAttribute("data-panel");
+
+		await page.getByRole("button", { name: "Rearrange" }).click();
+		await dragPanel(page, 0, 4);
+
+		await expect(panelAt(page, 4)).toHaveAttribute("data-panel", "volume");
+		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", displaced);
+
+		await page.reload();
+		await expect(panelAt(page, 4)).toHaveAttribute("data-panel", "volume");
+
+		// And there's a way back out of any arrangement.
+		await page.getByRole("button", { name: "Rearrange" }).click();
+		await page.getByRole("button", { name: "Reset" }).click();
+		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
+	});
+
+	test("the arrow keys move a panel without a pointer", async ({ page }) => {
+		await page.goto("/training");
+		await page.getByRole("button", { name: "Rearrange" }).click();
+
+		await page.locator('[data-slot-index="0"] .panel-handle').focus();
+		await page.keyboard.press("ArrowRight");
+
+		await expect(panelAt(page, 1)).toHaveAttribute("data-panel", "volume");
+	});
+
+	test("taps inside a panel don't fire while rearranging", async ({ page }) => {
+		await page.goto("/training");
+		const card = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();
+		const info = card.getByRole("button", { name: /Weekly volume/i });
+
+		await page.getByRole("button", { name: "Rearrange" }).click();
+		// force: panels jiggle while editing, so nothing inside one is ever
+		// "stable" — which is exactly the state this is testing.
+		await info.click({ force: true });
+		await expect(info).toHaveAttribute("aria-expanded", "false");
+
+		await page.getByRole("button", { name: "Done" }).click();
+		await info.click();
+		await expect(info).toHaveAttribute("aria-expanded", "true");
+	});
+});
+
 for (const viewport of [PHONE, NARROW_PHONE]) {
 	test(`training page fits a ${viewport.width}px viewport`, async ({ page }) => {
 		await page.setViewportSize(viewport);

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -118,6 +118,23 @@ test.describe("rearranging the panels", () => {
 		await expect(panelAt(page, 1)).toHaveAttribute("data-panel", "volume");
 	});
 
+	// On a phone the panels are most of the page, so a panel that swallowed
+	// touch gestures to be draggable would strand you at whichever one you
+	// started on. Touch drags go through the handle instead, and it's the only
+	// thing allowed to take touch-action away from the scroller.
+	test("a finger can still scroll the page while rearranging", async ({ page }) => {
+		await page.setViewportSize(PHONE);
+		await page.goto("/training");
+		await page.getByRole("button", { name: "Rearrange" }).click();
+
+		const blocked = await page.evaluate(() =>
+			[...document.querySelectorAll("#training-grid *")]
+				.filter((el) => getComputedStyle(el).touchAction === "none")
+				.map((el) => el.className.toString().split(" ")[0]),
+		);
+		expect([...new Set(blocked)]).toEqual(["panel-handle"]);
+	});
+
 	test("taps inside a panel don't fire while rearranging", async ({ page }) => {
 		await page.goto("/training");
 		const card = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();

--- a/src/components/Dashboard/Dashboard.svelte
+++ b/src/components/Dashboard/Dashboard.svelte
@@ -22,6 +22,7 @@
     import HackerNewsWidget from "./widgets/HackerNewsWidget.svelte";
     import SpotifyVizOverlay from "./SpotifyVizOverlay.svelte";
     import BackLink from "../../lib/ui/BackLink.svelte";
+    import { createReorder } from "../../lib/ui/reorder.svelte.js";
 
     const WIDGETS = {
         clock:   { component: ClockWidget,      kind: "div" },
@@ -41,109 +42,26 @@
 
     const DEFAULT_ORDER = ["clock", "gallery", "weather", "spotify", "strava", "github", "hn"];
     const LAYOUT_KEY = "dashboard-layout";
-    const DRAG_THRESHOLD = 5;
 
-    function loadLayout() {
-        try {
-            const raw = localStorage.getItem(LAYOUT_KEY);
-            if (!raw) return null;
-            const arr = JSON.parse(raw);
-            if (!Array.isArray(arr) || arr.length !== DEFAULT_ORDER.length) return null;
-            if (new Set(arr).size !== arr.length) return null;
-            if (!arr.every((id) => DEFAULT_ORDER.includes(id))) return null;
-            return arr;
-        } catch { return null; }
-    }
-
-    let layout = $state([...DEFAULT_ORDER]);
     let isEditing = $state(false);
     let isResponsive = $state(false);
-    let isDragging = $state(false);
-    let draggingId = $state(null);
-    let dropTargetIdx = $state(null);
-    let dragTransform = $state(null); // { x, y } | null
 
     let dashboardEl;
-    let widgetEls = {}; // id -> element (for transform during drag)
-    let suppressClickUntil = 0;
     let responsiveQuery;
     let onResponsiveChange;
     let clickCapture;
 
-    function swap(srcIdx, dstIdx) {
-        if (srcIdx === dstIdx) return;
-        const next = [...layout];
-        [next[srcIdx], next[dstIdx]] = [next[dstIdx], next[srcIdx]];
-        layout = next;
-        try { localStorage.setItem(LAYOUT_KEY, JSON.stringify(layout)); } catch {}
-        // Brief swap-flash + force-resize so list trimming + viz canvas re-fit.
-        requestAnimationFrame(() => {
-            window.dispatchEvent(new Event("resize"));
-        });
-    }
-
-    // Whole-widget drag. Listeners are attached on pointerdown and torn down
-    // on pointerup. We intentionally do NOT setPointerCapture — capturing
-    // redirects the synthesized click to the widget instead of the actual
-    // anchor inside, breaking link navigation.
-    //
-    // We deliberately do NOT set draggingId until the user crosses the 5px
-    // threshold. `class:dragging` adds pointer-events:none on the widget; if
-    // it flips on at pointerdown, the synthetic click after a non-drag press
-    // dispatches to the slot underneath instead of the anchor inside, and
-    // nothing in the widget becomes clickable. Defer it to onMove.
-    function initDrag(widgetId, e) {
-        if (e.button !== undefined && e.button !== 0) return;
-        if (draggingId !== null) return;
-        if (isResponsive && !isEditing) return;
-
-        const pointerId = e.pointerId;
-        const startX = e.clientX;
-        const startY = e.clientY;
-        let started = false;
-
-        const onMove = (ev) => {
-            if (ev.pointerId !== pointerId) return;
-            const dx = ev.clientX - startX;
-            const dy = ev.clientY - startY;
-            if (!started) {
-                if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
-                started = true;
-                draggingId = widgetId;
-                isDragging = true;
-            }
-            ev.preventDefault();
-            dragTransform = { x: dx, y: dy };
-            // .dragging has pointer-events: none in CSS so elementFromPoint
-            // pierces through to the slot under the cursor.
-            const el = document.elementFromPoint(ev.clientX, ev.clientY);
-            const slot = el?.closest(".slot[data-slot-index]");
-            const idx = slot ? Number(slot.dataset.slotIndex) : null;
-            const srcIdx = layout.indexOf(widgetId);
-            dropTargetIdx = (idx != null && idx !== srcIdx) ? idx : null;
-        };
-
-        const onEnd = (ev) => {
-            if (ev.pointerId !== pointerId) return;
-            document.removeEventListener("pointermove", onMove);
-            document.removeEventListener("pointerup", onEnd);
-            document.removeEventListener("pointercancel", onEnd);
-            if (started) {
-                const srcIdx = layout.indexOf(widgetId);
-                const dstIdx = dropTargetIdx;
-                if (dstIdx != null && dstIdx !== srcIdx) swap(srcIdx, dstIdx);
-                suppressClickUntil = Date.now() + 300;
-            }
-            isDragging = false;
-            draggingId = null;
-            dropTargetIdx = null;
-            dragTransform = null;
-        };
-
-        document.addEventListener("pointermove", onMove);
-        document.addEventListener("pointerup", onEnd);
-        document.addEventListener("pointercancel", onEnd);
-    }
+    // Drag mechanics live in lib/ui/reorder — /training uses the same ones.
+    // Dragging is free on desktop and gated behind edit mode once the layout
+    // goes responsive, where a press-and-drag is otherwise a scroll.
+    const reorder = createReorder({
+        order: DEFAULT_ORDER,
+        storageKey: LAYOUT_KEY,
+        enabled: () => !(isResponsive && !isEditing),
+        // Swap-flash + forced resize so list trimming and the viz canvas re-fit.
+        onReorder: () => requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))),
+    });
+    const layout = $derived(reorder.layout);
 
     function toggleEditing(e) {
         e.stopPropagation();
@@ -151,8 +69,7 @@
     }
 
     onMount(() => {
-        const stored = loadLayout();
-        if (stored) layout = stored;
+        reorder.restore();
 
         responsiveQuery = window.matchMedia("(max-width: 1100px)");
         isResponsive = responsiveQuery.matches;
@@ -167,7 +84,7 @@
         // editing (matches iOS jiggle-mode where taps don't open icons).
         clickCapture = (e) => {
             if (!e.target.closest("#dashboard-grid")) return;
-            if (Date.now() < suppressClickUntil || isEditing) {
+            if (reorder.suppressesClick() || isEditing) {
                 e.preventDefault();
                 e.stopPropagation();
             }
@@ -204,7 +121,7 @@
 <div
     class="dashboard"
     class:is-editing={isEditing}
-    class:is-dragging={isDragging}
+    class:is-dragging={reorder.isDragging}
     bind:this={dashboardEl}
     id="dashboard-grid"
 >
@@ -212,27 +129,27 @@
         {@const cfg = WIDGETS[widgetId]}
         <div
             class="slot slot-{SLOT_SIZES[idx]}"
-            class:drop-target={dropTargetIdx === idx}
+            class:drop-target={reorder.dropTargetIdx === idx}
             data-slot-index={idx}
         >
             {#if cfg.kind === "a"}
                 <a
                     class="widget widget-{widgetId}"
-                    class:dragging={draggingId === widgetId}
+                    class:dragging={reorder.draggingId === widgetId}
                     data-widget={widgetId}
                     href={cfg.href}
-                    style:transform={draggingId === widgetId && dragTransform ? `translate(${dragTransform.x}px, ${dragTransform.y}px) scale(1.02)` : null}
-                    onpointerdown={(e) => initDrag(widgetId, e)}
+                    style:transform={reorder.transformFor(widgetId)}
+                    onpointerdown={(e) => reorder.start(widgetId, e)}
                 >
                     <cfg.component />
                 </a>
             {:else}
                 <div
                     class="widget widget-{widgetId}"
-                    class:dragging={draggingId === widgetId}
+                    class:dragging={reorder.draggingId === widgetId}
                     data-widget={widgetId}
-                    style:transform={draggingId === widgetId && dragTransform ? `translate(${dragTransform.x}px, ${dragTransform.y}px) scale(1.02)` : null}
-                    onpointerdown={(e) => initDrag(widgetId, e)}
+                    style:transform={reorder.transformFor(widgetId)}
+                    onpointerdown={(e) => reorder.start(widgetId, e)}
                 >
                     <cfg.component />
                 </div>

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -166,7 +166,7 @@
             class:dragging={reorder.draggingId === id}
             data-panel={id}
             style:transform={reorder.transformFor(id)}
-            onpointerdown={(e) => reorder.start(id, e)}
+            onpointerdown={(e) => { if (e.pointerType !== "touch") reorder.start(id, e); }}
         >
             {#if isEditing}
                 <button
@@ -174,6 +174,7 @@
                     type="button"
                     aria-label="Move {PANELS[id]} — use the arrow keys, or drag"
                     title="Drag to rearrange"
+                    onpointerdown={(e) => { e.stopPropagation(); reorder.start(id, e); }}
                     onkeydown={(e) => nudge(id, e)}
                 >
                     <svg viewBox="0 0 16 16" aria-hidden="true">
@@ -320,10 +321,16 @@
         z-index: 20;
         opacity: 0.92;
         cursor: grabbing;
+        /* The card surfaces are translucent, so a panel in flight would
+           otherwise read as part of whatever it's passing over. */
+        filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.35));
     }
+    /* A finger dragging the panel body would have to give up scrolling
+       (touch-action: none) to do it, and on a phone the panels are most of
+       the page — you'd be stuck at whichever one you started on. So touch
+       drags from the handle only; a mouse can still grab anywhere. */
     .grid.is-editing .panel {
         cursor: grab;
-        touch-action: none;
         user-select: none;
     }
     .grid.is-editing .slot.drop-target {
@@ -350,9 +357,14 @@
         background: var(--background-one);
         color: var(--main-green);
         cursor: grab;
+        touch-action: none;
         box-shadow: var(--inner-box-shadow);
     }
     .panel-handle svg { width: 15px; height: 15px; display: block; fill: currentColor; }
+    @media (pointer: coarse) {
+        .panel-handle { width: 34px; height: 34px; top: -12px; right: -12px; }
+        .panel-handle svg { width: 18px; height: 18px; }
+    }
 
     /* iOS-style jiggle, matching /dashboard's edit mode. */
     @keyframes panel-jiggle {

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -7,10 +7,17 @@
     password gate: the page is public on purpose, and the payload carries no
     private activities and no GPS — see netlify/functions/_shared/training/
     shape.js for how that's enforced.
+
+    Panels are rearrangeable, using the same slot model as /dashboard (see
+    lib/ui/reorder). Unlike the dashboard, dragging is always behind an edit
+    toggle: these panels are full of links, scrollable lists and buttons, and
+    a page where pressing a run and moving the mouse drags the panel instead
+    of selecting text would be worse than one with an extra button.
 -->
 <script>
     import { onMount, onDestroy } from "svelte";
     import BackLink from "../../lib/ui/BackLink.svelte";
+    import { createReorder } from "../../lib/ui/reorder.svelte.js";
     import Spinner from "../../lib/ui/Spinner.svelte";
     import { fetchJsonSwr } from "../../lib/data/swrCache.js";
     import { createPoller } from "../../lib/data/poller.js";
@@ -28,9 +35,48 @@
 
     const ENDPOINT = "/.netlify/functions/trainingData";
 
+    // Slots 0–3 are the wide column, 4–7 the narrow one, 8 the full-width
+    // row underneath. A panel can sit in any of them; the charts and the run
+    // log all reflow to their container, so a "narrow" chart is a narrower
+    // chart rather than a broken one.
+    const PANELS = {
+        volume: "Weekly volume",
+        fitness: "Fitness and fatigue",
+        efficiency: "Aerobic efficiency",
+        recommendations: "What to do about it",
+        prediction: "Race projection",
+        load: "Injury risk",
+        intensity: "Intensity mix",
+        week: "This week",
+        runs: "Runs this block",
+    };
+    const DEFAULT_ORDER = [
+        "volume", "fitness", "efficiency", "recommendations",
+        "prediction", "load", "intensity", "week",
+        "runs",
+    ];
+    const WIDE_SLOTS = 4;
+    const NARROW_SLOTS = 4;
+    const LAYOUT_KEY = "training-layout";
+
     let data = $state(null);
     let error = $state("");
+    let isEditing = $state(false);
     let stopPoll;
+    let clickCapture;
+
+    const reorder = createReorder({
+        order: DEFAULT_ORDER,
+        storageKey: LAYOUT_KEY,
+        enabled: () => isEditing,
+        // Charts size themselves off their container, so a swap between the
+        // wide and narrow columns needs them to re-measure.
+        onReorder: () => requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))),
+    });
+
+    const wideIds = $derived(reorder.layout.slice(0, WIDE_SLOTS));
+    const narrowIds = $derived(reorder.layout.slice(WIDE_SLOTS, WIDE_SLOTS + NARROW_SLOTS));
+    const fullId = $derived(reorder.layout[WIDE_SLOTS + NARROW_SLOTS]);
 
     const currentWeek = $derived(
         data?.weeks?.find((w) => w.start === weekStartOf(data.today)) || null,
@@ -61,9 +107,36 @@
         }
     }
 
+    // Arrow keys on a panel's handle move it a slot at a time, so the layout
+    // is reachable without a pointer.
+    function nudge(id, event) {
+        const step = { ArrowLeft: -1, ArrowUp: -1, ArrowRight: 1, ArrowDown: 1 }[event.key];
+        if (!step) return;
+        const target = reorder.layout.indexOf(id) + step;
+        if (target < 0 || target >= DEFAULT_ORDER.length) return;
+        event.preventDefault();
+        reorder.move(id, target);
+        // The handle moves with the panel; keep focus on it for repeat presses.
+        const handle = event.currentTarget;
+        requestAnimationFrame(() => handle.focus());
+    }
+
     onMount(() => {
         document.body.classList.add("training-page");
+        reorder.restore();
         load();
+
+        // Capture phase, so it beats anchor navigation: while rearranging, a
+        // tap is aimed at the panel rather than at whatever is inside it.
+        clickCapture = (e) => {
+            if (!e.target.closest("#training-grid")) return;
+            if (e.target.closest(".panel-handle")) return;
+            if (reorder.suppressesClick() || isEditing) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        };
+        document.addEventListener("click", clickCapture, true);
         // The upstream sync runs hourly, so there's nothing to gain from
         // polling hard — this is really just to catch a sync landing while
         // the tab is left open.
@@ -72,6 +145,7 @@
 
     onDestroy(() => {
         stopPoll?.();
+        document.removeEventListener("click", clickCapture, true);
         document.body.classList.remove("training-page");
     });
 </script>
@@ -81,8 +155,82 @@
     <meta name="description" content="Live marathon training dashboard: weekly volume, fitness and fatigue, intensity balance, and where I'm projected to finish." />
 </svelte:head>
 
+{#snippet panelSlot(id, idx)}
+    <div
+        class="slot"
+        class:drop-target={reorder.dropTargetIdx === idx}
+        data-slot-index={idx}
+    >
+        <div
+            class="panel"
+            class:dragging={reorder.draggingId === id}
+            data-panel={id}
+            style:transform={reorder.transformFor(id)}
+            onpointerdown={(e) => reorder.start(id, e)}
+        >
+            {#if isEditing}
+                <button
+                    class="panel-handle"
+                    type="button"
+                    aria-label="Move {PANELS[id]} — use the arrow keys, or drag"
+                    title="Drag to rearrange"
+                    onkeydown={(e) => nudge(id, e)}
+                >
+                    <svg viewBox="0 0 16 16" aria-hidden="true">
+                        <circle cx="5.5" cy="4" r="1.35" /><circle cx="10.5" cy="4" r="1.35" />
+                        <circle cx="5.5" cy="8" r="1.35" /><circle cx="10.5" cy="8" r="1.35" />
+                        <circle cx="5.5" cy="12" r="1.35" /><circle cx="10.5" cy="12" r="1.35" />
+                    </svg>
+                </button>
+            {/if}
+            {@render panelBody(id)}
+        </div>
+    </div>
+{/snippet}
+
+{#snippet panelBody(id)}
+    {#if id === "volume"}
+        <VolumeChart weeks={data.weeks} today={data.today} />
+    {:else if id === "fitness"}
+        <FitnessChart series={data.series} today={data.today} />
+    {:else if id === "efficiency"}
+        <AerobicEfficiency efficiency={data.efficiency} summary={data.summary} today={data.today} />
+    {:else if id === "recommendations"}
+        <Recommendations recommendations={data.recommendations} />
+    {:else if id === "prediction"}
+        <RacePrediction summary={data.summary} />
+    {:else if id === "load"}
+        <LoadRisk acwr={data.summary?.acwr} riskWeek={data.summary?.riskWeek} />
+    {:else if id === "intensity"}
+        <IntensityMix intensity={data.summary?.intensity} />
+    {:else if id === "week"}
+        <WeekPlan {currentWeek} week={data.week} upcoming={data.upcoming} />
+    {:else if id === "runs"}
+        <RunLog runs={data.runs} total={data.summary?.totals?.runs} />
+    {/if}
+{/snippet}
+
 <main class="training">
     <BackLink />
+
+    {#if data}
+        <div class="edit-bar">
+            {#if isEditing}
+                <button class="edit-btn ghost" type="button" onclick={() => reorder.reset()}>
+                    Reset
+                </button>
+            {/if}
+            <button
+                class="edit-btn"
+                class:active={isEditing}
+                type="button"
+                aria-pressed={isEditing ? "true" : "false"}
+                onclick={() => (isEditing = !isEditing)}
+            >
+                {isEditing ? "Done" : "Rearrange"}
+            </button>
+        </div>
+    {/if}
 
     {#if error && !data}
         <div class="state">
@@ -97,23 +245,24 @@
 
         <SyncNotice sync={data.sync} runCount={data.runs?.length ?? 0} />
 
-        <div class="grid">
-            <div class="col-wide">
-                <VolumeChart weeks={data.weeks} today={data.today} />
-                <FitnessChart series={data.series} today={data.today} />
-                <AerobicEfficiency efficiency={data.efficiency} summary={data.summary} today={data.today} />
-                <Recommendations recommendations={data.recommendations} />
+        <div
+            class="grid"
+            class:is-editing={isEditing}
+            class:is-dragging={reorder.isDragging}
+            id="training-grid"
+        >
+            <div class="col">
+                {#each wideIds as id, i (id)}{@render panelSlot(id, i)}{/each}
             </div>
 
-            <div class="col-narrow">
-                <RacePrediction summary={data.summary} />
-                <LoadRisk acwr={data.summary?.acwr} riskWeek={data.summary?.riskWeek} />
-                <IntensityMix intensity={data.summary?.intensity} />
-                <WeekPlan {currentWeek} week={data.week} upcoming={data.upcoming} />
+            <div class="col">
+                {#each narrowIds as id, i (id)}{@render panelSlot(id, i + WIDE_SLOTS)}{/each}
+            </div>
+
+            <div class="col col-full">
+                {@render panelSlot(fullId, WIDE_SLOTS + NARROW_SLOTS)}
             </div>
         </div>
-
-        <RunLog runs={data.runs} total={data.summary?.totals?.runs} />
 
         <footer class="foot">
             <p>
@@ -155,12 +304,101 @@
         align-items: start;
         margin-bottom: var(--space-4);
     }
-    .col-wide, .col-narrow {
+    .col {
         display: flex;
         flex-direction: column;
         gap: var(--space-4);
         min-width: 0;
     }
+    .col-full { grid-column: 1 / -1; }
+
+    .slot { min-width: 0; }
+    .panel { position: relative; min-width: 0; }
+    .panel.dragging {
+        /* pointer-events off so elementFromPoint finds the slot underneath. */
+        pointer-events: none;
+        z-index: 20;
+        opacity: 0.92;
+        cursor: grabbing;
+    }
+    .grid.is-editing .panel {
+        cursor: grab;
+        touch-action: none;
+        user-select: none;
+    }
+    .grid.is-editing .slot.drop-target {
+        outline: 2px dashed var(--main-green);
+        outline-offset: 3px;
+        border-radius: var(--radius-xl);
+    }
+
+    /* Corner badge rather than an inline control: every panel already has an
+       info button in its top-right, and overhanging the border keeps the two
+       from reading as the same row of buttons. */
+    .panel-handle {
+        position: absolute;
+        top: -9px;
+        right: -9px;
+        z-index: 21;
+        width: 26px;
+        height: 26px;
+        display: grid;
+        place-items: center;
+        padding: 0;
+        border: 1px solid var(--main-green-translucent);
+        border-radius: 50%;
+        background: var(--background-one);
+        color: var(--main-green);
+        cursor: grab;
+        box-shadow: var(--inner-box-shadow);
+    }
+    .panel-handle svg { width: 15px; height: 15px; display: block; fill: currentColor; }
+
+    /* iOS-style jiggle, matching /dashboard's edit mode. */
+    @keyframes panel-jiggle {
+        0% { transform: rotate(-0.35deg); }
+        50% { transform: rotate(0.35deg) translateY(-1px); }
+        100% { transform: rotate(-0.35deg); }
+    }
+    .grid.is-editing .panel { animation: panel-jiggle 0.5s ease-in-out infinite; }
+    .grid.is-editing .col:nth-child(even) .panel { animation-delay: -0.2s; animation-duration: 0.54s; }
+    .grid.is-editing .panel.dragging { animation: none; }
+    @media (prefers-reduced-motion: reduce) {
+        .grid.is-editing .panel,
+        .grid.is-editing .col:nth-child(even) .panel { animation: none; }
+    }
+
+    .edit-bar {
+        position: fixed;
+        top: 0.9rem;
+        right: 1rem;
+        z-index: 60;
+        display: flex;
+        gap: var(--space-2);
+    }
+    .edit-btn {
+        padding: 0.4rem 0.85rem;
+        border: 1px solid var(--main-green-translucent);
+        border-radius: var(--radius-pill);
+        background: var(--inner-background);
+        color: var(--main-green);
+        font-family: inherit;
+        font-size: var(--font-xs);
+        font-weight: 600;
+        cursor: pointer;
+        opacity: 0.85;
+        backdrop-filter: blur(var(--blur-md));
+        -webkit-backdrop-filter: blur(var(--blur-md));
+        transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+    }
+    .edit-btn:hover { opacity: 1; }
+    .edit-btn.active {
+        background: var(--main-green);
+        border-color: var(--main-green);
+        color: var(--background-one);
+        opacity: 1;
+    }
+    .edit-btn.ghost { opacity: 0.6; }
 
     @media (max-width: 1100px) {
         .training { padding-top: 3.5rem; }
@@ -168,6 +406,7 @@
     @media (max-width: 860px) {
         .grid { grid-template-columns: minmax(0, 1fr); }
         .training { padding: 3.5rem var(--space-4) var(--space-7); }
+        .edit-bar { top: 0.75rem; right: 0.75rem; }
     }
 
     .foot {

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -102,6 +102,32 @@ export function weekday(dayKey) {
 }
 
 /**
+ * The week a Monday starts, as the range it actually covers: "17–23 Aug",
+ * or "31 Aug – 6 Sept" where the week straddles two months.
+ *
+ * A training week is seven days, and labelling it with its Monday alone asks
+ * the reader to do the arithmetic every time they want to know whether a
+ * given Saturday falls inside it.
+ *
+ * @param {string} weekStart Monday day key.
+ * @returns {string}
+ */
+export function weekRange(weekStart) {
+	if (!weekStart) return "";
+	const start = new Date(`${String(weekStart).slice(0, 10)}T12:00:00Z`);
+	if (Number.isNaN(start.getTime())) return "";
+	const end = new Date(start.getTime() + 6 * 86_400_000);
+
+	const day = (d) => d.toLocaleDateString("en-GB", { day: "numeric", timeZone: "UTC" });
+	const dayMonth = (d) =>
+		d.toLocaleDateString("en-GB", { day: "numeric", month: "short", timeZone: "UTC" });
+
+	return start.getUTCMonth() === end.getUTCMonth()
+		? `${day(start)}–${dayMonth(end)}`
+		: `${dayMonth(start)} – ${dayMonth(end)}`;
+}
+
+/**
  * Month-and-day label for chart axes.
  *
  * @param {string} dayKey

--- a/src/components/Training/lib/format.test.js
+++ b/src/components/Training/lib/format.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { weekRange, pace, clock, km, pct, shortDate } from "./format.js";
+
+describe("weekRange", () => {
+	it("covers the seven days from the Monday", () => {
+		expect(weekRange("2026-08-17")).toBe("17–23 Aug");
+	});
+
+	it("names both months when the week straddles them", () => {
+		expect(weekRange("2026-08-31")).toBe("31 Aug – 6 Sept");
+	});
+
+	it("handles a week that crosses the year", () => {
+		expect(weekRange("2026-12-28")).toBe("28 Dec – 3 Jan");
+	});
+
+	it("has nothing to say about a missing or unparseable week", () => {
+		expect(weekRange(null)).toBe("");
+		expect(weekRange("not-a-date")).toBe("");
+	});
+});
+
+// The rest of the module predates this file; these are the cases the training
+// display leans on most.
+describe("training formatters", () => {
+	it("rolls the minute rather than printing a sixtieth second", () => {
+		expect(pace(359.7)).toBe("6:00/km");
+	});
+
+	it("prints a race time with hours only when there are any", () => {
+		expect(clock(13200)).toBe("3:40:00");
+		expect(clock(1800)).toBe("30:00");
+	});
+
+	it("drops noise decimals on big distances", () => {
+		expect(km(12345)).toBe("12.3 km");
+		expect(km(123456)).toBe("123 km");
+	});
+
+	it("reports missing values as an em dash rather than NaN", () => {
+		expect(pace(null)).toBe("—");
+		expect(km(undefined)).toBe("—");
+		expect(pct(null)).toBe("—");
+		expect(shortDate("")).toBe("");
+	});
+});

--- a/src/components/Training/sections/Recommendations.svelte
+++ b/src/components/Training/sections/Recommendations.svelte
@@ -17,10 +17,10 @@
     let { recommendations = [] } = $props();
 
     const SEVERITY = {
-        critical: { label: "Act now", tone: "bad", icon: "!" },
-        warning: { label: "Watch", tone: "warn", icon: "▲" },
-        info: { label: "Note", tone: "info", icon: "i" },
-        good: { label: "On track", tone: "good", icon: "✓" },
+        critical: { label: "Act now", tone: "bad", icon: "alert" },
+        warning: { label: "Watch", tone: "warn", icon: "warn" },
+        info: { label: "Note", tone: "info", icon: "info" },
+        good: { label: "On track", tone: "good", icon: "check" },
     };
 
     const items = $derived(
@@ -44,6 +44,35 @@
     }
 </script>
 
+<!--
+    Outline marks on a 16-unit box rather than typographic glyphs: "✓", "!" and
+    "▲" are set on a text baseline at different heights and optical weights, so
+    no amount of line-height gets all four sitting square in the same badge.
+    Shape carries the severity as well as colour does — the triangle is the one
+    you look for — which is what makes the ranking readable without relying on
+    hue at all.
+-->
+{#snippet glyph(kind)}
+    <svg class="rec-icon" viewBox="0 0 16 16" aria-hidden="true">
+        {#if kind === "warn"}
+            <path d="M8 2.6 L14.6 13.4 H1.4 Z" />
+            <path d="M8 6.4 V9.6" />
+            <circle class="dot" cx="8" cy="11.5" r="0.85" />
+        {:else}
+            <circle cx="8" cy="8" r="6.2" />
+            {#if kind === "check"}
+                <path d="M5 8.3 L7.1 10.4 L11 5.9" />
+            {:else if kind === "alert"}
+                <path d="M8 4.4 V8.6" />
+                <circle class="dot" cx="8" cy="11" r="0.85" />
+            {:else}
+                <circle class="dot" cx="8" cy="5" r="0.85" />
+                <path d="M8 7.4 V11.6" />
+            {/if}
+        {/if}
+    </svg>
+{/snippet}
+
 <Card title="What to do about it" info={GLOSSARY.recommendations}>
     {#snippet aside()}
         {#if counts.total > 0}
@@ -65,7 +94,7 @@
                 <li class="rec tone-{rec.meta.tone}">
                     <div class="rec-head">
                         <span class="rec-badge">
-                            <span class="rec-icon" aria-hidden="true">{rec.meta.icon}</span>
+                            {@render glyph(rec.meta.icon)}
                             {rec.meta.label}
                         </span>
                         {#if readout(rec)}
@@ -131,8 +160,8 @@
     .rec-badge {
         display: inline-flex;
         align-items: center;
-        gap: var(--space-2);
-        padding: 3px var(--space-2) 3px 5px;
+        gap: 5px;
+        padding: 3px var(--space-2) 3px 6px;
         border-radius: var(--radius-pill);
         background: var(--tone-bg);
         font-size: var(--font-2xs);
@@ -142,19 +171,19 @@
         color: var(--tone);
     }
     .rec-icon {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 1.1em;
-        height: 1.1em;
-        border-radius: 50%;
-        background: var(--tone);
-        color: var(--badge-text-colour);
-        font-size: 0.85em;
-        font-weight: 700;
-        line-height: 1;
-        /* The glyphs are different sizes; nudge them onto the same centre. */
-        text-indent: 0.02em;
+        flex: none;
+        width: 1.25em;
+        height: 1.25em;
+        display: block;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 1.4;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+    }
+    .rec-icon .dot {
+        fill: currentColor;
+        stroke: none;
     }
 
     .rec-metric {

--- a/src/components/Training/sections/RunLog.svelte
+++ b/src/components/Training/sections/RunLog.svelte
@@ -116,14 +116,20 @@
         list-style: none;
         margin: 0;
         padding: 0;
-        max-height: 520px;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        max-height: 560px;
         overflow-y: auto;
     }
+    /* A hairline between rows as well as the gap: a two-line row on a phone
+       otherwise runs straight into the next one's title. */
+    .log li + li { border-top: 1px solid var(--main-green-translucent); padding-top: var(--space-2); }
     .row {
         display: flex;
         align-items: center;
         gap: var(--space-4);
-        padding: var(--space-3);
+        padding: var(--space-3) var(--space-3) var(--space-3) var(--space-4);
         border-radius: var(--radius-sm);
         text-decoration: none;
         color: inherit;
@@ -149,9 +155,10 @@
     .row-meta {
         display: block;
         font-size: var(--font-2xs);
+        line-height: 1.7;
         color: var(--paragraph-colour);
         opacity: 0.7;
-        margin-top: 2px;
+        margin-top: 3px;
     }
     .tag {
         display: inline-block;
@@ -213,10 +220,12 @@
        ellipses every title down to a word. Give the name the full width and
        drop the numbers onto a second line under it. */
     @media (max-width: 540px) {
+        .log { gap: var(--space-3); }
+        .log li + li { padding-top: var(--space-3); }
         .row {
             flex-wrap: wrap;
             justify-content: space-between;
-            gap: var(--space-1) var(--space-4);
+            gap: var(--space-2) var(--space-4);
         }
         .row-main { flex-basis: 100%; }
         /* Distance/time to the left edge, pace/GAP to the right, on a line of

--- a/src/components/Training/sections/VolumeChart.svelte
+++ b/src/components/Training/sections/VolumeChart.svelte
@@ -15,7 +15,7 @@
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
     import { axisTicks, bars, CHART_WEEKS, niceScale } from "../lib/chart.js";
-    import { axisDate } from "../lib/format.js";
+    import { axisDate, weekRange } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { weeks = [], today = null } = $props();
@@ -93,7 +93,7 @@
                         height={bar.height}
                         rx="2"
                     >
-                        <title>{axisDate(week.start)} — {bar.value.toFixed(1)} km{week.targetKm ? ` of ${week.targetKm} km planned` : ""}</title>
+                        <title>{weekRange(week.start)} — {bar.value.toFixed(1)} km{week.targetKm ? ` of ${week.targetKm} km planned` : ""}</title>
                     </rect>
                     {#if targets[i]}
                         <line

--- a/src/components/Training/sections/WeekPlan.svelte
+++ b/src/components/Training/sections/WeekPlan.svelte
@@ -7,7 +7,7 @@
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
-    import { pct, shortDate, weekday } from "../lib/format.js";
+    import { pct, weekday, weekRange } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { currentWeek = null, week = null, upcoming = [] } = $props();
@@ -39,6 +39,12 @@
 </script>
 
 <Card title="This week" info={GLOSSARY.week}>
+    {#snippet aside()}
+        {#if currentWeek?.start}
+            <span class="range">{weekRange(currentWeek.start)}</span>
+        {/if}
+    {/snippet}
+
     {#if !currentWeek}
         <p class="empty">No runs logged this week yet.</p>
     {:else}
@@ -76,7 +82,7 @@
             <ol class="days">
                 {#each days as day (day.date)}
                     <li class="day {day.status}" class:today={day.isToday}>
-                        <span class="day-name">{weekday(day.date)}</span>
+                        <span class="day-name">{weekday(day.date)} {Number(day.date.slice(8, 10))}</span>
                         <span class="day-plan">
                             {#if day.planned.length}
                                 {#each day.planned as session}
@@ -127,7 +133,7 @@
             <ul>
                 {#each upcoming as week (week.start)}
                     <li>
-                        <span class="week-date">{shortDate(week.start)}</span>
+                        <span class="week-date">{weekRange(week.start)}</span>
                         <span class="week-km">{week.targetKm ? `${week.targetKm} km` : "—"}</span>
                         <span class="week-long">{week.longRunKm ? `${week.longRunKm} km long` : ""}</span>
                     </li>
@@ -138,6 +144,13 @@
 </Card>
 
 <style>
+    .range {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--paragraph-colour);
+        opacity: 0.6;
+    }
     .metric { margin-bottom: var(--space-4); }
     .metric-head {
         display: flex;
@@ -195,7 +208,7 @@
     }
     .day {
         display: grid;
-        grid-template-columns: 34px 1fr auto;
+        grid-template-columns: 46px 1fr auto;
         align-items: baseline;
         gap: var(--space-3);
         padding: var(--space-2) var(--space-2);
@@ -215,9 +228,10 @@
     .day-name {
         font-size: var(--font-2xs);
         text-transform: uppercase;
-        letter-spacing: 0.08em;
+        letter-spacing: 0.06em;
         color: var(--main-green);
         font-weight: 600;
+        white-space: nowrap;
     }
     .day-plan {
         display: flex;

--- a/src/lib/ui/Card.svelte
+++ b/src/lib/ui/Card.svelte
@@ -55,7 +55,16 @@
 						aria-controls={panelId}
 						aria-label={open ? `Hide what ${title} means` : `What does ${title} mean?`}
 						onclick={() => (open = !open)}
-					>i</button>
+					>
+						<!-- Drawn rather than set: a lowercase "i" sits on its
+						     own baseline with a stem that doesn't fill the em
+						     box, so centring the glyph in a circle by line
+						     height always leaves it a pixel or two high. -->
+						<svg viewBox="0 0 16 16" aria-hidden="true">
+							<circle cx="8" cy="4.6" r="1.15" />
+							<rect x="6.85" y="7.2" width="2.3" height="5.4" rx="1.15" />
+						</svg>
+					</button>
 				{/if}
 			</svelte:element>
 			{#if aside}
@@ -122,8 +131,8 @@
 
 	.info-btn {
 		flex: none;
-		width: 1.15rem;
-		height: 1.15rem;
+		width: 1.2rem;
+		height: 1.2rem;
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -132,14 +141,16 @@
 		border-radius: 50%;
 		background: transparent;
 		color: var(--main-green);
-		font-family: var(--font-serif);
-		font-size: 0.72rem;
-		font-style: italic;
-		font-weight: 700;
-		line-height: 1;
+		line-height: 0;
 		cursor: pointer;
 		opacity: 0.75;
 		transition: opacity 0.15s ease, background-color 0.15s ease;
+	}
+	.info-btn svg {
+		width: 68%;
+		height: 68%;
+		display: block;
+		fill: currentColor;
 	}
 	.info-btn:hover, .info-btn:focus-visible { opacity: 1; background: var(--main-green-translucent); }
 	.info-btn.open {

--- a/src/lib/ui/layoutStore.js
+++ b/src/lib/ui/layoutStore.js
@@ -1,0 +1,68 @@
+// The non-reactive half of drag-to-rearrange: reading, validating and writing
+// a saved panel order. Kept as plain JS (rather than living inside
+// reorder.svelte.js) so it can be tested without compiling runes — this is
+// where the interesting failure cases are.
+
+/**
+ * A stored layout is only usable if it is still a permutation of the panels
+ * the page has today. A renamed panel, a truncated write, or a layout saved by
+ * an older version of the page all fail this and fall back to the default,
+ * which is much better than rendering a grid with holes or duplicates in it.
+ *
+ * @param {unknown} stored parsed value from storage.
+ * @param {string[]} defaults the page's default order.
+ * @returns {string[] | null} the layout, or null if it can't be trusted.
+ */
+export function validateLayout(stored, defaults) {
+	if (!Array.isArray(stored)) return null;
+	if (stored.length !== defaults.length) return null;
+	if (new Set(stored).size !== stored.length) return null;
+	if (!stored.every((id) => defaults.includes(id))) return null;
+	return [...stored];
+}
+
+/**
+ * Reads and validates the layout saved under `key`. Storage can throw
+ * outright (Safari private browsing) and can hold anything at all, so every
+ * failure is the same failure: no usable layout.
+ *
+ * @returns {string[] | null}
+ */
+export function readLayout(key, defaults) {
+	try {
+		const raw = localStorage.getItem(key);
+		if (!raw) return null;
+		return validateLayout(JSON.parse(raw), defaults);
+	} catch {
+		return null;
+	}
+}
+
+/** Best-effort persist; a full or unavailable store just means no memory. */
+export function writeLayout(key, layout) {
+	try {
+		localStorage.setItem(key, JSON.stringify(layout));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Swaps two slots. Out-of-range or no-op swaps return the layout unchanged so
+ * callers can treat a dropped-on-itself drag as "nothing happened".
+ *
+ * @param {string[]} layout
+ * @param {number} srcIdx
+ * @param {number} dstIdx
+ * @returns {string[]}
+ */
+export function swapSlots(layout, srcIdx, dstIdx) {
+	if (!Number.isInteger(srcIdx) || !Number.isInteger(dstIdx)) return layout;
+	if (srcIdx === dstIdx) return layout;
+	if (srcIdx < 0 || dstIdx < 0) return layout;
+	if (srcIdx >= layout.length || dstIdx >= layout.length) return layout;
+	const next = [...layout];
+	[next[srcIdx], next[dstIdx]] = [next[dstIdx], next[srcIdx]];
+	return next;
+}

--- a/src/lib/ui/layoutStore.test.js
+++ b/src/lib/ui/layoutStore.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { validateLayout, readLayout, writeLayout, swapSlots } from "./layoutStore.js";
+
+const DEFAULTS = ["a", "b", "c"];
+
+describe("validateLayout", () => {
+	it("accepts any permutation of the current panels", () => {
+		expect(validateLayout(["c", "a", "b"], DEFAULTS)).toEqual(["c", "a", "b"]);
+	});
+
+	it("copies rather than aliasing the stored array", () => {
+		const stored = ["c", "a", "b"];
+		const layout = validateLayout(stored, DEFAULTS);
+		layout[0] = "b";
+		expect(stored[0]).toBe("c");
+	});
+
+	it("rejects a layout from a version with different panels", () => {
+		expect(validateLayout(["a", "b", "gone"], DEFAULTS)).toBeNull();
+		expect(validateLayout(["a", "b"], DEFAULTS)).toBeNull();
+		expect(validateLayout(["a", "b", "c", "d"], DEFAULTS)).toBeNull();
+	});
+
+	it("rejects duplicates, which would leave a slot empty", () => {
+		expect(validateLayout(["a", "a", "b"], DEFAULTS)).toBeNull();
+	});
+
+	it("rejects anything that isn't an array", () => {
+		expect(validateLayout(null, DEFAULTS)).toBeNull();
+		expect(validateLayout({ 0: "a" }, DEFAULTS)).toBeNull();
+		expect(validateLayout("abc", DEFAULTS)).toBeNull();
+	});
+});
+
+describe("readLayout / writeLayout", () => {
+	let store;
+
+	beforeEach(() => {
+		store = new Map();
+		vi.stubGlobal("localStorage", {
+			getItem: (k) => (store.has(k) ? store.get(k) : null),
+			setItem: (k, v) => store.set(k, v),
+		});
+	});
+
+	afterEach(() => vi.unstubAllGlobals());
+
+	it("round-trips a layout", () => {
+		expect(writeLayout("k", ["b", "c", "a"])).toBe(true);
+		expect(readLayout("k", DEFAULTS)).toEqual(["b", "c", "a"]);
+	});
+
+	it("returns null when nothing has been saved", () => {
+		expect(readLayout("k", DEFAULTS)).toBeNull();
+	});
+
+	it("survives a half-written value", () => {
+		store.set("k", '["a","b"');
+		expect(readLayout("k", DEFAULTS)).toBeNull();
+	});
+
+	it("survives storage being unavailable entirely", () => {
+		vi.stubGlobal("localStorage", {
+			getItem() { throw new Error("SecurityError"); },
+			setItem() { throw new Error("QuotaExceededError"); },
+		});
+		expect(readLayout("k", DEFAULTS)).toBeNull();
+		expect(writeLayout("k", ["a", "b", "c"])).toBe(false);
+	});
+});
+
+describe("swapSlots", () => {
+	it("exchanges the two panels", () => {
+		expect(swapSlots(["a", "b", "c"], 0, 2)).toEqual(["c", "b", "a"]);
+	});
+
+	it("leaves the layout alone for a no-op or out-of-range swap", () => {
+		const layout = ["a", "b", "c"];
+		expect(swapSlots(layout, 1, 1)).toBe(layout);
+		expect(swapSlots(layout, -1, 1)).toBe(layout);
+		expect(swapSlots(layout, 0, 9)).toBe(layout);
+		expect(swapSlots(layout, 0, null)).toBe(layout);
+	});
+
+	it("doesn't mutate the layout it was given", () => {
+		const layout = ["a", "b", "c"];
+		swapSlots(layout, 0, 1);
+		expect(layout).toEqual(["a", "b", "c"]);
+	});
+});

--- a/src/lib/ui/reorder.svelte.js
+++ b/src/lib/ui/reorder.svelte.js
@@ -1,0 +1,149 @@
+// Drag-to-rearrange for a grid of fixed slots.
+//
+// Extracted from /dashboard, which had all of this inline, when /training
+// wanted the same behaviour. The model is deliberately slots-not-lists: the
+// positions are fixed and sized by the page, and a drop swaps whichever two
+// panels are involved. Nothing reflows mid-drag, so the thing under your
+// finger stays under your finger — which is the whole reason this doesn't use
+// an insert-and-shift list.
+//
+// Two details here are load-bearing and were both learned the hard way:
+//
+//   - No setPointerCapture. Capturing redirects the synthesized click to the
+//     dragged element instead of the anchor inside it, which breaks every link
+//     in a panel.
+//   - draggingId is not set until the pointer crosses the threshold. The
+//     dragging class carries `pointer-events: none` (so elementFromPoint can
+//     find the slot underneath), and turning that on at pointerdown means a
+//     plain press dispatches its click to the slot rather than to whatever was
+//     pressed — nothing inside a panel would be clickable at all.
+
+import { readLayout, writeLayout, swapSlots } from "./layoutStore.js";
+
+const CLICK_SUPPRESSION_MS = 300;
+
+/**
+ * @param {object} options
+ * @param {string[]} options.order default panel ids, in slot order.
+ * @param {string} options.storageKey localStorage key for the saved layout.
+ * @param {string} [options.slotSelector] identifies a drop target; the
+ *   element must carry `data-slot-index`.
+ * @param {number} [options.threshold] px of movement before a press becomes
+ *   a drag.
+ * @param {() => boolean} [options.enabled] gate, e.g. "only in edit mode".
+ * @param {() => void} [options.onReorder] side effects after a swap lands.
+ */
+export function createReorder({
+	order,
+	storageKey,
+	slotSelector = ".slot[data-slot-index]",
+	threshold = 5,
+	enabled = () => true,
+	onReorder = () => {},
+}) {
+	const defaults = [...order];
+
+	let layout = $state([...defaults]);
+	let draggingId = $state(null);
+	let dropTargetIdx = $state(null);
+	let dragTransform = $state(null);
+	let isDragging = $state(false);
+	let suppressClickUntil = 0;
+
+	function restore() {
+		const stored = readLayout(storageKey, defaults);
+		if (!stored) return false;
+		layout = stored;
+		return true;
+	}
+
+	function swap(srcIdx, dstIdx) {
+		const next = swapSlots(layout, srcIdx, dstIdx);
+		if (next === layout) return;
+		layout = next;
+		writeLayout(storageKey, layout);
+		onReorder();
+	}
+
+	function start(id, event) {
+		if (event.button !== undefined && event.button !== 0) return;
+		if (draggingId !== null) return;
+		if (!enabled()) return;
+
+		const pointerId = event.pointerId;
+		const startX = event.clientX;
+		const startY = event.clientY;
+		let started = false;
+
+		const onMove = (ev) => {
+			if (ev.pointerId !== pointerId) return;
+			const dx = ev.clientX - startX;
+			const dy = ev.clientY - startY;
+			if (!started) {
+				if (Math.hypot(dx, dy) < threshold) return;
+				started = true;
+				draggingId = id;
+				isDragging = true;
+			}
+			ev.preventDefault();
+			dragTransform = { x: dx, y: dy };
+
+			const under = document.elementFromPoint(ev.clientX, ev.clientY);
+			const slot = under?.closest(slotSelector);
+			const idx = slot ? Number(slot.dataset.slotIndex) : null;
+			const srcIdx = layout.indexOf(id);
+			dropTargetIdx = idx != null && Number.isFinite(idx) && idx !== srcIdx ? idx : null;
+		};
+
+		const onEnd = (ev) => {
+			if (ev.pointerId !== pointerId) return;
+			document.removeEventListener("pointermove", onMove);
+			document.removeEventListener("pointerup", onEnd);
+			document.removeEventListener("pointercancel", onEnd);
+			if (started) {
+				if (dropTargetIdx != null) swap(layout.indexOf(id), dropTargetIdx);
+				suppressClickUntil = Date.now() + CLICK_SUPPRESSION_MS;
+			}
+			isDragging = false;
+			draggingId = null;
+			dropTargetIdx = null;
+			dragTransform = null;
+		};
+
+		document.addEventListener("pointermove", onMove);
+		document.addEventListener("pointerup", onEnd);
+		document.addEventListener("pointercancel", onEnd);
+	}
+
+	return {
+		get layout() { return layout; },
+		get draggingId() { return draggingId; },
+		get dropTargetIdx() { return dropTargetIdx; },
+		get isDragging() { return isDragging; },
+
+		/** Inline transform for a panel mid-drag, or null when it's at rest. */
+		transformFor(id, { scale = 1.02 } = {}) {
+			if (draggingId !== id || !dragTransform) return null;
+			return `translate(${dragTransform.x}px, ${dragTransform.y}px) scale(${scale})`;
+		},
+
+		/** True for the moment after a drag, when the click is drag residue. */
+		suppressesClick() {
+			return Date.now() < suppressClickUntil;
+		},
+
+		restore,
+		start,
+
+		/** Put a panel in a given slot, swapping with whatever is there. */
+		move(id, targetIdx) {
+			swap(layout.indexOf(id), targetIdx);
+		},
+
+		reset() {
+			layout = [...defaults];
+			writeLayout(storageKey, layout);
+			onReorder();
+		},
+	};
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #61, addressing four pieces of feedback on `/training`.

### The icons weren't centred

The info "i" and the severity marks were typographic glyphs centred by line height. That never quite works: `i`, `!`, `✓` and `▲` sit on a baseline at four different heights and optical weights, so each badge was off-centre in its own direction (and a `text-indent` nudge only ever fixed one of them at a time). They're now outline marks drawn on a 16-unit box, which centres them by construction, and shape carries the severity alongside colour — the triangle is the one you look for.

[WATCH badge with a centred triangle mark](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbadge-zoom.png)
[ON TRACK badge with a centred check mark](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbadge-ok-zoom.png)

### Weeks are labelled with the week they cover

Upcoming weeks showed their Monday alone, which asks the reader to work out whether a given Saturday falls inside one. They now read as ranges — `17–23 Aug`, or `31 Aug – 6 Sept` where the week straddles two months. The current week's range sits in the card header, the day rows carry their date rather than just a weekday, and the volume chart's bar tooltips say the same thing.

[This week card showing dated day rows and upcoming weeks as ranges](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fzoom-week-dark.png)

### Runs in a block have room to breathe

The rows sat flush against each other. On a phone, where a row wraps to two lines, one run's pace ran straight into the next one's title. Rows now get a gap and a hairline between them, both widened on small screens.

[Runs this block on a phone, with separated rows](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fzoom-runs-mobile.png)

### Panels are rearrangeable

`/dashboard` had drag-to-rearrange written inline. This lifts the mechanics into `src/lib/ui/reorder.svelte.js`, with the storage and swap logic in plain JS next door (`layoutStore.js`) where Vitest can reach it without compiling runes, and puts `/training` on the same slot model: fixed positions, a drop swaps the two panels, order saved to `localStorage`. The dashboard behaves exactly as before and the two pages now share one implementation.

Three deliberate differences from the dashboard:

- **Dragging is always behind a Rearrange toggle.** These panels are full of links, scrollable lists and buttons; a page where pressing a run and moving the mouse drags the panel instead of selecting text would be worse than one with an extra button. Editing also gets a Reset, so no arrangement is a dead end.
- **Touch drags go through the handle.** Making the panel body draggable by finger means taking `touch-action` away from it, and on a phone the panels are most of the page — you'd be stranded at whichever one you started on. A mouse can still grab anywhere.
- **The handle takes arrow keys**, so the layout is reachable without a pointer.

[Training panels in edit mode, showing drag handles and the Reset/Done controls](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftraining-editing-desktop.png)

### Verification

- `npm test` — 482 unit tests pass, including new coverage for the week-range formatter and for layout validation (a stored layout naming a panel that no longer exists, duplicates, a half-written value, storage throwing outright).
- `npx playwright test` — 14 pass, with new specs asserting panels don't move until you ask, that a drop lands in the right slot and survives a reload, that arrow keys move a panel, that taps inside a panel don't fire while rearranging, and that nothing but the handle takes `touch-action` from the scroller.
- Drove a real touch drag and a touch scroll through CDP on a Pixel 5 profile, and re-checked the dashboard's own drag after the extraction (drop lands, order persists).
- Checked dark and light at 1440px and 390px, including a scrambled layout with the run log in a narrow column; the existing "nothing exceeds the viewport" specs still hold at 390 and 360.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

