### PR TITLE
Clear the static-analysis findings from the training-panel work

### DIFF
--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -113,11 +113,23 @@ export function weekday(dayKey) {
  * @returns {string}
  */
 export function weekRange(weekStart) {
-	if (!weekStart) return "";
-	const start = new Date(`${String(weekStart).slice(0, 10)}T12:00:00Z`);
-	if (Number.isNaN(start.getTime())) return "";
-	const end = new Date(start.getTime() + 6 * 86_400_000);
+	const start = utcNoon(weekStart);
+	return start ? span(start, sixDaysOn(start)) : "";
+}
 
+/** The day key as a UTC-noon Date, or null if there isn't a usable one. */
+function utcNoon(dayKey) {
+	const date = new Date(`${String(dayKey ?? "").slice(0, 10)}T12:00:00Z`);
+	return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function sixDaysOn(start) {
+	const end = new Date(start);
+	end.setUTCDate(end.getUTCDate() + 6);
+	return end;
+}
+
+function span(start, end) {
 	const day = (d) => d.toLocaleDateString("en-GB", { day: "numeric", timeZone: "UTC" });
 	const dayMonth = (d) =>
 		d.toLocaleDateString("en-GB", { day: "numeric", month: "short", timeZone: "UTC" });

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -112,11 +112,6 @@ export function weekday(dayKey) {
  * @param {string} weekStart Monday day key.
  * @returns {string}
  */
-export function weekRange(weekStart) {
-	const start = utcNoon(weekStart);
-	return start ? span(start, sixDaysOn(start)) : "";
-}
-
 /** The day key as a UTC-noon Date, or null if there isn't a usable one. */
 function utcNoon(dayKey) {
 	const date = new Date(`${String(dayKey ?? "").slice(0, 10)}T12:00:00Z`);
@@ -137,6 +132,11 @@ function span(start, end) {
 	return start.getUTCMonth() === end.getUTCMonth()
 		? `${day(start)}–${dayMonth(end)}`
 		: `${dayMonth(start)} – ${dayMonth(end)}`;
+}
+
+export function weekRange(weekStart) {
+	const start = utcNoon(weekStart);
+	return start ? span(start, sixDaysOn(start)) : "";
 }
 
 /**

--- a/src/components/Training/lib/format.test.js
+++ b/src/components/Training/lib/format.test.js
@@ -39,7 +39,7 @@ describe("training formatters", () => {
 
 	it("reports missing values as an em dash rather than NaN", () => {
 		expect(pace(null)).toBe("—");
-		expect(km(undefined)).toBe("—");
+		expect(km()).toBe("—");
 		expect(pct(null)).toBe("—");
 		expect(shortDate("")).toBe("");
 	});

--- a/src/lib/ui/layoutStore.js
+++ b/src/lib/ui/layoutStore.js
@@ -5,19 +5,30 @@
 
 /**
  * A stored layout is only usable if it is still a permutation of the panels
- * the page has today. A renamed panel, a truncated write, or a layout saved by
- * an older version of the page all fail this and fall back to the default,
- * which is much better than rendering a grid with holes or duplicates in it.
+ * the page has today: same length, no duplicates, no unknown ids.
+ */
+function isPermutationOf(stored, defaults) {
+	return stored.length === defaults.length
+		&& new Set(stored).size === stored.length
+		&& stored.every((id) => defaults.includes(id));
+}
+
+/**
+ * A renamed panel, a truncated write, or a layout saved by an older version of
+ * the page all fail validation and fall back to the default, which is much
+ * better than rendering a grid with holes or duplicates in it.
  *
  * @param {unknown} stored parsed value from storage.
  * @param {string[]} defaults the page's default order.
  * @returns {string[] | null} the layout, or null if it can't be trusted.
  */
-export function validateLayout(stored, defaults) {
-	if (!Array.isArray(stored)) return null;
-	if (stored.length !== defaults.length) return null;
-	if (new Set(stored).size !== stored.length) return null;
-	if (!stored.every((id) => defaults.includes(id))) return null;
+function validateLayout(stored, defaults) {
+	if (!Array.isArray(stored)) {
+		return null;
+	}
+	if (!isPermutationOf(stored, defaults)) {
+		return null;
+	}
 	return [...stored];
 }
 
@@ -28,41 +39,65 @@ export function validateLayout(stored, defaults) {
  *
  * @returns {string[] | null}
  */
-export function readLayout(key, defaults) {
+function readLayout(key, defaults) {
 	try {
 		const raw = localStorage.getItem(key);
-		if (!raw) return null;
+		if (!raw) {
+			return null;
+		}
 		return validateLayout(JSON.parse(raw), defaults);
-	} catch {
+	} catch (error) {
 		return null;
 	}
 }
 
 /** Best-effort persist; a full or unavailable store just means no memory. */
-export function writeLayout(key, layout) {
+function writeLayout(key, layout) {
 	try {
 		localStorage.setItem(key, JSON.stringify(layout));
 		return true;
-	} catch {
+	} catch (error) {
 		return false;
 	}
 }
 
+function isSlot(layout, idx) {
+	return Number.isInteger(idx) && idx >= 0 && idx < layout.length;
+}
+
+function canSwap(layout, srcIdx, dstIdx) {
+	return srcIdx !== dstIdx && isSlot(layout, srcIdx) && isSlot(layout, dstIdx);
+}
+
 /**
- * Swaps two slots. Out-of-range or no-op swaps return the layout unchanged so
- * callers can treat a dropped-on-itself drag as "nothing happened".
+ * Swaps two slots. Out-of-range or no-op swaps return the layout unchanged
+ * (identity included) so callers can treat a drag dropped on itself as
+ * "nothing happened".
  *
  * @param {string[]} layout
  * @param {number} srcIdx
  * @param {number} dstIdx
  * @returns {string[]}
  */
-export function swapSlots(layout, srcIdx, dstIdx) {
-	if (!Number.isInteger(srcIdx) || !Number.isInteger(dstIdx)) return layout;
-	if (srcIdx === dstIdx) return layout;
-	if (srcIdx < 0 || dstIdx < 0) return layout;
-	if (srcIdx >= layout.length || dstIdx >= layout.length) return layout;
-	const next = [...layout];
-	[next[srcIdx], next[dstIdx]] = [next[dstIdx], next[srcIdx]];
-	return next;
+function swapSlots(layout, srcIdx, dstIdx) {
+	if (!canSwap(layout, srcIdx, dstIdx)) {
+		return layout;
+	}
+	const src = layout.at(srcIdx);
+	const dst = layout.at(dstIdx);
+	return layout.map((id, idx) => {
+		if (idx === srcIdx) {
+			return dst;
+		}
+		if (idx === dstIdx) {
+			return src;
+		}
+		return id;
+	});
 }
+
+// Exported down here rather than inline. Static analysis reads this repo's JS
+// with a parser that predates ES modules: an `export` keyword mid-file makes
+// it lose the thread and misread everything after it, which it then reports as
+// phantom findings against the try/catch above. A trailing list parses.
+export { validateLayout, readLayout, writeLayout, swapSlots };

--- a/src/lib/ui/reorder.svelte.js
+++ b/src/lib/ui/reorder.svelte.js
@@ -18,6 +18,10 @@
 //     plain press dispatches its click to the slot rather than to whatever was
 //     pressed — nothing inside a panel would be clickable at all.
 
+// $state is a Svelte compiler intrinsic rather than an import, so tell plain-JS
+// linters about it.
+/* global $state */
+
 import { readLayout, writeLayout, swapSlots } from "./layoutStore.js";
 
 const CLICK_SUPPRESSION_MS = 300;
@@ -33,7 +37,7 @@ const CLICK_SUPPRESSION_MS = 300;
  * @param {() => boolean} [options.enabled] gate, e.g. "only in edit mode".
  * @param {() => void} [options.onReorder] side effects after a swap lands.
  */
-export function createReorder({
+function createReorder({
 	order,
 	storageKey,
 	slotSelector = ".slot[data-slot-index]",
@@ -52,62 +56,113 @@ export function createReorder({
 
 	function restore() {
 		const stored = readLayout(storageKey, defaults);
-		if (!stored) return false;
+		if (!stored) {
+			return false;
+		}
 		layout = stored;
 		return true;
 	}
 
 	function swap(srcIdx, dstIdx) {
 		const next = swapSlots(layout, srcIdx, dstIdx);
-		if (next === layout) return;
+		if (next === layout) {
+			return;
+		}
 		layout = next;
 		writeLayout(storageKey, layout);
 		onReorder();
 	}
 
+	// Left button only. Synthetic events, and pointer events for touch on some
+	// engines, leave `button` unset; that counts as primary.
+	function isPrimaryButton(event) {
+		return typeof event.button !== "number" || event.button === 0;
+	}
+
+	function canStart(event) {
+		return isPrimaryButton(event) && draggingId === null && enabled();
+	}
+
+	// `.dragging` sets pointer-events: none, so this looks straight through the
+	// panel being dragged to the slot underneath the pointer.
+	function slotUnder(x, y) {
+		const el = document.elementFromPoint(x, y);
+		return el ? el.closest(slotSelector) : null;
+	}
+
+	function slotIndexUnder(x, y) {
+		const slot = slotUnder(x, y);
+		const idx = slot ? Number(slot.dataset.slotIndex) : Number.NaN;
+		return Number.isFinite(idx) ? idx : null;
+	}
+
+	function updateDropTarget(id, x, y) {
+		const idx = slotIndexUnder(x, y);
+		dropTargetIdx = idx === layout.indexOf(id) ? null : idx;
+	}
+
+	function clearDrag() {
+		isDragging = false;
+		draggingId = null;
+		dropTargetIdx = null;
+		dragTransform = null;
+	}
+
 	function start(id, event) {
-		if (event.button !== undefined && event.button !== 0) return;
-		if (draggingId !== null) return;
-		if (!enabled()) return;
+		if (!canStart(event)) {
+			return;
+		}
 
 		const pointerId = event.pointerId;
 		const startX = event.clientX;
 		const startY = event.clientY;
 		let started = false;
 
+		// A press only becomes a drag once it has travelled far enough; until
+		// then the pointer still belongs to whatever is inside the panel.
+		const begin = (ev) => {
+			if (started) {
+				return true;
+			}
+			if (Math.hypot(ev.clientX - startX, ev.clientY - startY) < threshold) {
+				return false;
+			}
+			started = true;
+			draggingId = id;
+			isDragging = true;
+			return true;
+		};
+
+		const drop = () => {
+			if (dropTargetIdx !== null) {
+				swap(layout.indexOf(id), dropTargetIdx);
+			}
+			suppressClickUntil = Date.now() + CLICK_SUPPRESSION_MS;
+		};
+
 		const onMove = (ev) => {
-			if (ev.pointerId !== pointerId) return;
-			const dx = ev.clientX - startX;
-			const dy = ev.clientY - startY;
-			if (!started) {
-				if (Math.hypot(dx, dy) < threshold) return;
-				started = true;
-				draggingId = id;
-				isDragging = true;
+			if (ev.pointerId !== pointerId) {
+				return;
+			}
+			if (!begin(ev)) {
+				return;
 			}
 			ev.preventDefault();
-			dragTransform = { x: dx, y: dy };
-
-			const under = document.elementFromPoint(ev.clientX, ev.clientY);
-			const slot = under?.closest(slotSelector);
-			const idx = slot ? Number(slot.dataset.slotIndex) : null;
-			const srcIdx = layout.indexOf(id);
-			dropTargetIdx = idx != null && Number.isFinite(idx) && idx !== srcIdx ? idx : null;
+			dragTransform = { x: ev.clientX - startX, y: ev.clientY - startY };
+			updateDropTarget(id, ev.clientX, ev.clientY);
 		};
 
 		const onEnd = (ev) => {
-			if (ev.pointerId !== pointerId) return;
+			if (ev.pointerId !== pointerId) {
+				return;
+			}
 			document.removeEventListener("pointermove", onMove);
 			document.removeEventListener("pointerup", onEnd);
 			document.removeEventListener("pointercancel", onEnd);
 			if (started) {
-				if (dropTargetIdx != null) swap(layout.indexOf(id), dropTargetIdx);
-				suppressClickUntil = Date.now() + CLICK_SUPPRESSION_MS;
+				drop();
 			}
-			isDragging = false;
-			draggingId = null;
-			dropTargetIdx = null;
-			dragTransform = null;
+			clearDrag();
 		};
 
 		document.addEventListener("pointermove", onMove);
@@ -116,14 +171,24 @@ export function createReorder({
 	}
 
 	return {
-		get layout() { return layout; },
-		get draggingId() { return draggingId; },
-		get dropTargetIdx() { return dropTargetIdx; },
-		get isDragging() { return isDragging; },
+		get layout() {
+			return layout;
+		},
+		get draggingId() {
+			return draggingId;
+		},
+		get dropTargetIdx() {
+			return dropTargetIdx;
+		},
+		get isDragging() {
+			return isDragging;
+		},
 
 		/** Inline transform for a panel mid-drag, or null when it's at rest. */
 		transformFor(id, { scale = 1.02 } = {}) {
-			if (draggingId !== id || !dragTransform) return null;
+			if (draggingId !== id || !dragTransform) {
+				return null;
+			}
 			return `translate(${dragTransform.x}px, ${dragTransform.y}px) scale(${scale})`;
 		},
 
@@ -147,3 +212,6 @@ export function createReorder({
 		},
 	};
 }
+
+// Exported here rather than inline, for the reason given in layoutStore.js.
+export { createReorder };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#62 merged with 35 new Codacy findings against its quality gate (which is set to zero). This clears all of them — the check is now green on this branch, reporting **0 new issues and 26 fixed**. It's a separate PR only because #62 was merged while I was fixing them.

### The real ones

- **Complexity ceiling (4).** `validateLayout`, `swapSlots`, `start` and the pointer-move handler were over it. They're now split into named pieces — `isPermutationOf`, `canSwap`/`isSlot`, `canStart`/`isPrimaryButton`, `begin`/`drop`/`updateDropTarget`/`slotIndexUnder` — which reads better than the originals did.
- **Object injection.** The slot swap wrote through computed indices (`next[srcIdx] = …`). It now reads with `at()` and rebuilds via `map`, so there's no computed member assignment at all.
- **Use before define.** The week-range helpers are declared above `weekRange` rather than relying on hoisting.
- **`curly` and `no-undefined`.** Guards are braced, and the one `undefined` argument in a test is just an omitted argument now.

### The artifacts

Two findings weren't real, and both are worth knowing about because they'll recur:

- **Svelte runes.** `$state` is a compiler intrinsic, not an import, so a plain-JS linter reads it as an undefined global. Declared with a `/* global $state */` directive.
- **A parser that predates ES modules.** Codacy's PMD reads JavaScript with Rhino, which stops at the first `export` keyword and misreads the rest of the file — reporting "unnecessary block" against the `try`/`catch` and the returned object below it. I confirmed this by reproducing it locally with PMD 6.55 (PMD 7 no longer misparses, so Codacy is on the older line): a file is clean until an `export` appears above the block, and clean again when the exports move to a trailing list. So `layoutStore.js` and `reorder.svelte.js` export at the bottom, with a comment saying why, which is cheaper and quieter than a `NOPMD` annotation per phantom.

### Verification

Rather than guessing at what the service would say, I reproduced its analysers locally — ESLint 8 with `curly`, `complexity: 4`, `camelcase`, `no-console`, `no-undefined`, `no-undef`, `no-use-before-define` and the `security` plugin, plus PMD 6.55 with the `ecmascript` rules involved — and both are clean across every file this branch touches. The only remaining hits in `format.js` sit on pre-existing lines the branch doesn't touch.

Behaviour is unchanged: 482 unit tests and 14 Playwright specs pass, including the drag, persistence, keyboard and touch-scroll specs that cover the code being restructured here.

### Worth a decision separately

The repo carries about 1,133 existing findings (407 `curly`, 192 `camelcase`, 133 `complexity`, 59 of those PMD phantom blocks), so before this the gate failed on every PR regardless of content — #61 and #62 both merged red. Two things would make it meaningful again: an ESLint config committed to the repo so the rules are visible while writing rather than after pushing, and a decision on PMD for JavaScript, which cannot parse this codebase and so can only produce noise. Happy to do either.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

