### PR TITLE
Give /training the dashboard's rearranging, not a version of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,24 @@ is free while the layout is wide enough to be pointer-driven, and behind the
 how you scroll. It also owns the capture-phase click suppression that keeps a
 drag from opening whatever it finished on, and keeps taps inert while editing —
 the iOS jiggle-mode rule. `createRearrangeable()` hands back a reorder instance
-and its edit mode already wired together; the only thing the two pages set
-differently is where their own layout collapses (1100px, 860px). The jiggle
-keyframes are in `global.css`, since keyframes declared inside a component are
-scoped to it and these belong to both.
+and its edit mode already wired together.
+
+The styling is shared the same way, under "Rearrangeable grids" in
+`global.css`: the grab cursor, the gestures a tile swallows so a press-and-drag
+isn't read as a scroll, how it looks in flight, the jiggle, and the dashed drop
+outline. A page opts in by marking its container `drag-grid` and its tiles
+`drag-tile`; the classes the drag sets — `is-dragging`, `is-editing`,
+`dragging`, `drop-target` — mean the same thing on both. That's deliberately
+not per-component: those rules are the feel of the thing, and keeping a copy
+each is how the two pages came to behave differently in the first place.
+
+What a page still says for itself is what genuinely differs: where its layout
+collapses (1100px, 860px), which tiles take the second jiggle so the grid
+doesn't rock in lockstep (by slot on the dashboard, by column on training), the
+shadow a tile lifts with (opaque widgets want a `box-shadow`, translucent cards
+a `drop-shadow`), and the drop outline's geometry, inset on the dashboard and
+outset on training, set through `--drop-outline-offset` and
+`--drop-outline-radius`.
 
 ### Netlify function re-export pattern
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ src/
                           player/ modals/ layout/) and feature logic (lib/).
   lib/              Cross-feature code, NOT tied to one route:
     ui/             Shared presentational components (BackLink, Button, Card,
-                    CloseButton, GateOverlay, Spinner) + reorder (drag-to-
-                    rearrange) and its storage half, layoutStore
+                    CloseButton, EditToggle, GateOverlay, Spinner) + reorder
+                    (drag-to-rearrange), editMode (when it's allowed) and
+                    layoutStore (where the arrangement is kept)
     data/           Client data layer (fetchJson, swrCache, concurrent)
     strava.js       Promoted feature-agnostic helpers (format/decode)
     tilt.js         Reusable Svelte action
@@ -93,10 +94,16 @@ pointer passes the threshold (the `dragging` class carries
 pure parts — validating a stored layout, swapping slots — live in
 `lib/ui/layoutStore.js` so they're testable without compiling runes.
 
-The two pages gate it differently. `/dashboard` drags freely on desktop and
-behind an Edit toggle once responsive; `/training` is always behind its
-Rearrange toggle, because those panels are full of links and scrollable lists
-and a stray drag would cost you a text selection or a tap.
+`lib/ui/editMode.svelte.js` wraps that in the rule both pages follow: dragging
+is free while the layout is wide enough to be pointer-driven, and behind the
+`lib/ui/EditToggle` pill once it collapses, where a press-and-drag is otherwise
+how you scroll. It also owns the capture-phase click suppression that keeps a
+drag from opening whatever it finished on, and keeps taps inert while editing —
+the iOS jiggle-mode rule. `createRearrangeable()` hands back a reorder instance
+and its edit mode already wired together; the only thing the two pages set
+differently is where their own layout collapses (1100px, 860px). The jiggle
+keyframes are in `global.css`, since keyframes declared inside a component are
+scoped to it and these belong to both.
 
 ### Netlify function re-export pattern
 
@@ -178,10 +185,12 @@ handlers are exercised through Node's global `Request`/`Response` with
 
 A handful of [Playwright](https://playwright.dev) smoke tests in `e2e/`
 (`*.e2e.js`) guard the lowest-risk/highest-value flows — the homepage boots,
-`/dashboard` mounts its widget grid, `/gallery` renders and its photo fetch
-settles, and `/training` renders its sections — labelled axes, plan-matched run
-log, working "i" disclosures, panels that rearrange and stay rearranged —
-without any of them growing wider than a phone screen. They run against `vite preview` (the static build, no
+`/gallery` renders and its photo fetch settles, and `/training` renders its
+sections — labelled axes, plan-matched run log, working "i" disclosures —
+without any of them growing wider than a phone screen. Rearranging is asserted
+on both pages that do it, since they share the code: a drag swaps two tiles and
+survives a reload, the Edit toggle is absent until the layout collapses, and on
+a phone the tiles keep `touch-action` (and their taps) until it's pressed. They run against `vite preview` (the static build, no
 Functions), so they assert routes render rather than live data; `/training`
 needs a payload before it draws anything wide, so it gets one from the real
 metrics engine (`e2e/fixtures/trainingPayload.js`) via a route stub. Install the browser once with

--- a/e2e/dashboard.e2e.js
+++ b/e2e/dashboard.e2e.js
@@ -13,3 +13,39 @@ test("dashboard mounts its widget grid", async ({ page }) => {
 	const widgets = grid.locator(".widget");
 	expect(await widgets.count()).toBeGreaterThanOrEqual(5);
 });
+
+// The drag and its edit mode are shared with /training (lib/ui/reorder and
+// lib/ui/editMode), so the behaviour is asserted on both pages: this is where
+// it came from, and it's the one that mustn't change.
+test("a widget can be dragged into another slot, and stays there", async ({ page }) => {
+	await page.goto("/dashboard");
+	const widgetAt = (idx) => page.locator(`[data-slot-index="${idx}"] .widget`);
+
+	const first = await widgetAt(0).getAttribute("data-widget");
+	const fifth = await widgetAt(4).getAttribute("data-widget");
+
+	const source = await widgetAt(0).boundingBox();
+	const target = await page.locator('[data-slot-index="4"]').boundingBox();
+	await page.mouse.move(source.x + source.width / 2, source.y + 24);
+	await page.mouse.down();
+	await page.mouse.move(target.x + target.width / 2, target.y + 24, { steps: 14 });
+	await page.mouse.up();
+
+	await expect(widgetAt(4)).toHaveAttribute("data-widget", first);
+	await expect(widgetAt(0)).toHaveAttribute("data-widget", fifth);
+
+	await page.reload();
+	await expect(widgetAt(4)).toHaveAttribute("data-widget", first);
+});
+
+test("the edit toggle is a small-screen affair", async ({ page }) => {
+	await page.goto("/dashboard");
+	const toggle = page.getByRole("button", { name: "Toggle layout edit mode" });
+	await expect(toggle).toHaveCount(0);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect(toggle).toBeVisible();
+	await expect(toggle).toHaveText(/Edit/);
+	await toggle.click();
+	await expect(toggle).toHaveText(/Done/);
+});

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -65,12 +65,13 @@ test("the charts are labelled with the values they plot", async ({ page }) => {
 	expect(labels.some((text) => Number(text) > 0)).toBe(true);
 });
 
-// Rearranging shares its machinery with /dashboard (lib/ui/reorder), but this
-// page gates it behind the Rearrange button, so the interesting part is that
-// the gate opens, a drop lands in the right slot, and the choice survives a
-// reload.
+// Rearranging is /dashboard's, code and behaviour both (lib/ui/reorder for the
+// drag, lib/ui/editMode for when it's allowed): drag a panel onto another to
+// swap them, free on a wide screen, behind the Edit toggle once the layout
+// collapses and a press-and-drag would otherwise be a scroll.
 test.describe("rearranging the panels", () => {
 	const panelAt = (page, idx) => page.locator(`[data-slot-index="${idx}"] .panel`);
+	const editToggle = (page) => page.getByRole("button", { name: "Toggle layout edit mode" });
 
 	async function dragPanel(page, fromIdx, toIdx) {
 		const source = await panelAt(page, fromIdx).boundingBox();
@@ -81,19 +82,10 @@ test.describe("rearranging the panels", () => {
 		await page.mouse.up();
 	}
 
-	test("panels stay put until you ask to rearrange them", async ({ page }) => {
-		await page.goto("/training");
-		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
-
-		await dragPanel(page, 0, 4);
-		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
-	});
-
 	test("a drag swaps the two panels and the layout is remembered", async ({ page }) => {
 		await page.goto("/training");
 		const displaced = await panelAt(page, 4).getAttribute("data-panel");
 
-		await page.getByRole("button", { name: "Rearrange" }).click();
 		await dragPanel(page, 0, 4);
 
 		await expect(panelAt(page, 4)).toHaveAttribute("data-panel", "volume");
@@ -101,52 +93,62 @@ test.describe("rearranging the panels", () => {
 
 		await page.reload();
 		await expect(panelAt(page, 4)).toHaveAttribute("data-panel", "volume");
-
-		// And there's a way back out of any arrangement.
-		await page.getByRole("button", { name: "Rearrange" }).click();
-		await page.getByRole("button", { name: "Reset" }).click();
-		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
 	});
 
-	test("the arrow keys move a panel without a pointer", async ({ page }) => {
-		await page.goto("/training");
-		await page.getByRole("button", { name: "Rearrange" }).click();
-
-		await page.locator('[data-slot-index="0"] .panel-handle').focus();
-		await page.keyboard.press("ArrowRight");
-
-		await expect(panelAt(page, 1)).toHaveAttribute("data-panel", "volume");
-	});
-
-	// On a phone the panels are most of the page, so a panel that swallowed
-	// touch gestures to be draggable would strand you at whichever one you
-	// started on. Touch drags go through the handle instead, and it's the only
-	// thing allowed to take touch-action away from the scroller.
-	test("a finger can still scroll the page while rearranging", async ({ page }) => {
-		await page.setViewportSize(PHONE);
-		await page.goto("/training");
-		await page.getByRole("button", { name: "Rearrange" }).click();
-
-		const blocked = await page.evaluate(() =>
-			[...document.querySelectorAll("#training-grid *")]
-				.filter((el) => getComputedStyle(el).touchAction === "none")
-				.map((el) => el.className.toString().split(" ")[0]),
-		);
-		expect([...new Set(blocked)]).toEqual(["panel-handle"]);
-	});
-
-	test("taps inside a panel don't fire while rearranging", async ({ page }) => {
+	// A press that doesn't travel is still a click, which is what keeps every
+	// link and disclosure inside a draggable panel working.
+	test("a press that goes nowhere still opens what it pressed", async ({ page }) => {
 		await page.goto("/training");
 		const card = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();
 		const info = card.getByRole("button", { name: /Weekly volume/i });
 
-		await page.getByRole("button", { name: "Rearrange" }).click();
+		await info.click();
+		await expect(info).toHaveAttribute("aria-expanded", "true");
+	});
+
+	test("there's no toggle to find on a wide screen", async ({ page }) => {
+		await page.goto("/training");
+		await expect(editToggle(page)).toHaveCount(0);
+	});
+
+	test("on a phone the panels wait to be told", async ({ page }) => {
+		await page.setViewportSize(PHONE);
+		await page.goto("/training");
+
+		// Dragging is off, so the page still scrolls with a finger rather than
+		// picking up whichever panel it landed on.
+		const idle = await panelAt(page, 0).evaluate((el) => getComputedStyle(el).touchAction);
+		expect(idle).toBe("auto");
+
+		await dragPanel(page, 0, 1);
+		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
+
+		await editToggle(page).click();
+		const editing = await panelAt(page, 0).evaluate((el) => getComputedStyle(el).touchAction);
+		expect(editing).toBe("none");
+
+		// A drag can only reach as far as the viewport: stacked panels are a
+		// screen tall each, so put both of them on it first. Instant, because
+		// the site scrolls smoothly and a drag measured mid-animation aims at
+		// where the panels used to be.
+		await page.evaluate(() => window.scrollTo({ top: 480, behavior: "instant" }));
+		await dragPanel(page, 0, 1);
+		await expect(panelAt(page, 1)).toHaveAttribute("data-panel", "volume");
+	});
+
+	test("taps inside a panel don't fire while editing", async ({ page }) => {
+		await page.setViewportSize(PHONE);
+		await page.goto("/training");
+		const card = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();
+		const info = card.getByRole("button", { name: /Weekly volume/i });
+
+		await editToggle(page).click();
 		// force: panels jiggle while editing, so nothing inside one is ever
 		// "stable" — which is exactly the state this is testing.
 		await info.click({ force: true });
 		await expect(info).toHaveAttribute("aria-expanded", "false");
 
-		await page.getByRole("button", { name: "Done" }).click();
+		await editToggle(page).click();
 		await info.click();
 		await expect(info).toHaveAttribute("aria-expanded", "true");
 	});

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -214,6 +214,7 @@
     50%  { transform: rotate(0.5deg)  translate(0, -1px); }
     100% { transform: rotate(-0.5deg) translate(0, 0); }
 }
+
 @keyframes edit-jiggle-b {
     0%   { transform: rotate(0.55deg)  translate(0, -1px); }
     50%  { transform: rotate(-0.55deg) translate(0, 0); }

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -239,6 +239,7 @@
 
 .drag-tile {
     cursor: grab;
+
     /* A press that turns into a drag mustn't start selecting text on the
        way, and mustn't be read as a scroll. Pages release both once their
        layout collapses, where dragging waits to be asked for. */

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -204,6 +204,22 @@
    Multi-layer radial-gradient "drift" used by the homepage + resume (body) and
    the /gallery and /dashboard route bodies, all referencing this one keyframe.
    The standalone /404 keeps its own copy (it doesn't load this file). */
+
+/* iOS-style jiggle for a grid in edit mode, on /dashboard and /training. Two
+   of them, applied to alternating tiles, so a grid doesn't rock in lockstep.
+   Global because keyframes declared inside a Svelte component are scoped to
+   it, and these belong to both. */
+@keyframes edit-jiggle-a {
+    0%   { transform: rotate(-0.5deg) translate(0, 0); }
+    50%  { transform: rotate(0.5deg)  translate(0, -1px); }
+    100% { transform: rotate(-0.5deg) translate(0, 0); }
+}
+@keyframes edit-jiggle-b {
+    0%   { transform: rotate(0.55deg)  translate(0, -1px); }
+    50%  { transform: rotate(-0.55deg) translate(0, 0); }
+    100% { transform: rotate(0.55deg)  translate(0, -1px); }
+}
+
 @keyframes gradient {
     0%   { background-position: 25% 75%, 80% 20%, 18% 28%, 82% 72%; }
     16%  { background-position: 70% 60%, 30% 40%, 55% 48%, 35% 82%; }

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -221,6 +221,62 @@
     100% { transform: rotate(0.55deg)  translate(0, -1px); }
 }
 
+/* === Rearrangeable grids ===
+   How a draggable grid looks and responds, for the pages driven by
+   lib/ui/reorder + lib/ui/editMode: /dashboard's widgets and /training's
+   panels. Both mark their container `.drag-grid` and their tiles
+   `.drag-tile`, and the classes the drag itself sets — is-dragging,
+   is-editing, dragging, drop-target — mean the same thing on both.
+
+   Here rather than in either component because these rules ARE the feel of
+   the thing: the grab cursor, the gestures a tile swallows, whether it
+   jiggles and how fast. Two copies is how the two pages came to behave
+   differently in the first place. What stays local to each page is what
+   genuinely differs: where its layout collapses, and how its tiles
+   alternate between the two jiggles. */
+.drag-grid.is-dragging,
+.drag-grid.is-dragging * { cursor: grabbing !important; }
+
+.drag-tile {
+    cursor: grab;
+    /* A press that turns into a drag mustn't start selecting text on the
+       way, and mustn't be read as a scroll. Pages release both once their
+       layout collapses, where dragging waits to be asked for. */
+    touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+/* pointer-events off so elementFromPoint can find the slot underneath. */
+.drag-tile.dragging {
+    cursor: grabbing;
+    pointer-events: none;
+    opacity: 0.92;
+}
+
+/* The slot a drop would land in. Dashed, and faded in rather than snapped on.
+   Each page sets the two geometry properties to suit its own tiles; the
+   treatment itself is the same on both. */
+.drag-grid .slot {
+    outline: 2px dashed transparent;
+    outline-offset: var(--drop-outline-offset, -8px);
+    border-radius: var(--drop-outline-radius, 20px);
+    transition: outline 0.15s ease;
+}
+.drag-grid .slot.drop-target { outline-color: var(--main-green); }
+
+.drag-grid.is-editing .drag-tile {
+    animation: edit-jiggle-a 0.42s ease-in-out infinite;
+    transform-origin: center;
+    will-change: transform;
+}
+.drag-grid.is-editing .drag-tile.dragging { animation: none; }
+
+@media (prefers-reduced-motion: reduce) {
+    .drag-grid.is-editing .drag-tile,
+    .drag-grid.is-editing .drag-tile.dragging { animation: none; }
+}
+
 @keyframes gradient {
     0%   { background-position: 25% 75%, 80% 20%, 18% 28%, 82% 72%; }
     16%  { background-position: 70% 60%, 30% 40%, 55% 48%, 35% 82%; }

--- a/src/components/Dashboard/Dashboard.svelte
+++ b/src/components/Dashboard/Dashboard.svelte
@@ -2,9 +2,8 @@
     Dashboard scaffold. Owns:
       - the slot grid (3 rows × 4 cols, mobile collapse + container queries)
       - the layout state ($state array of widget IDs, persisted to localStorage)
-      - drag-and-drop between slots (whole-widget drag, 5px threshold, no
-        setPointerCapture so anchor clicks aren't redirected)
-      - edit mode toggle (mobile only; required before drag is enabled)
+      - drag-and-drop between slots, and the edit mode that gates it on mobile,
+        both from lib/ui (reorder + editMode) and shared with /training
 
     Widget components are content-only — Dashboard provides the .widget wrapper
     div (or <a> for the gallery widget which is a link). Each widget id maps
@@ -22,7 +21,8 @@
     import HackerNewsWidget from "./widgets/HackerNewsWidget.svelte";
     import SpotifyVizOverlay from "./SpotifyVizOverlay.svelte";
     import BackLink from "../../lib/ui/BackLink.svelte";
-    import { createReorder } from "../../lib/ui/reorder.svelte.js";
+    import EditToggle from "../../lib/ui/EditToggle.svelte";
+    import { createRearrangeable } from "../../lib/ui/editMode.svelte.js";
 
     const WIDGETS = {
         clock:   { component: ClockWidget,      kind: "div" },
@@ -43,59 +43,28 @@
     const DEFAULT_ORDER = ["clock", "gallery", "weather", "spotify", "strava", "github", "hn"];
     const LAYOUT_KEY = "dashboard-layout";
 
-    let isEditing = $state(false);
-    let isResponsive = $state(false);
-
     let dashboardEl;
-    let responsiveQuery;
-    let onResponsiveChange;
-    let clickCapture;
 
-    // Drag mechanics live in lib/ui/reorder — /training uses the same ones.
-    // Dragging is free on desktop and gated behind edit mode once the layout
-    // goes responsive, where a press-and-drag is otherwise a scroll.
-    const reorder = createReorder({
+    // Drag mechanics and the edit mode that gates them both live in lib/ui —
+    // /training runs the same ones. Dragging is free on desktop and behind the
+    // toggle once the layout goes responsive, where a press-and-drag is
+    // otherwise a scroll.
+    const { reorder, edit } = createRearrangeable({
+        gridId: "dashboard-grid",
+        responsiveQuery: "(max-width: 1100px)",
         order: DEFAULT_ORDER,
         storageKey: LAYOUT_KEY,
-        enabled: () => !(isResponsive && !isEditing),
         // Swap-flash + forced resize so list trimming and the viz canvas re-fit.
         onReorder: () => requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))),
     });
     const layout = $derived(reorder.layout);
 
-    function toggleEditing(e) {
-        e.stopPropagation();
-        isEditing = !isEditing;
-    }
-
     onMount(() => {
         reorder.restore();
-
-        responsiveQuery = window.matchMedia("(max-width: 1100px)");
-        isResponsive = responsiveQuery.matches;
-        onResponsiveChange = (e) => {
-            isResponsive = e.matches;
-            if (!e.matches) isEditing = false;
-        };
-        responsiveQuery.addEventListener("change", onResponsiveChange);
-
-        // Capture-phase click suppression. Beats anchor navigation. Suppresses
-        // inside the dashboard within 300ms of drag, and at all times while
-        // editing (matches iOS jiggle-mode where taps don't open icons).
-        clickCapture = (e) => {
-            if (!e.target.closest("#dashboard-grid")) return;
-            if (reorder.suppressesClick() || isEditing) {
-                e.preventDefault();
-                e.stopPropagation();
-            }
-        };
-        document.addEventListener("click", clickCapture, true);
+        edit.listen();
     });
 
-    onDestroy(() => {
-        responsiveQuery?.removeEventListener("change", onResponsiveChange);
-        document.removeEventListener("click", clickCapture, true);
-    });
+    onDestroy(() => edit.stop());
 </script>
 
 <svelte:head>
@@ -106,21 +75,13 @@
 
 <BackLink />
 
-<button
-    class="dashboard-edit-btn"
-    class:active={isEditing}
-    type="button"
-    aria-pressed={isEditing ? "true" : "false"}
-    aria-label="Toggle layout edit mode"
-    onclick={toggleEditing}
->
-    <span class="dashboard-edit-icon" aria-hidden="true">✎</span>
-    <span class="dashboard-edit-label">{isEditing ? "Done" : "Edit"}</span>
-</button>
+{#if edit.isResponsive}
+    <EditToggle editing={edit.isEditing} onclick={edit.toggle} />
+{/if}
 
 <div
     class="dashboard"
-    class:is-editing={isEditing}
+    class:is-editing={edit.isEditing}
     class:is-dragging={reorder.isDragging}
     bind:this={dashboardEl}
     id="dashboard-grid"
@@ -365,59 +326,17 @@
         :global(.widget-weather .weather-stats) { grid-template-columns: 1fr 1fr; gap: 0.3rem 0.75rem; font-size: 0.78rem; }
     }
 
-    /* === edit mode (mobile only) === */
-    .dashboard-edit-btn {
-        display: none;
-        position: fixed;
-        top: 0.5rem;
-        right: 0.75rem;
-        z-index: 50;
-        align-items: center;
-        gap: 0.4rem;
-        padding: 0.45rem 0.85rem;
-        background: var(--inner-background, rgba(0, 0, 0, 0.35));
-        border: 1px solid var(--main-green-translucent);
-        border-radius: 999px;
-        color: var(--main-green);
-        font-family: inherit;
-        font-size: 0.85rem;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        cursor: pointer;
-        opacity: 0.85;
-        backdrop-filter: blur(8px);
-        -webkit-backdrop-filter: blur(8px);
-        transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
-    }
-    .dashboard-edit-btn:hover { opacity: 1; }
-    .dashboard-edit-btn:active { transform: scale(0.96); }
-    .dashboard-edit-btn.active {
-        background: var(--main-green);
-        color: var(--background-one);
-        border-color: var(--main-green);
-        opacity: 1;
-    }
-    .dashboard-edit-icon { font-size: 0.95rem; line-height: 1; }
-
-    /* iOS-style jiggle while in edit mode. Two animations + odd/even
-       offsets so widgets don't move in lockstep. */
-    @keyframes widget-jiggle-a {
-        0%   { transform: rotate(-0.5deg) translate(0, 0); }
-        50%  { transform: rotate(0.5deg)  translate(0, -1px); }
-        100% { transform: rotate(-0.5deg) translate(0, 0); }
-    }
-    @keyframes widget-jiggle-b {
-        0%   { transform: rotate(0.55deg)  translate(0, -1px); }
-        50%  { transform: rotate(-0.55deg) translate(0, 0); }
-        100% { transform: rotate(0.55deg)  translate(0, -1px); }
-    }
+    /* === edit mode (mobile only) ===
+       The toggle itself is lib/ui/EditToggle; the jiggle keyframes are in
+       global.css, shared with /training. Odd/even slots take different ones
+       so the grid doesn't rock in lockstep. */
     .dashboard.is-editing .slot > :global(.widget) {
-        animation: widget-jiggle-a 0.42s ease-in-out infinite;
+        animation: edit-jiggle-a 0.42s ease-in-out infinite;
         transform-origin: center;
         will-change: transform;
     }
     .dashboard.is-editing .slot:nth-child(odd) > :global(.widget) {
-        animation-name: widget-jiggle-b;
+        animation-name: edit-jiggle-b;
         animation-duration: 0.46s;
         animation-delay: -0.18s;
     }
@@ -439,7 +358,7 @@
         .slot { container-type: inline-size; }
         .slot-large, .slot-small { grid-column: span 2; }
         .slot > :global(.widget-gallery) { aspect-ratio: 16 / 9; }
-        .dashboard-edit-btn { display: inline-flex; }
+        /* A finger scrolls the page until edit mode says otherwise. */
         .slot > :global(.widget) { touch-action: auto; cursor: default; }
         .dashboard.is-editing .slot > :global(.widget) { touch-action: none; }
     }

--- a/src/components/Dashboard/Dashboard.svelte
+++ b/src/components/Dashboard/Dashboard.svelte
@@ -80,7 +80,7 @@
 {/if}
 
 <div
-    class="dashboard"
+    class="dashboard drag-grid"
     class:is-editing={edit.isEditing}
     class:is-dragging={reorder.isDragging}
     bind:this={dashboardEl}
@@ -95,7 +95,7 @@
         >
             {#if cfg.kind === "a"}
                 <a
-                    class="widget widget-{widgetId}"
+                    class="widget drag-tile widget-{widgetId}"
                     class:dragging={reorder.draggingId === widgetId}
                     data-widget={widgetId}
                     href={cfg.href}
@@ -106,7 +106,7 @@
                 </a>
             {:else}
                 <div
-                    class="widget widget-{widgetId}"
+                    class="widget drag-tile widget-{widgetId}"
                     class:dragging={reorder.draggingId === widgetId}
                     data-widget={widgetId}
                     style:transform={reorder.transformFor(widgetId)}
@@ -155,9 +155,11 @@
         max-width: 1800px;
         margin: 0 auto;
     }
+    /* The grab cursor, the swallowed gestures and the jiggle are in global.css
+       under "Rearrangeable grids", shared with /training. What's left here is
+       what this page does differently — starting with a grid that clips at
+       100vh and has to stop while something is being dragged out of it. */
     .dashboard.is-dragging { overflow: visible; }
-    .dashboard.is-dragging,
-    .dashboard.is-dragging :global(*) { cursor: grabbing !important; }
 
     :global(.widget) {
         position: relative;
@@ -202,15 +204,15 @@
     }
     :global(.profile-link:hover) { opacity: 1; }
 
+    /* Widgets fill their slot edge to edge, so the drop outline is drawn
+       inside them; the treatment itself is in global.css. */
     .slot {
         display: flex;
         min-width: 0;
         min-height: 0;
         position: relative;
-        border-radius: 20px;
-        transition: outline 0.15s ease;
-        outline: 2px dashed transparent;
-        outline-offset: -8px;
+        --drop-outline-offset: -8px;
+        --drop-outline-radius: 20px;
         container-type: size;
         container-name: slot;
     }
@@ -222,20 +224,12 @@
         height: 100%;
         min-width: 0;
         min-height: 0;
-        cursor: grab;
-        touch-action: none;
-        user-select: none;
-        -webkit-user-select: none;
     }
     .slot > :global(.widget.dragging) {
-        cursor: grabbing;
-        opacity: 0.92;
         box-shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
         z-index: 1000;
         transition: box-shadow 0.15s ease;
-        pointer-events: none;
     }
-    .slot.drop-target { outline-color: var(--main-green); }
 
     .slot > :global(.widget-gallery) {
         padding: 0;
@@ -327,24 +321,14 @@
     }
 
     /* === edit mode (mobile only) ===
-       The toggle itself is lib/ui/EditToggle; the jiggle keyframes are in
-       global.css, shared with /training. Odd/even slots take different ones
-       so the grid doesn't rock in lockstep. */
-    .dashboard.is-editing .slot > :global(.widget) {
-        animation: edit-jiggle-a 0.42s ease-in-out infinite;
-        transform-origin: center;
-        will-change: transform;
-    }
-    .dashboard.is-editing .slot:nth-child(odd) > :global(.widget) {
+       The toggle is lib/ui/EditToggle and the jiggle is in global.css, both
+       shared with /training. Alternate slots take the second of the two, so
+       the grid doesn't rock in lockstep — this page alternates by slot,
+       /training by column. */
+    .dashboard.is-editing .slot:nth-child(odd) > :global(.widget:not(.dragging)) {
         animation-name: edit-jiggle-b;
         animation-duration: 0.46s;
         animation-delay: -0.18s;
-    }
-    .dashboard.is-editing .slot > :global(.widget.dragging) { animation: none; }
-
-    @media (prefers-reduced-motion: reduce) {
-        .dashboard.is-editing .slot > :global(.widget),
-        .dashboard.is-editing .slot:nth-child(odd) > :global(.widget) { animation: none; }
     }
 
     @media (max-width: 1100px) {

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -249,7 +249,15 @@
     }
     .col-full { grid-column: 1 / -1; }
 
-    .slot { min-width: 0; }
+    /* The drop outline fades in rather than snapping on, as it does on the
+       dashboard: it's declared transparent here and coloured in below. */
+    .slot {
+        min-width: 0;
+        outline: 2px dashed transparent;
+        outline-offset: 3px;
+        border-radius: var(--radius-xl);
+        transition: outline 0.15s ease;
+    }
     /* Same affordances as a dashboard widget: the whole panel is the handle,
        and a press that turns into a drag mustn't start selecting text on the
        way. Both are lifted once the layout collapses, where dragging waits
@@ -274,11 +282,7 @@
     }
     .grid.is-dragging,
     .grid.is-dragging :global(*) { cursor: grabbing !important; }
-    .slot.drop-target {
-        outline: 2px dashed var(--main-green);
-        outline-offset: 3px;
-        border-radius: var(--radius-xl);
-    }
+    .slot.drop-target { outline-color: var(--main-green); }
 
     /* Jiggle keyframes are in global.css, shared with /dashboard; the columns
        alternate so the page doesn't rock in lockstep. */

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -129,7 +129,7 @@
         data-slot-index={idx}
     >
         <div
-            class="panel"
+            class="panel drag-tile"
             class:dragging={reorder.draggingId === id}
             data-panel={id}
             style:transform={reorder.transformFor(id)}
@@ -183,7 +183,7 @@
         <SyncNotice sync={data.sync} runCount={data.runs?.length ?? 0} />
 
         <div
-            class="grid"
+            class="grid drag-grid"
             class:is-editing={edit.isEditing}
             class:is-dragging={reorder.isDragging}
             id="training-grid"
@@ -249,57 +249,32 @@
     }
     .col-full { grid-column: 1 / -1; }
 
-    /* The drop outline fades in rather than snapping on, as it does on the
-       dashboard: it's declared transparent here and coloured in below. */
+    /* Cards sit inside their slot, so the drop outline goes outside rather
+       than inset the way the dashboard's does. */
     .slot {
         min-width: 0;
-        outline: 2px dashed transparent;
-        outline-offset: 3px;
-        border-radius: var(--radius-xl);
-        transition: outline 0.15s ease;
+        --drop-outline-offset: 3px;
+        --drop-outline-radius: var(--radius-xl);
     }
-    /* Same affordances as a dashboard widget: the whole panel is the handle,
-       and a press that turns into a drag mustn't start selecting text on the
-       way. Both are lifted once the layout collapses, where dragging waits
-       for the Edit toggle. */
+    /* The grab cursor, the swallowed gestures and the jiggle are in
+       global.css under "Rearrangeable grids", shared with /dashboard. What's
+       left here is what this page does differently. */
     .panel {
         position: relative;
         min-width: 0;
-        cursor: grab;
-        touch-action: none;
-        user-select: none;
-        -webkit-user-select: none;
     }
     .panel.dragging {
-        /* pointer-events off so elementFromPoint finds the slot underneath. */
-        pointer-events: none;
         z-index: 20;
-        opacity: 0.92;
-        cursor: grabbing;
         /* The card surfaces are translucent, so a panel in flight would
            otherwise read as part of whatever it's passing over. */
         filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.35));
     }
-    .grid.is-dragging,
-    .grid.is-dragging :global(*) { cursor: grabbing !important; }
-    .slot.drop-target { outline-color: var(--main-green); }
-
-    /* Jiggle keyframes are in global.css, shared with /dashboard; the columns
-       alternate so the page doesn't rock in lockstep. */
-    .grid.is-editing .panel {
-        animation: edit-jiggle-a 0.42s ease-in-out infinite;
-        transform-origin: center;
-        will-change: transform;
-    }
-    .grid.is-editing .col:nth-child(even) .panel {
+    /* The second column takes the other jiggle, so the page doesn't rock in
+       lockstep — the dashboard alternates by slot, this by column. */
+    .grid.is-editing .col:nth-child(even) .panel:not(.dragging) {
         animation-name: edit-jiggle-b;
         animation-duration: 0.46s;
         animation-delay: -0.18s;
-    }
-    .grid.is-editing .panel.dragging { animation: none; }
-    @media (prefers-reduced-motion: reduce) {
-        .grid.is-editing .panel,
-        .grid.is-editing .col:nth-child(even) .panel { animation: none; }
     }
 
     @media (max-width: 1100px) {

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -8,16 +8,17 @@
     private activities and no GPS — see netlify/functions/_shared/training/
     shape.js for how that's enforced.
 
-    Panels are rearrangeable, using the same slot model as /dashboard (see
-    lib/ui/reorder). Unlike the dashboard, dragging is always behind an edit
-    toggle: these panels are full of links, scrollable lists and buttons, and
-    a page where pressing a run and moving the mouse drags the panel instead
-    of selecting text would be worse than one with an extra button.
+    Panels rearrange exactly the way /dashboard's widgets do, running the same
+    code (lib/ui/reorder for the drag, lib/ui/editMode for when it's allowed):
+    grab a panel and drop it on another to swap them, free on a wide screen,
+    behind the Edit toggle once the layout is narrow enough that a press-and-
+    drag would otherwise be a scroll.
 -->
 <script>
     import { onMount, onDestroy } from "svelte";
     import BackLink from "../../lib/ui/BackLink.svelte";
-    import { createReorder } from "../../lib/ui/reorder.svelte.js";
+    import EditToggle from "../../lib/ui/EditToggle.svelte";
+    import { createRearrangeable } from "../../lib/ui/editMode.svelte.js";
     import Spinner from "../../lib/ui/Spinner.svelte";
     import { fetchJsonSwr } from "../../lib/data/swrCache.js";
     import { createPoller } from "../../lib/data/poller.js";
@@ -39,17 +40,6 @@
     // row underneath. A panel can sit in any of them; the charts and the run
     // log all reflow to their container, so a "narrow" chart is a narrower
     // chart rather than a broken one.
-    const PANELS = {
-        volume: "Weekly volume",
-        fitness: "Fitness and fatigue",
-        efficiency: "Aerobic efficiency",
-        recommendations: "What to do about it",
-        prediction: "Race projection",
-        load: "Injury risk",
-        intensity: "Intensity mix",
-        week: "This week",
-        runs: "Runs this block",
-    };
     const DEFAULT_ORDER = [
         "volume", "fitness", "efficiency", "recommendations",
         "prediction", "load", "intensity", "week",
@@ -61,14 +51,15 @@
 
     let data = $state(null);
     let error = $state("");
-    let isEditing = $state(false);
     let stopPoll;
-    let clickCapture;
 
-    const reorder = createReorder({
+    const { reorder, edit } = createRearrangeable({
+        gridId: "training-grid",
+        // Where the two columns become one, which is also where a press-and-
+        // drag stops being spare and starts being how you scroll.
+        responsiveQuery: "(max-width: 860px)",
         order: DEFAULT_ORDER,
         storageKey: LAYOUT_KEY,
-        enabled: () => isEditing,
         // Charts size themselves off their container, so a swap between the
         // wide and narrow columns needs them to re-measure.
         onReorder: () => requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))),
@@ -107,36 +98,12 @@
         }
     }
 
-    // Arrow keys on a panel's handle move it a slot at a time, so the layout
-    // is reachable without a pointer.
-    function nudge(id, event) {
-        const step = { ArrowLeft: -1, ArrowUp: -1, ArrowRight: 1, ArrowDown: 1 }[event.key];
-        if (!step) return;
-        const target = reorder.layout.indexOf(id) + step;
-        if (target < 0 || target >= DEFAULT_ORDER.length) return;
-        event.preventDefault();
-        reorder.move(id, target);
-        // The handle moves with the panel; keep focus on it for repeat presses.
-        const handle = event.currentTarget;
-        requestAnimationFrame(() => handle.focus());
-    }
-
     onMount(() => {
         document.body.classList.add("training-page");
         reorder.restore();
+        edit.listen();
         load();
 
-        // Capture phase, so it beats anchor navigation: while rearranging, a
-        // tap is aimed at the panel rather than at whatever is inside it.
-        clickCapture = (e) => {
-            if (!e.target.closest("#training-grid")) return;
-            if (e.target.closest(".panel-handle")) return;
-            if (reorder.suppressesClick() || isEditing) {
-                e.preventDefault();
-                e.stopPropagation();
-            }
-        };
-        document.addEventListener("click", clickCapture, true);
         // The upstream sync runs hourly, so there's nothing to gain from
         // polling hard — this is really just to catch a sync landing while
         // the tab is left open.
@@ -145,7 +112,7 @@
 
     onDestroy(() => {
         stopPoll?.();
-        document.removeEventListener("click", clickCapture, true);
+        edit.stop();
         document.body.classList.remove("training-page");
     });
 </script>
@@ -166,24 +133,8 @@
             class:dragging={reorder.draggingId === id}
             data-panel={id}
             style:transform={reorder.transformFor(id)}
-            onpointerdown={(e) => { if (e.pointerType !== "touch") reorder.start(id, e); }}
+            onpointerdown={(e) => reorder.start(id, e)}
         >
-            {#if isEditing}
-                <button
-                    class="panel-handle"
-                    type="button"
-                    aria-label="Move {PANELS[id]} — use the arrow keys, or drag"
-                    title="Drag to rearrange"
-                    onpointerdown={(e) => { e.stopPropagation(); reorder.start(id, e); }}
-                    onkeydown={(e) => nudge(id, e)}
-                >
-                    <svg viewBox="0 0 16 16" aria-hidden="true">
-                        <circle cx="5.5" cy="4" r="1.35" /><circle cx="10.5" cy="4" r="1.35" />
-                        <circle cx="5.5" cy="8" r="1.35" /><circle cx="10.5" cy="8" r="1.35" />
-                        <circle cx="5.5" cy="12" r="1.35" /><circle cx="10.5" cy="12" r="1.35" />
-                    </svg>
-                </button>
-            {/if}
             {@render panelBody(id)}
         </div>
     </div>
@@ -214,23 +165,8 @@
 <main class="training">
     <BackLink />
 
-    {#if data}
-        <div class="edit-bar">
-            {#if isEditing}
-                <button class="edit-btn ghost" type="button" onclick={() => reorder.reset()}>
-                    Reset
-                </button>
-            {/if}
-            <button
-                class="edit-btn"
-                class:active={isEditing}
-                type="button"
-                aria-pressed={isEditing ? "true" : "false"}
-                onclick={() => (isEditing = !isEditing)}
-            >
-                {isEditing ? "Done" : "Rearrange"}
-            </button>
-        </div>
+    {#if data && edit.isResponsive}
+        <EditToggle editing={edit.isEditing} onclick={edit.toggle} />
     {/if}
 
     {#if error && !data}
@@ -248,7 +184,7 @@
 
         <div
             class="grid"
-            class:is-editing={isEditing}
+            class:is-editing={edit.isEditing}
             class:is-dragging={reorder.isDragging}
             id="training-grid"
         >
@@ -314,7 +250,18 @@
     .col-full { grid-column: 1 / -1; }
 
     .slot { min-width: 0; }
-    .panel { position: relative; min-width: 0; }
+    /* Same affordances as a dashboard widget: the whole panel is the handle,
+       and a press that turns into a drag mustn't start selecting text on the
+       way. Both are lifted once the layout collapses, where dragging waits
+       for the Edit toggle. */
+    .panel {
+        position: relative;
+        min-width: 0;
+        cursor: grab;
+        touch-action: none;
+        user-select: none;
+        -webkit-user-select: none;
+    }
     .panel.dragging {
         /* pointer-events off so elementFromPoint finds the slot underneath. */
         pointer-events: none;
@@ -325,92 +272,31 @@
            otherwise read as part of whatever it's passing over. */
         filter: drop-shadow(0 12px 22px rgba(0, 0, 0, 0.35));
     }
-    /* A finger dragging the panel body would have to give up scrolling
-       (touch-action: none) to do it, and on a phone the panels are most of
-       the page — you'd be stuck at whichever one you started on. So touch
-       drags from the handle only; a mouse can still grab anywhere. */
-    .grid.is-editing .panel {
-        cursor: grab;
-        user-select: none;
-    }
-    .grid.is-editing .slot.drop-target {
+    .grid.is-dragging,
+    .grid.is-dragging :global(*) { cursor: grabbing !important; }
+    .slot.drop-target {
         outline: 2px dashed var(--main-green);
         outline-offset: 3px;
         border-radius: var(--radius-xl);
     }
 
-    /* Corner badge rather than an inline control: every panel already has an
-       info button in its top-right, and overhanging the border keeps the two
-       from reading as the same row of buttons. */
-    .panel-handle {
-        position: absolute;
-        top: -9px;
-        right: -9px;
-        z-index: 21;
-        width: 26px;
-        height: 26px;
-        display: grid;
-        place-items: center;
-        padding: 0;
-        border: 1px solid var(--main-green-translucent);
-        border-radius: 50%;
-        background: var(--background-one);
-        color: var(--main-green);
-        cursor: grab;
-        touch-action: none;
-        box-shadow: var(--inner-box-shadow);
+    /* Jiggle keyframes are in global.css, shared with /dashboard; the columns
+       alternate so the page doesn't rock in lockstep. */
+    .grid.is-editing .panel {
+        animation: edit-jiggle-a 0.42s ease-in-out infinite;
+        transform-origin: center;
+        will-change: transform;
     }
-    .panel-handle svg { width: 15px; height: 15px; display: block; fill: currentColor; }
-    @media (pointer: coarse) {
-        .panel-handle { width: 34px; height: 34px; top: -12px; right: -12px; }
-        .panel-handle svg { width: 18px; height: 18px; }
+    .grid.is-editing .col:nth-child(even) .panel {
+        animation-name: edit-jiggle-b;
+        animation-duration: 0.46s;
+        animation-delay: -0.18s;
     }
-
-    /* iOS-style jiggle, matching /dashboard's edit mode. */
-    @keyframes panel-jiggle {
-        0% { transform: rotate(-0.35deg); }
-        50% { transform: rotate(0.35deg) translateY(-1px); }
-        100% { transform: rotate(-0.35deg); }
-    }
-    .grid.is-editing .panel { animation: panel-jiggle 0.5s ease-in-out infinite; }
-    .grid.is-editing .col:nth-child(even) .panel { animation-delay: -0.2s; animation-duration: 0.54s; }
     .grid.is-editing .panel.dragging { animation: none; }
     @media (prefers-reduced-motion: reduce) {
         .grid.is-editing .panel,
         .grid.is-editing .col:nth-child(even) .panel { animation: none; }
     }
-
-    .edit-bar {
-        position: fixed;
-        top: 0.9rem;
-        right: 1rem;
-        z-index: 60;
-        display: flex;
-        gap: var(--space-2);
-    }
-    .edit-btn {
-        padding: 0.4rem 0.85rem;
-        border: 1px solid var(--main-green-translucent);
-        border-radius: var(--radius-pill);
-        background: var(--inner-background);
-        color: var(--main-green);
-        font-family: inherit;
-        font-size: var(--font-xs);
-        font-weight: 600;
-        cursor: pointer;
-        opacity: 0.85;
-        backdrop-filter: blur(var(--blur-md));
-        -webkit-backdrop-filter: blur(var(--blur-md));
-        transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
-    }
-    .edit-btn:hover { opacity: 1; }
-    .edit-btn.active {
-        background: var(--main-green);
-        border-color: var(--main-green);
-        color: var(--background-one);
-        opacity: 1;
-    }
-    .edit-btn.ghost { opacity: 0.6; }
 
     @media (max-width: 1100px) {
         .training { padding-top: 3.5rem; }
@@ -418,7 +304,9 @@
     @media (max-width: 860px) {
         .grid { grid-template-columns: minmax(0, 1fr); }
         .training { padding: 3.5rem var(--space-4) var(--space-7); }
-        .edit-bar { top: 0.75rem; right: 0.75rem; }
+        /* A finger scrolls the page until edit mode says otherwise. */
+        .panel { touch-action: auto; cursor: default; }
+        .grid.is-editing .panel { touch-action: none; }
     }
 
     .foot {

--- a/src/lib/ui/EditToggle.svelte
+++ b/src/lib/ui/EditToggle.svelte
@@ -1,0 +1,57 @@
+<!--
+    The edit-mode pill from /dashboard, shared with /training.
+
+    It only appears once a layout has collapsed to the point where dragging
+    has to be asked for; on a wide screen there's nothing to toggle, so the
+    page doesn't render it at all.
+-->
+<script>
+    let { editing = false, onclick } = $props();
+</script>
+
+<button
+    class="edit-btn"
+    class:active={editing}
+    type="button"
+    aria-pressed={editing ? "true" : "false"}
+    aria-label="Toggle layout edit mode"
+    {onclick}
+>
+    <span class="edit-icon" aria-hidden="true">✎</span>
+    <span class="edit-label">{editing ? "Done" : "Edit"}</span>
+</button>
+
+<style>
+    .edit-btn {
+        position: fixed;
+        top: 0.5rem;
+        right: 0.75rem;
+        z-index: 50;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.45rem 0.85rem;
+        background: var(--inner-background, rgba(0, 0, 0, 0.35));
+        border: 1px solid var(--main-green-translucent);
+        border-radius: 999px;
+        color: var(--main-green);
+        font-family: inherit;
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        cursor: pointer;
+        opacity: 0.85;
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+    }
+    .edit-btn:hover { opacity: 1; }
+    .edit-btn:active { transform: scale(0.96); }
+    .edit-btn.active {
+        background: var(--main-green);
+        color: var(--background-one);
+        border-color: var(--main-green);
+        opacity: 1;
+    }
+    .edit-icon { font-size: 0.95rem; line-height: 1; }
+</style>

--- a/src/lib/ui/editMode.svelte.js
+++ b/src/lib/ui/editMode.svelte.js
@@ -1,0 +1,87 @@
+// A rearrangeable grid: the drag mechanics, plus the edit mode that decides
+// when they're allowed.
+//
+// Dragging is free while the layout is wide enough to be pointer-driven, and
+// gated behind a toggle once it goes responsive — where a press-and-drag is
+// otherwise how you scroll the page. The toggle only exists in that narrow
+// state, which is why widening the window turns editing back off.
+//
+// This lived inline in Dashboard.svelte until /training wanted the same
+// behaviour. It's here so there's one of it: the same rule for when dragging
+// is allowed, and the same rule for which clicks are drag residue.
+
+import { createReorder } from "./reorder.svelte.js";
+
+/**
+ * @param {object} options
+ * @param {string} options.gridId id of the grid element; clicks are only
+ *   suppressed inside it.
+ * @param {string} [options.responsiveQuery] media query for "the layout has
+ *   collapsed", i.e. where dragging has to be asked for first.
+ * @param {...*} options.rest everything else goes to createReorder.
+ * @returns {{reorder: object, edit: object}}
+ */
+export function createRearrangeable({
+	gridId,
+	responsiveQuery = "(max-width: 1100px)",
+	...reorderOptions
+}) {
+	let isEditing = $state(false);
+	let isResponsive = $state(false);
+
+	const reorder = createReorder({
+		...reorderOptions,
+		enabled: () => !(isResponsive && !isEditing),
+	});
+
+	let query;
+	let onQueryChange;
+	let onClickCapture;
+
+	function listen() {
+		query = window.matchMedia(responsiveQuery);
+		isResponsive = query.matches;
+		onQueryChange = (event) => {
+			isResponsive = event.matches;
+			// Widening the window puts dragging back within reach anyway, and
+			// leaves no button to turn edit mode off with.
+			if (!event.matches) isEditing = false;
+		};
+		query.addEventListener("change", onQueryChange);
+
+		// Capture phase, so this beats anchor navigation: a click inside the
+		// grid is swallowed for a moment after a drag, and at all times while
+		// editing — matching iOS jiggle mode, where tapping an icon doesn't
+		// open it.
+		onClickCapture = (event) => {
+			if (!event.target.closest(`#${gridId}`)) return;
+			if (reorder.suppressesClick() || isEditing) {
+				event.preventDefault();
+				event.stopPropagation();
+			}
+		};
+		document.addEventListener("click", onClickCapture, true);
+	}
+
+	function stop() {
+		query?.removeEventListener("change", onQueryChange);
+		document.removeEventListener("click", onClickCapture, true);
+	}
+
+	return {
+		reorder,
+		edit: {
+			get isEditing() { return isEditing; },
+			get isResponsive() { return isResponsive; },
+
+			/** stopPropagation: the button sits over the grid's click capture. */
+			toggle(event) {
+				event?.stopPropagation();
+				isEditing = !isEditing;
+			},
+
+			listen,
+			stop,
+		},
+	};
+}

--- a/src/lib/ui/editMode.svelte.js
+++ b/src/lib/ui/editMode.svelte.js
@@ -10,6 +10,9 @@
 // behaviour. It's here so there's one of it: the same rule for when dragging
 // is allowed, and the same rule for which clicks are drag residue.
 
+/* global $state -- a compiler intrinsic, not an import, and the analyser on
+   pull requests reads this file without knowing that. */
+
 import { createReorder } from "./reorder.svelte.js";
 
 /**
@@ -45,7 +48,9 @@ export function createRearrangeable({
 			isResponsive = event.matches;
 			// Widening the window puts dragging back within reach anyway, and
 			// leaves no button to turn edit mode off with.
-			if (!event.matches) isEditing = false;
+			if (!event.matches) {
+				isEditing = false;
+			}
 		};
 		query.addEventListener("change", onQueryChange);
 
@@ -54,7 +59,9 @@ export function createRearrangeable({
 		// editing — matching iOS jiggle mode, where tapping an icon doesn't
 		// open it.
 		onClickCapture = (event) => {
-			if (!event.target.closest(`#${gridId}`)) return;
+			if (!event.target.closest(`#${gridId}`)) {
+				return;
+			}
 			if (reorder.suppressesClick() || isEditing) {
 				event.preventDefault();
 				event.stopPropagation();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/training` was rearranging panels its own way — a "Rearrange" button, a drag
handle, a reset, keyboard nudges — while `/dashboard` already had a rearranging
model that works. This drops the alternative and gives `/training` the same one,
then puts the implementation somewhere both pages read from so they can't drift
apart again.

## The interaction, on both pages now

Drag a tile anywhere on it while the layout is wide. Once the layout collapses
to a single column, dragging waits behind the **Edit** pill, because on a phone
a press-and-drag is how you scroll — the toggle only exists at that width. In
edit mode tiles jiggle and taps inside the grid do nothing, the way an iOS home
screen behaves. A drop swaps the two tiles involved, and the arrangement is
remembered.

## What's shared

Behaviour was already single-sourced in this branch:

| | |
|---|---|
| `lib/ui/reorder.svelte.js` | the drag itself: threshold, drop target, swap |
| `lib/ui/layoutStore.js` | validating and persisting an arrangement |
| `lib/ui/editMode.svelte.js` | when dragging is allowed, and swallowing the click after it |
| `lib/ui/EditToggle.svelte` | the Edit/Done pill |

The last commits do the same for the styling, which was still written out twice
with different selectors: the grab cursor, the gestures a tile swallows, how it
looks in flight, the jiggle timings, the dashed drop outline. Those rules are
the feel of the thing, and two copies of them is how the pages came to feel
different in the first place. They now live once in `global.css` under
"Rearrangeable grids", next to the keyframes; a page opts in by marking its
container `drag-grid` and its tiles `drag-tile`.

Neither page has any drag code of its own left. What each still states is only
what genuinely differs: where its layout collapses (1100px, 860px), which tiles
take the second jiggle so a grid doesn't rock in lockstep (by slot on the
dashboard, by column on training), the shadow a tile lifts with (opaque widgets
want a `box-shadow`, translucent cards a `drop-shadow`), and the drop outline's
geometry — inset on the dashboard, outset on training, now two custom
properties.

## Two bugs the consolidation shook out

Both found by reading computed styles on both pages at both widths rather than
by eye, and both fixed here:

- The drop outline stopped colouring. Component styles load after `global.css`,
  so a scoped `.slot { outline: ... transparent }` shorthand quietly beat the
  shared `outline-color` at equal specificity. The whole treatment is one rule
  now.
- A widget dragged out of an odd slot kept jiggling in flight, its alternation
  rule outweighing the shared "not while dragging". Both pages now exclude the
  dragged tile from alternating.

## Trade-off

`/training` loses the arrow-key reordering it briefly had, since `/dashboard`
doesn't have it. Worth revisiting for both pages together rather than keeping
one of them different.

## Verification

- 482 unit tests, 73 lint warnings and no errors, clean build.
- 16 Playwright specs, including drag coverage for `/dashboard` that didn't
  exist before: a desktop drag swaps and persists, the toggle appears only on a
  narrow screen, a phone scrolls until edit mode is on and drags after, and a
  press that doesn't travel still opens what it pressed.
- Both pages compared directly at 1512px and 390px, idle, editing and mid-drag:
  cursor, `touch-action`, `user-select`, jiggle name and duration, and the drop
  outline all agree.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

