### PR TITLE
Add a last-run panel, and stop the long run filling up all week

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,12 @@ commented as such — no `setPointerCapture` (it redirects the synthesized click
 away from anchors inside a panel), and `draggingId` is only set once the
 pointer passes the threshold (the `dragging` class carries
 `pointer-events: none`, which would otherwise swallow ordinary clicks). The
-pure parts — validating a stored layout, swapping slots — live in
-`lib/ui/layoutStore.js` so they're testable without compiling runes.
+pure parts — reconciling a stored layout, swapping slots — live in
+`lib/ui/layoutStore.js` so they're testable without compiling runes. Reconciling
+rather than validating is deliberate: a saved list of nine ids isn't a
+permutation of ten, so adding a panel used to silently reset the arrangement of
+anyone who had made one. Now the saved order is kept, unknown ids are dropped,
+and a new panel is slotted in at its default position.
 
 `lib/ui/editMode.svelte.js` wraps that in the rule both pages follow: dragging
 is free while the layout is wide enough to be pointer-driven, and behind the

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ outline. A page opts in by marking its container `drag-grid` and its tiles
 not per-component: those rules are the feel of the thing, and keeping a copy
 each is how the two pages came to behave differently in the first place.
 
+Because the slots are fixed, the columns are independent: a heavy one just ends
+further down the page rather than pulling anything up beside it. So `/training`'s
+default order is balanced by measured height as well as by subject, and an e2e
+test holds the two columns to within a quarter of each other — hand-balancing is
+the kind of thing that rots quietly the next time a panel is added.
+
 What a page still says for itself is what genuinely differs: where its layout
 collapses (1100px, 860px), which tiles take the second jiggle so the grid
 doesn't rock in lockstep (by slot on the dashboard, by column on training), the

--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -29,6 +29,28 @@ const NAMES = [
 	"Recovery Shakeout",
 ];
 
+// A minute-by-minute recording of one run, which is what the sync derives time
+// in zones and aerobic drift from (see shape.js). Without one, those are null
+// and the last-run panel renders its "no heart rate" path — real for a manual
+// entry, but not what the page normally shows.
+function streamsFor({ distance, movingTime, averageHr, next }) {
+	const steps = Math.max(20, Math.round(movingTime / 60));
+	const time = [];
+	const distanceStream = [];
+	const heartrate = [];
+	const grade = [];
+
+	for (let i = 0; i <= steps; i++) {
+		time.push(Math.round((movingTime / steps) * i));
+		distanceStream.push((distance / steps) * i);
+		// Drifting up through the run, the way heart rate does at a fixed
+		// effort, plus enough noise to land either side of a zone floor.
+		heartrate.push(averageHr - 6 + (12 * i) / steps + (next() - 0.5) * 6);
+		grade.push((next() - 0.5) * 3);
+	}
+	return { time, distance: distanceStream, heartrate, grade_smooth: grade };
+}
+
 /**
  * @param {object} [options]
  * @param {string} [options.today] day key the dashboard is built against.
@@ -50,6 +72,7 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 		const paceSecPerKm = isLong ? 330 + next() * 25 : 300 + next() * 40;
 		const movingTime = Math.round((distance / 1000) * paceSecPerKm);
 		const date = day.toISOString().slice(0, 10);
+		const averageHr = 138 + next() * 22;
 
 		raw.push({
 			id: id++,
@@ -64,8 +87,9 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 			moving_time: movingTime,
 			elapsed_time: movingTime + 90,
 			total_elevation_gain: Math.round(next() * 120),
-			average_heartrate: 138 + next() * 22,
+			average_heartrate: averageHr,
 			max_heartrate: 172 + next() * 15,
+			average_cadence: 84 + next() * 6,
 			workout_type: isLong ? 2 : dow === 5 ? 3 : 0,
 			splits_metric: Array.from({ length: Math.floor(distance / 1000) }, () => ({
 				distance: 1000,
@@ -77,12 +101,19 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 				{ name: "5k", distance: 5000, elapsed_time: Math.round(paceSecPerKm * 5 * 0.92) },
 				{ name: "10k", distance: 10000, elapsed_time: Math.round(paceSecPerKm * 10 * 0.95) },
 			],
+			streams: streamsFor({ distance, movingTime, averageHr, next }),
 		});
 	}
 
 	return {
 		...buildDashboard({
-			activities: shapeActivities(raw, { thresholds: plan.thresholds }),
+			// Streams are per-activity here, where the real sync fetches them
+			// one run at a time; shapeActivities takes one set for the batch,
+			// so shape each run with its own.
+			activities: raw
+				.map(({ streams, ...activity }) =>
+					shapeActivities([activity], { streams, thresholds: plan.thresholds })[0])
+				.filter(Boolean),
 			plan,
 			today,
 		}),

--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -11,6 +11,10 @@ import { shapeActivities } from "../../netlify/functions/_shared/training/shape.
 import { buildDashboard } from "../../netlify/functions/_shared/training/metrics.js";
 import { loadPlan } from "../../netlify/functions/_shared/training/planFile.js";
 
+// Strava's field names are quoted throughout: they're the API's spelling rather
+// than identifiers this repo chose, and quoting says so — to a reader and to
+// the analyser, which otherwise reads every one of them as a naming mistake.
+
 // A deterministic generator, so a layout assertion can never fail on a Tuesday
 // only because that week's random distances happened to be long.
 function sequence(seed = 42) {
@@ -48,7 +52,7 @@ function streamsFor({ distance, movingTime, averageHr, next }) {
 		heartrate.push(averageHr - 6 + (12 * i) / steps + (next() - 0.5) * 6);
 		grade.push((next() - 0.5) * 3);
 	}
-	return { time, distance: distanceStream, heartrate, grade_smooth: grade };
+	return { time, distance: distanceStream, heartrate, "grade_smooth": grade };
 }
 
 /**
@@ -80,33 +84,33 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 			// rather than widening the log.
 			name: isLong ? "Long Run Along the Lakeshore Trail" : NAMES[Math.floor(next() * NAMES.length)],
 			type: "Run",
-			sport_type: "Run",
+			"sport_type": "Run",
 			private: false,
-			start_date_local: `${date}T07:12:00Z`,
+			"start_date_local": `${date}T07:12:00Z`,
 			distance,
-			moving_time: movingTime,
-			elapsed_time: movingTime + 90,
-			total_elevation_gain: Math.round(next() * 120),
-			average_heartrate: averageHr,
-			max_heartrate: 172 + next() * 15,
-			average_cadence: 84 + next() * 6,
-			workout_type: isLong ? 2 : dow === 5 ? 3 : 0,
+			"moving_time": movingTime,
+			"elapsed_time": movingTime + 90,
+			"total_elevation_gain": Math.round(next() * 120),
+			"average_heartrate": averageHr,
+			"max_heartrate": 172 + next() * 15,
+			"average_cadence": 84 + next() * 6,
+			"workout_type": isLong ? 2 : dow === 5 ? 3 : 0,
 			// Whole kilometres, then the fragment Strava sends for however far
 			// past the last one you actually got. Real runs almost never end on
 			// a round number, and that stub's pace is where the panel's chart
 			// went wrong the first time.
-			splits_metric: Array.from({ length: Math.ceil(distance / 1000) }, (_, i) => {
+			"splits_metric": Array.from({ length: Math.ceil(distance / 1000) }, (_, i) => {
 				const splitM = Math.min(1000, distance - i * 1000);
 				return {
 					distance: splitM,
-					moving_time: Math.round((paceSecPerKm + (next() - 0.5) * 20) * (splitM / 1000)),
-					elevation_difference: Math.round((next() - 0.5) * 12),
-					average_heartrate: 140 + next() * 20,
+					"moving_time": Math.round((paceSecPerKm + (next() - 0.5) * 20) * (splitM / 1000)),
+					"elevation_difference": Math.round((next() - 0.5) * 12),
+					"average_heartrate": 140 + next() * 20,
 				};
 			}),
-			best_efforts: [
-				{ name: "5k", distance: 5000, elapsed_time: Math.round(paceSecPerKm * 5 * 0.92) },
-				{ name: "10k", distance: 10000, elapsed_time: Math.round(paceSecPerKm * 10 * 0.95) },
+			"best_efforts": [
+				{ name: "5k", distance: 5000, "elapsed_time": Math.round(paceSecPerKm * 5 * 0.92) },
+				{ name: "10k", distance: 10000, "elapsed_time": Math.round(paceSecPerKm * 10 * 0.95) },
 			],
 			streams: streamsFor({ distance, movingTime, averageHr, next }),
 		});

--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -91,12 +91,19 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 			max_heartrate: 172 + next() * 15,
 			average_cadence: 84 + next() * 6,
 			workout_type: isLong ? 2 : dow === 5 ? 3 : 0,
-			splits_metric: Array.from({ length: Math.floor(distance / 1000) }, () => ({
-				distance: 1000,
-				moving_time: Math.round(paceSecPerKm + (next() - 0.5) * 20),
-				elevation_difference: Math.round((next() - 0.5) * 12),
-				average_heartrate: 140 + next() * 20,
-			})),
+			// Whole kilometres, then the fragment Strava sends for however far
+			// past the last one you actually got. Real runs almost never end on
+			// a round number, and that stub's pace is where the panel's chart
+			// went wrong the first time.
+			splits_metric: Array.from({ length: Math.ceil(distance / 1000) }, (_, i) => {
+				const splitM = Math.min(1000, distance - i * 1000);
+				return {
+					distance: splitM,
+					moving_time: Math.round((paceSecPerKm + (next() - 0.5) * 20) * (splitM / 1000)),
+					elevation_difference: Math.round((next() - 0.5) * 12),
+					average_heartrate: 140 + next() * 20,
+				};
+			}),
 			best_efforts: [
 				{ name: "5k", distance: 5000, elapsed_time: Math.round(paceSecPerKm * 5 * 0.92) },
 				{ name: "10k", distance: 10000, elapsed_time: Math.round(paceSecPerKm * 10 * 0.95) },

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -56,6 +56,32 @@ test("the run log says which runs were the plan", async ({ page }) => {
 	await expect(log.locator(".tag.extra-tag").first()).toBeVisible();
 });
 
+test("the last run is reported with what it did to the training", async ({ page }) => {
+	await page.goto("/training");
+	const panel = page.locator("section.card").filter({ hasText: "Last run" }).first();
+
+	// What it was: the run itself, linked out to Strava for the map the
+	// payload deliberately doesn't carry.
+	await expect(panel.getByRole("link").first()).toHaveAttribute(
+		"href",
+		/strava\.com\/activities\/\d+/,
+	);
+
+	// How it went: a pace per kilometre, on an axis labelled in paces.
+	const paces = await panel.locator(".y-axis span").allTextContents();
+	expect(paces.length).toBeGreaterThan(2);
+	expect(paces.every((label) => /^\d+:\d{2}$/.test(label))).toBe(true);
+
+	// What it changed: all three of fitness, fatigue and form, each with a
+	// signed delta rather than just a value.
+	const changes = panel.locator(".change");
+	await expect(changes).toHaveCount(3);
+	for (const label of ["Fitness", "Fatigue", "Form"]) {
+		await expect(panel.getByText(label, { exact: true })).toBeVisible();
+	}
+	await expect(changes.first().locator("strong")).toHaveText(/^[+-]?\d/);
+});
+
 test("the charts are labelled with the values they plot", async ({ page }) => {
 	await page.goto("/training");
 	const volume = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();
@@ -73,26 +99,52 @@ test.describe("rearranging the panels", () => {
 	const panelAt = (page, idx) => page.locator(`[data-slot-index="${idx}"] .panel`);
 	const editToggle = (page) => page.getByRole("button", { name: "Toggle layout edit mode" });
 
+	// Both ends of a drag have to be on screen at once: a pointer can't travel
+	// past the viewport, and the drop target is found by hit-testing whatever
+	// is under it. Panels are tall — stacked on a phone, one is taller than the
+	// screen — so centre the point halfway between the two slots and then aim
+	// at the middle of whatever part of each is actually showing. Scrolling is
+	// instant because the site scrolls smoothly, and a drag measured
+	// mid-animation aims at where the panels used to be.
 	async function dragPanel(page, fromIdx, toIdx) {
-		const source = await panelAt(page, fromIdx).boundingBox();
-		const target = await page.locator(`[data-slot-index="${toIdx}"]`).boundingBox();
-		await page.mouse.move(source.x + source.width / 2, source.y + 24);
+		await page.evaluate(([from, to]) => {
+			const centre = (i) => {
+				const box = document.querySelector(`[data-slot-index="${i}"]`).getBoundingClientRect();
+				return box.top + box.height / 2 + window.scrollY;
+			};
+			const between = (centre(from) + centre(to)) / 2;
+			window.scrollTo({ top: Math.max(0, between - window.innerHeight / 2), behavior: "instant" });
+		}, [fromIdx, toIdx]);
+
+		const { height } = page.viewportSize();
+		const visibleMiddle = (box) => ({
+			x: box.x + box.width / 2,
+			y: (Math.max(box.y, 12) + Math.min(box.y + box.height, height - 12)) / 2,
+		});
+
+		const source = visibleMiddle(await panelAt(page, fromIdx).boundingBox());
+		const target = visibleMiddle(await page.locator(`[data-slot-index="${toIdx}"]`).boundingBox());
+
+		await page.mouse.move(source.x, source.y);
 		await page.mouse.down();
-		await page.mouse.move(target.x + target.width / 2, target.y + 24, { steps: 14 });
+		await page.mouse.move(target.x, target.y, { steps: 14 });
 		await page.mouse.up();
 	}
 
 	test("a drag swaps the two panels and the layout is remembered", async ({ page }) => {
 		await page.goto("/training");
-		const displaced = await panelAt(page, 4).getAttribute("data-panel");
+		const dragged = await panelAt(page, 0).getAttribute("data-panel");
+		// Slot 5 is the top of the narrow column: a swap across the page, and
+		// the two panels most likely to be on screen together.
+		const displaced = await panelAt(page, 5).getAttribute("data-panel");
 
-		await dragPanel(page, 0, 4);
+		await dragPanel(page, 0, 5);
 
-		await expect(panelAt(page, 4)).toHaveAttribute("data-panel", "volume");
+		await expect(panelAt(page, 5)).toHaveAttribute("data-panel", dragged);
 		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", displaced);
 
 		await page.reload();
-		await expect(panelAt(page, 4)).toHaveAttribute("data-panel", "volume");
+		await expect(panelAt(page, 5)).toHaveAttribute("data-panel", dragged);
 	});
 
 	// A press that doesn't travel is still a click, which is what keeps every
@@ -114,6 +166,7 @@ test.describe("rearranging the panels", () => {
 	test("on a phone the panels wait to be told", async ({ page }) => {
 		await page.setViewportSize(PHONE);
 		await page.goto("/training");
+		const first = await panelAt(page, 0).getAttribute("data-panel");
 
 		// Dragging is off, so the page still scrolls with a finger rather than
 		// picking up whichever panel it landed on.
@@ -121,19 +174,14 @@ test.describe("rearranging the panels", () => {
 		expect(idle).toBe("auto");
 
 		await dragPanel(page, 0, 1);
-		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", "volume");
+		await expect(panelAt(page, 0)).toHaveAttribute("data-panel", first);
 
 		await editToggle(page).click();
 		const editing = await panelAt(page, 0).evaluate((el) => getComputedStyle(el).touchAction);
 		expect(editing).toBe("none");
 
-		// A drag can only reach as far as the viewport: stacked panels are a
-		// screen tall each, so put both of them on it first. Instant, because
-		// the site scrolls smoothly and a drag measured mid-animation aims at
-		// where the panels used to be.
-		await page.evaluate(() => window.scrollTo({ top: 480, behavior: "instant" }));
 		await dragPanel(page, 0, 1);
-		await expect(panelAt(page, 1)).toHaveAttribute("data-panel", "volume");
+		await expect(panelAt(page, 1)).toHaveAttribute("data-panel", first);
 	});
 
 	test("taps inside a panel don't fire while editing", async ({ page }) => {

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -82,6 +82,26 @@ test("the last run is reported with what it did to the training", async ({ page 
 	await expect(changes.first().locator("strong")).toHaveText(/^[+-]?\d/);
 });
 
+test("the week's long run is a day rather than a bar that fills up all week", async ({ page }) => {
+	await page.goto("/training");
+	// By its heading, not its text: "Load and risk" says "this week's ramp".
+	const week = page
+		.locator("section.card")
+		.filter({ has: page.getByRole("heading", { name: "This week" }) });
+
+	// One bar, and it's the volume one. The long run had a second, which every
+	// easy run filled in on its way past — the same kilometres, counted twice.
+	await expect(week.locator(".track")).toHaveCount(1);
+
+	// The fixture stands on a Tuesday, so Sunday's long run is still ahead: it
+	// reads as the day it falls on rather than as a number partly reached.
+	const longRun = week.locator(".long-run");
+	await expect(longRun).toHaveClass(/ahead/);
+	await expect(longRun).toContainText("Long run");
+	await expect(longRun).toContainText("Sun");
+	await expect(longRun).toContainText("20 km");
+});
+
 test("the charts are labelled with the values they plot", async ({ page }) => {
 	await page.goto("/training");
 	const volume = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -102,6 +102,23 @@ test("the week's long run is a day rather than a bar that fills up all week", as
 	await expect(longRun).toContainText("20 km");
 });
 
+test("neither column runs on far past the other", async ({ page }) => {
+	// The columns are independent, so a heavy one simply ends further down the
+	// page: with the two tallest panels both on the left it finished a
+	// thousand pixels below the right. The default order is hand-balanced,
+	// which is exactly the kind of thing that rots quietly when a panel is
+	// added, so the tolerance here is wide enough to allow real variation and
+	// tight enough to notice a column of leftovers.
+	await page.setViewportSize({ width: 1280, height: 900 });
+	await page.goto("/training");
+
+	const [left, right] = await page
+		.locator("#training-grid .col:not(.col-full)")
+		.evaluateAll((cols) => cols.map((col) => col.getBoundingClientRect().height));
+
+	expect(Math.min(left, right) / Math.max(left, right)).toBeGreaterThan(0.75);
+});
+
 test("the charts are labelled with the values they plot", async ({ page }) => {
 	await page.goto("/training");
 	const volume = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();

--- a/netlify/functions/_shared/training/lastRun.js
+++ b/netlify/functions/_shared/training/lastRun.js
@@ -1,0 +1,249 @@
+// The last run, in enough detail to answer "what did that do to my training?"
+//
+// Every other panel on the dashboard is trend-shaped: twelve weeks of volume, a
+// block of fitness, four weeks of intensity. None of them answer the question
+// you actually have on the walk home, which is what that particular run was and
+// what it changed. This module is that answer, about exactly one activity.
+//
+// Nothing here is fetched: the splits, zone seconds, decoupling and load were
+// all computed at sync time (see shape.js), and the fitness series is the one
+// the rest of the dashboard is drawn from. The work is reading a single run
+// against the athlete's own recent history, since none of these numbers mean
+// anything in isolation — a load of 90 is a big day or a Tuesday depending
+// entirely on whose 90 it is.
+
+import { addDays, daysBetween, toDayKey } from "./dates.js";
+import { publicLastRun } from "./shape.js";
+import { classifyByPace } from "./zones.js";
+
+// How far back "a typical run for you" reaches. Six weeks holds a few long runs
+// and a down week without stretching into a different phase of the block.
+const TYPICAL_WINDOW_DAYS = 42;
+
+// Halves of a run only say something when there are enough kilometres in each.
+const MIN_SPLITS_FOR_HALVES = 4;
+
+// A closing 200 m split has the pace of whatever the last thirty seconds were,
+// so short splits are ranked out of the fastest/slowest line rather than
+// winning it.
+const MIN_SPLIT_M = 600;
+
+// Where a run stops being easy, by the share of its time spent above zone 2.
+const HARD_SHARE_PCT = 20;
+const MODERATE_SHARE_PCT = 35;
+
+const sum = (values) => values.reduce((total, v) => total + (Number(v) || 0), 0);
+
+function median(values) {
+	if (values.length === 0) return null;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * What the day's running did to fitness, fatigue and form.
+ *
+ * fitnessSeries reports a day's ctl/atl *after* that day's load, but its tsb as
+ * the form you woke up with, before it (see fitness.js). Taking ctl and atl
+ * from the day before and the day itself therefore brackets the run cleanly,
+ * and form is recomputed from those rather than read off, so all three deltas
+ * describe the same moment.
+ *
+ * @param {object[]} series from fitnessSeries().
+ * @param {string} date day key of the run.
+ * @returns {object|null} null on the first day of the block, which has no
+ *   day before it to compare against.
+ */
+function formImpact(series, date) {
+	const idx = (series || []).findIndex((d) => d.date === date);
+	if (idx < 1) return null;
+
+	const before = series[idx - 1];
+	const after = series[idx];
+	const formBefore = before.ctl - before.atl;
+	const formAfter = after.ctl - after.atl;
+
+	return {
+		dayLoad: after.load,
+		ctl: after.ctl,
+		ctlDelta: after.ctl - before.ctl,
+		atl: after.atl,
+		atlDelta: after.atl - before.atl,
+		tsb: formAfter,
+		tsbDelta: formAfter - formBefore,
+	};
+}
+
+/** Runs of the six weeks before this one, oldest first. */
+function recentBefore(runs, date) {
+	const from = addDays(date, -TYPICAL_WINDOW_DAYS);
+	return runs.slice(0, -1).filter((run) => {
+		const day = toDayKey(run.startDateLocal);
+		return day && day >= from && day <= date;
+	});
+}
+
+/**
+ * How long since a run cost this much. The honest version of "that was a big
+ * one": a load only means something next to the loads around it.
+ *
+ * @returns {number|null} days since the last run at least this hard, or null
+ *   when nothing in the block matches it.
+ */
+function daysSinceAsHard(previous, load, date) {
+	if (!(load > 0)) return null;
+	for (let i = previous.length - 1; i >= 0; i--) {
+		if ((Number(previous[i].load) || 0) >= load) {
+			return daysBetween(toDayKey(previous[i].startDateLocal), date);
+		}
+	}
+	return null;
+}
+
+function loadImpact(run, previous, date) {
+	const load = Number.isFinite(run.load) ? run.load : null;
+	const typical = median(previous.map((r) => Number(r.load) || 0).filter((v) => v > 0));
+
+	return {
+		load,
+		typicalLoad: typical,
+		// Above 100% is a harder run than your median; the ratio travels
+		// better between athletes than either number does.
+		vsTypicalPct: load > 0 && typical > 0 ? (load / typical) * 100 : null,
+		daysSinceAsHard: daysSinceAsHard(previous, load, date),
+		runsCompared: previous.length,
+	};
+}
+
+/** The week the run landed in, and how much of it this one run was. */
+function weekImpact(weeks, run, date) {
+	const week = (weeks || []).find((w) => w.start <= date && date <= addDays(w.start, 6));
+	if (!week) return null;
+
+	const distanceKm = (Number(run.distanceM) || 0) / 1000;
+	const targetKm = Number.isFinite(week.targetKm) ? week.targetKm : null;
+
+	return {
+		start: week.start,
+		actualKm: Number.isFinite(week.actualKm) ? week.actualKm : null,
+		targetKm,
+		// Against the target where there is one: "a third of the week" is a
+		// statement about the plan, not about how much else got run.
+		sharePct: targetKm > 0 ? (distanceKm / targetKm) * 100 : null,
+	};
+}
+
+function paceOver(splits) {
+	const distanceM = sum(splits.map((s) => s.distanceM));
+	const timeSec = sum(splits.map((s) => s.timeSec));
+	return distanceM > 0 && timeSec > 0 ? timeSec / (distanceM / 1000) : null;
+}
+
+/**
+ * How the run was paced: did it hold together, and where were its edges?
+ *
+ * Halved by kilometre rather than by time, because the halves are being
+ * compared on pace and a time-halved run puts more distance in the faster half
+ * by construction.
+ *
+ * @param {object[]} splits stored per-kilometre splits.
+ * @returns {object|null}
+ */
+function pacing(splits) {
+	const list = (splits || []).filter((s) => s.distanceM > 0 && s.timeSec > 0);
+	if (list.length < MIN_SPLITS_FOR_HALVES) return null;
+
+	const half = Math.floor(list.length / 2);
+	const firstHalfPaceSecPerKm = paceOver(list.slice(0, half));
+	const secondHalfPaceSecPerKm = paceOver(list.slice(half));
+	const ranked = list
+		.filter((s) => s.distanceM >= MIN_SPLIT_M)
+		.sort((a, b) => a.paceSecPerKm - b.paceSecPerKm);
+
+	return {
+		firstHalfPaceSecPerKm,
+		secondHalfPaceSecPerKm,
+		// Positive is a fade, negative a negative split — the way round every
+		// coach says it, so the sign doesn't need explaining.
+		fadePct:
+			firstHalfPaceSecPerKm > 0 && secondHalfPaceSecPerKm > 0
+				? ((secondHalfPaceSecPerKm - firstHalfPaceSecPerKm) / firstHalfPaceSecPerKm) * 100
+				: null,
+		fastest: ranked[0] ? { km: ranked[0].km, paceSecPerKm: ranked[0].paceSecPerKm } : null,
+		slowest: ranked.at(-1) ? { km: ranked.at(-1).km, paceSecPerKm: ranked.at(-1).paceSecPerKm } : null,
+	};
+}
+
+/** Time in zones 1–5 rolled up the way the intensity panel says it. */
+function zoneMix(zoneSeconds) {
+	if (!Array.isArray(zoneSeconds)) return null;
+	const totalSec = sum(zoneSeconds);
+	if (!(totalSec > 0)) return null;
+
+	const easySec = (zoneSeconds[0] || 0) + (zoneSeconds[1] || 0);
+	const moderateSec = zoneSeconds[2] || 0;
+	const hardSec = (zoneSeconds[3] || 0) + (zoneSeconds[4] || 0);
+
+	return {
+		easySec,
+		moderateSec,
+		hardSec,
+		totalSec,
+		easyPct: (easySec / totalSec) * 100,
+		moderatePct: (moderateSec / totalSec) * 100,
+		hardPct: (hardSec / totalSec) * 100,
+	};
+}
+
+/**
+ * Easy, moderate or hard — from where the heart rate actually sat, falling back
+ * to grade-adjusted pace for a run recorded without a strap.
+ */
+function effortOf(mix, run, thresholds) {
+	if (!mix) return classifyByPace(run.gapPaceSecPerKm, thresholds);
+	if (mix.hardPct >= HARD_SHARE_PCT) return "hard";
+	if (mix.moderatePct >= MODERATE_SHARE_PCT) return "moderate";
+	return "easy";
+}
+
+/**
+ * The newest run in the block, with the context that makes it readable.
+ *
+ * @param {object} input
+ * @param {object[]} input.runs shaped activities, oldest first.
+ * @param {object[]} input.series from fitnessSeries().
+ * @param {object[]} input.weeks compared plan weeks.
+ * @param {object} [input.planMatch] the plan match for this run, if any.
+ * @param {object} [input.thresholds] from the plan file.
+ * @param {string} input.today day key.
+ * @returns {object|null} null when nothing has been run yet.
+ */
+export function lastRunDetail({ runs = [], series = [], weeks = [], planMatch = null, thresholds = {}, today }) {
+	const run = runs.at(-1);
+	if (!run) return null;
+
+	const date = toDayKey(run.startDateLocal);
+	const previous = recentBefore(runs, date);
+	const mix = zoneMix(run.zoneSeconds);
+
+	return {
+		...publicLastRun(run),
+		date,
+		daysAgo: daysBetween(date, today),
+		// A double day's form change belongs to both runs, and saying so is
+		// better than quietly attributing it to the second one.
+		runsThatDay: runs.filter((r) => toDayKey(r.startDateLocal) === date).length,
+		plan: planMatch,
+		effort: effortOf(mix, run, thresholds),
+		zoneMix: mix,
+		// The per-kilometre list itself comes from publicLastRun; this is what
+		// it adds up to.
+		pacing: pacing(run.splits),
+		impact: {
+			form: formImpact(series, date),
+			load: loadImpact(run, previous, date),
+			week: weekImpact(weeks, run, date),
+		},
+	};
+}

--- a/netlify/functions/_shared/training/lastRun.js
+++ b/netlify/functions/_shared/training/lastRun.js
@@ -27,13 +27,24 @@ const MIN_SPLITS_FOR_HALVES = 4;
 const HARD_SHARE_PCT = 20;
 const MODERATE_SHARE_PCT = 35;
 
-const sum = (values) => values.reduce((total, v) => total + (Number(v) || 0), 0);
+const number = (value) => Number(value) || 0;
+const finite = (value) => (Number.isFinite(value) ? value : null);
+const sum = (values) => values.reduce((total, v) => total + number(v), 0);
 
 function median(values) {
-	if (values.length === 0) return null;
+	if (values.length === 0) {
+		return null;
+	}
 	const sorted = [...values].sort((a, b) => a - b);
 	const mid = Math.floor(sorted.length / 2);
-	return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+	const lower = sorted.at(mid - 1);
+	const upper = sorted.at(mid);
+	return sorted.length % 2 ? upper : (lower + upper) / 2;
+}
+
+/** Fitness minus fatigue, as of the end of a day in the series. */
+function formOf(day) {
+	return day.ctl - day.atl;
 }
 
 /**
@@ -52,12 +63,12 @@ function median(values) {
  */
 function formImpact(series, date) {
 	const idx = (series || []).findIndex((d) => d.date === date);
-	if (idx < 1) return null;
+	if (idx < 1) {
+		return null;
+	}
 
-	const before = series[idx - 1];
-	const after = series[idx];
-	const formBefore = before.ctl - before.atl;
-	const formAfter = after.ctl - after.atl;
+	const before = series.at(idx - 1);
+	const after = series.at(idx);
 
 	return {
 		dayLoad: after.load,
@@ -65,8 +76,8 @@ function formImpact(series, date) {
 		ctlDelta: after.ctl - before.ctl,
 		atl: after.atl,
 		atlDelta: after.atl - before.atl,
-		tsb: formAfter,
-		tsbDelta: formAfter - formBefore,
+		tsb: formOf(after),
+		tsbDelta: formOf(after) - formOf(before),
 	};
 }
 
@@ -87,25 +98,24 @@ function recentBefore(runs, date) {
  *   when nothing in the block matches it.
  */
 function daysSinceAsHard(previous, load, date) {
-	if (!(load > 0)) return null;
-	for (let i = previous.length - 1; i >= 0; i--) {
-		if ((Number(previous[i].load) || 0) >= load) {
-			return daysBetween(toDayKey(previous[i].startDateLocal), date);
-		}
+	const match = load > 0 ? previous.findLast((run) => number(run.load) >= load) : null;
+	if (!match) {
+		return null;
 	}
-	return null;
+	return daysBetween(toDayKey(match.startDateLocal), date);
 }
 
 function loadImpact(run, previous, date) {
-	const load = Number.isFinite(run.load) ? run.load : null;
-	const typical = median(previous.map((r) => Number(r.load) || 0).filter((v) => v > 0));
+	const load = finite(run.load);
+	const typical = median(previous.map((r) => number(r.load)).filter((v) => v > 0));
+	const comparable = load > 0 && typical > 0;
 
 	return {
 		load,
 		typicalLoad: typical,
 		// Above 100% is a harder run than your median; the ratio travels
 		// better between athletes than either number does.
-		vsTypicalPct: load > 0 && typical > 0 ? (load / typical) * 100 : null,
+		vsTypicalPct: comparable ? (load / typical) * 100 : null,
 		daysSinceAsHard: daysSinceAsHard(previous, load, date),
 		runsCompared: previous.length,
 	};
@@ -114,14 +124,16 @@ function loadImpact(run, previous, date) {
 /** The week the run landed in, and how much of it this one run was. */
 function weekImpact(weeks, run, date) {
 	const week = (weeks || []).find((w) => w.start <= date && date <= addDays(w.start, 6));
-	if (!week) return null;
+	if (!week) {
+		return null;
+	}
 
-	const distanceKm = (Number(run.distanceM) || 0) / 1000;
-	const targetKm = Number.isFinite(week.targetKm) ? week.targetKm : null;
+	const distanceKm = number(run.distanceM) / 1000;
+	const targetKm = finite(week.targetKm);
 
 	return {
 		start: week.start,
-		actualKm: Number.isFinite(week.actualKm) ? week.actualKm : null,
+		actualKm: finite(week.actualKm),
 		targetKm,
 		// Against the target where there is one: "a third of the week" is a
 		// statement about the plan, not about how much else got run.
@@ -132,7 +144,28 @@ function weekImpact(weeks, run, date) {
 function paceOver(splits) {
 	const distanceM = sum(splits.map((s) => s.distanceM));
 	const timeSec = sum(splits.map((s) => s.timeSec));
-	return distanceM > 0 && timeSec > 0 ? timeSec / (distanceM / 1000) : null;
+	return distanceM > 0 ? timeSec / (distanceM / 1000) : null;
+}
+
+function fadeBetween(first, second) {
+	if (!(first > 0) || !(second > 0)) {
+		return null;
+	}
+	// Positive is a fade, negative a negative split — the way round every
+	// coach says it, so the sign doesn't need explaining.
+	return ((second - first) / first) * 100;
+}
+
+/** The fastest and slowest kilometre, of the ones that were a kilometre. */
+function edges(list) {
+	// The closing fragment stays in the halves, where it's weighted by its own
+	// short distance, but it can't win fastest or slowest on a partial lap.
+	const ranked = list
+		.filter((s) => s.distanceM >= WHOLE_SPLIT_M)
+		.sort((a, b) => a.paceSecPerKm - b.paceSecPerKm)
+		.map((s) => ({ km: s.km, paceSecPerKm: s.paceSecPerKm }));
+
+	return { fastest: ranked.at(0) ?? null, slowest: ranked.at(-1) ?? null };
 }
 
 /**
@@ -147,40 +180,40 @@ function paceOver(splits) {
  */
 function pacing(splits) {
 	const list = (splits || []).filter((s) => s.distanceM > 0 && s.timeSec > 0);
-	if (list.length < MIN_SPLITS_FOR_HALVES) return null;
+	if (list.length < MIN_SPLITS_FOR_HALVES) {
+		return null;
+	}
 
 	const half = Math.floor(list.length / 2);
 	const firstHalfPaceSecPerKm = paceOver(list.slice(0, half));
 	const secondHalfPaceSecPerKm = paceOver(list.slice(half));
-	// The closing fragment stays in the halves, where it's weighted by its own
-	// short distance, but it can't win fastest or slowest on a partial lap.
-	const ranked = list
-		.filter((s) => s.distanceM >= WHOLE_SPLIT_M)
-		.sort((a, b) => a.paceSecPerKm - b.paceSecPerKm);
 
 	return {
 		firstHalfPaceSecPerKm,
 		secondHalfPaceSecPerKm,
-		// Positive is a fade, negative a negative split — the way round every
-		// coach says it, so the sign doesn't need explaining.
-		fadePct:
-			firstHalfPaceSecPerKm > 0 && secondHalfPaceSecPerKm > 0
-				? ((secondHalfPaceSecPerKm - firstHalfPaceSecPerKm) / firstHalfPaceSecPerKm) * 100
-				: null,
-		fastest: ranked[0] ? { km: ranked[0].km, paceSecPerKm: ranked[0].paceSecPerKm } : null,
-		slowest: ranked.at(-1) ? { km: ranked.at(-1).km, paceSecPerKm: ranked.at(-1).paceSecPerKm } : null,
+		fadePct: fadeBetween(firstHalfPaceSecPerKm, secondHalfPaceSecPerKm),
+		...edges(list),
 	};
+}
+
+/** Seconds spent in the given zones, counting from zone 1. */
+function secondsIn(zoneSeconds, ...zones) {
+	return sum(zones.map((zone) => zoneSeconds.at(zone - 1)));
 }
 
 /** Time in zones 1–5 rolled up the way the intensity panel says it. */
 function zoneMix(zoneSeconds) {
-	if (!Array.isArray(zoneSeconds)) return null;
+	if (!Array.isArray(zoneSeconds)) {
+		return null;
+	}
 	const totalSec = sum(zoneSeconds);
-	if (!(totalSec > 0)) return null;
+	if (!(totalSec > 0)) {
+		return null;
+	}
 
-	const easySec = (zoneSeconds[0] || 0) + (zoneSeconds[1] || 0);
-	const moderateSec = zoneSeconds[2] || 0;
-	const hardSec = (zoneSeconds[3] || 0) + (zoneSeconds[4] || 0);
+	const easySec = secondsIn(zoneSeconds, 1, 2);
+	const moderateSec = secondsIn(zoneSeconds, 3);
+	const hardSec = secondsIn(zoneSeconds, 4, 5);
 
 	return {
 		easySec,
@@ -198,10 +231,13 @@ function zoneMix(zoneSeconds) {
  * to grade-adjusted pace for a run recorded without a strap.
  */
 function effortOf(mix, run, thresholds) {
-	if (!mix) return classifyByPace(run.gapPaceSecPerKm, thresholds);
-	if (mix.hardPct >= HARD_SHARE_PCT) return "hard";
-	if (mix.moderatePct >= MODERATE_SHARE_PCT) return "moderate";
-	return "easy";
+	if (!mix) {
+		return classifyByPace(run.gapPaceSecPerKm, thresholds);
+	}
+	if (mix.hardPct >= HARD_SHARE_PCT) {
+		return "hard";
+	}
+	return mix.moderatePct >= MODERATE_SHARE_PCT ? "moderate" : "easy";
 }
 
 /**
@@ -218,10 +254,11 @@ function effortOf(mix, run, thresholds) {
  */
 export function lastRunDetail({ runs = [], series = [], weeks = [], planMatch = null, thresholds = {}, today }) {
 	const run = runs.at(-1);
-	if (!run) return null;
+	if (!run) {
+		return null;
+	}
 
 	const date = toDayKey(run.startDateLocal);
-	const previous = recentBefore(runs, date);
 	const mix = zoneMix(run.zoneSeconds);
 
 	return {
@@ -239,7 +276,7 @@ export function lastRunDetail({ runs = [], series = [], weeks = [], planMatch = 
 		pacing: pacing(run.splits),
 		impact: {
 			form: formImpact(series, date),
-			load: loadImpact(run, previous, date),
+			load: loadImpact(run, recentBefore(runs, date), date),
 			week: weekImpact(weeks, run, date),
 		},
 	};

--- a/netlify/functions/_shared/training/lastRun.js
+++ b/netlify/functions/_shared/training/lastRun.js
@@ -13,7 +13,7 @@
 // entirely on whose 90 it is.
 
 import { addDays, daysBetween, toDayKey } from "./dates.js";
-import { publicLastRun } from "./shape.js";
+import { publicLastRun, WHOLE_SPLIT_M } from "./shape.js";
 import { classifyByPace } from "./zones.js";
 
 // How far back "a typical run for you" reaches. Six weeks holds a few long runs
@@ -22,11 +22,6 @@ const TYPICAL_WINDOW_DAYS = 42;
 
 // Halves of a run only say something when there are enough kilometres in each.
 const MIN_SPLITS_FOR_HALVES = 4;
-
-// A closing 200 m split has the pace of whatever the last thirty seconds were,
-// so short splits are ranked out of the fastest/slowest line rather than
-// winning it.
-const MIN_SPLIT_M = 600;
 
 // Where a run stops being easy, by the share of its time spent above zone 2.
 const HARD_SHARE_PCT = 20;
@@ -157,8 +152,10 @@ function pacing(splits) {
 	const half = Math.floor(list.length / 2);
 	const firstHalfPaceSecPerKm = paceOver(list.slice(0, half));
 	const secondHalfPaceSecPerKm = paceOver(list.slice(half));
+	// The closing fragment stays in the halves, where it's weighted by its own
+	// short distance, but it can't win fastest or slowest on a partial lap.
 	const ranked = list
-		.filter((s) => s.distanceM >= MIN_SPLIT_M)
+		.filter((s) => s.distanceM >= WHOLE_SPLIT_M)
 		.sort((a, b) => a.paceSecPerKm - b.paceSecPerKm);
 
 	return {

--- a/netlify/functions/_shared/training/lastRun.test.js
+++ b/netlify/functions/_shared/training/lastRun.test.js
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "vitest";
+import { lastRunDetail } from "./lastRun.js";
+import { fitnessSeries } from "./fitness.js";
+import { dailyLoads } from "./load.js";
+
+const THRESHOLDS = {
+	maxHr: 195,
+	restingHr: 47,
+	lactateThresholdHr: 172,
+	thresholdPaceSecPerKm: 255,
+	marathonPaceSecPerKm: 285,
+};
+
+/** A shaped-activity-shaped object, with only the fields under test set. */
+function run(date, overrides = {}) {
+	const distanceM = overrides.distanceM ?? 10000;
+	const movingTimeSec = overrides.movingTimeSec ?? 3000;
+	return {
+		id: Number(date.replaceAll("-", "")),
+		name: "Morning Run",
+		type: "Run",
+		startDateLocal: `${date}T07:00:00Z`,
+		distanceM,
+		movingTimeSec,
+		elapsedTimeSec: movingTimeSec + 60,
+		elevationGainM: 40,
+		averageHr: 145,
+		maxHr: 168,
+		averageCadence: 86,
+		paceSecPerKm: movingTimeSec / (distanceM / 1000),
+		gapPaceSecPerKm: movingTimeSec / (distanceM / 1000),
+		load: 50,
+		loadMethod: "hr",
+		zoneSeconds: null,
+		decouplingPct: null,
+		splits: [],
+		...overrides,
+	};
+}
+
+/** Even kilometres at a given pace, with the last one optionally short. */
+function splits(paces, { lastDistanceM = 1000 } = {}) {
+	return paces.map((paceSecPerKm, i) => {
+		const distanceM = i === paces.length - 1 ? lastDistanceM : 1000;
+		return {
+			km: i + 1,
+			distanceM,
+			timeSec: paceSecPerKm * (distanceM / 1000),
+			elevationM: 0,
+			paceSecPerKm,
+			gapPaceSecPerKm: paceSecPerKm,
+			averageHr: 150,
+		};
+	});
+}
+
+function seriesFor(runs, { from, to }) {
+	return fitnessSeries(dailyLoads(runs), { from, to });
+}
+
+describe("lastRunDetail", () => {
+	it("has nothing to report before anything has been run", () => {
+		expect(lastRunDetail({ runs: [], today: "2026-08-11" })).toBeNull();
+	});
+
+	it("reports the newest run, however the list arrived", () => {
+		const runs = [run("2026-08-03"), run("2026-08-09", { name: "Sunday Long Run" })];
+		const detail = lastRunDetail({ runs, today: "2026-08-11" });
+
+		expect(detail.name).toBe("Sunday Long Run");
+		expect(detail.date).toBe("2026-08-09");
+		expect(detail.daysAgo).toBe(2);
+	});
+
+	it("carries the measurements the log leaves behind", () => {
+		const detail = lastRunDetail({
+			runs: [run("2026-08-09", { decouplingPct: 3.4, zoneSeconds: [600, 1800, 300, 0, 0] })],
+			today: "2026-08-09",
+		});
+
+		expect(detail.maxHr).toBe(168);
+		expect(detail.averageCadence).toBe(86);
+		expect(detail.decouplingPct).toBe(3.4);
+		expect(detail.load).toBe(50);
+	});
+
+	// The privacy boundary, restated at the point it would be crossed: this is
+	// the one place per-kilometre data is served at all.
+	it("serves splits without the hill profile behind them", () => {
+		const detail = lastRunDetail({
+			runs: [run("2026-08-09", { splits: splits([300, 305, 298, 310]) })],
+			today: "2026-08-09",
+		});
+
+		expect(detail.splits).toHaveLength(4);
+		expect(detail.splits[0]).toEqual({
+			km: 1,
+			paceSecPerKm: 300,
+			gapPaceSecPerKm: 300,
+			averageHr: 150,
+		});
+		for (const split of detail.splits) {
+			expect(split).not.toHaveProperty("elevationM");
+			expect(split).not.toHaveProperty("distanceM");
+		}
+	});
+
+	describe("what it did to fitness, fatigue and form", () => {
+		const range = { from: "2026-07-01", to: "2026-08-09" };
+
+		it("brackets the run: fatigue jumps, fitness inches up, form drops", () => {
+			const runs = [run("2026-08-02"), run("2026-08-09", { load: 120 })];
+			const detail = lastRunDetail({
+				runs,
+				series: seriesFor(runs, range),
+				today: "2026-08-09",
+			});
+
+			const { form } = detail.impact;
+			expect(form.dayLoad).toBe(120);
+			expect(form.atlDelta).toBeGreaterThan(form.ctlDelta);
+			expect(form.ctlDelta).toBeGreaterThan(0);
+			// Fatigue rising faster than fitness is what leaves you flat.
+			expect(form.tsbDelta).toBeLessThan(0);
+			expect(form.tsb).toBeCloseTo(form.ctl - form.atl, 10);
+		});
+
+		it("has no before to compare against on the block's first day", () => {
+			const runs = [run("2026-07-01")];
+			const detail = lastRunDetail({
+				runs,
+				series: seriesFor(runs, { from: "2026-07-01", to: "2026-07-01" }),
+				today: "2026-07-01",
+			});
+
+			expect(detail.impact.form).toBeNull();
+		});
+
+		it("counts the runs sharing the day, since the change belongs to both", () => {
+			const runs = [run("2026-08-09"), run("2026-08-09", { id: 2, name: "Evening Shakeout" })];
+			const detail = lastRunDetail({ runs, today: "2026-08-09" });
+
+			expect(detail.runsThatDay).toBe(2);
+		});
+	});
+
+	describe("how it compares with the runs around it", () => {
+		it("measures the load against the median of the last six weeks", () => {
+			const runs = [
+				run("2026-07-20", { load: 40 }),
+				run("2026-07-27", { load: 60 }),
+				run("2026-08-03", { load: 50 }),
+				run("2026-08-09", { load: 100 }),
+			];
+			const { load } = lastRunDetail({ runs, today: "2026-08-09" }).impact;
+
+			expect(load.typicalLoad).toBe(50);
+			expect(load.vsTypicalPct).toBe(200);
+			expect(load.runsCompared).toBe(3);
+		});
+
+		it("ignores runs from further back than the window", () => {
+			const runs = [run("2026-05-01", { load: 400 }), run("2026-08-09", { load: 100 })];
+			const { load } = lastRunDetail({ runs, today: "2026-08-09" }).impact;
+
+			expect(load.runsCompared).toBe(0);
+			expect(load.typicalLoad).toBeNull();
+			expect(load.vsTypicalPct).toBeNull();
+		});
+
+		it("says how long since a run cost as much", () => {
+			const runs = [
+				run("2026-07-26", { load: 130 }),
+				run("2026-08-02", { load: 60 }),
+				run("2026-08-09", { load: 120 }),
+			];
+			const { load } = lastRunDetail({ runs, today: "2026-08-09" }).impact;
+
+			expect(load.daysSinceAsHard).toBe(14);
+		});
+
+		it("reports nothing to match when it's the hardest of the block", () => {
+			const runs = [run("2026-08-02", { load: 60 }), run("2026-08-09", { load: 200 })];
+			const { load } = lastRunDetail({ runs, today: "2026-08-09" }).impact;
+
+			expect(load.daysSinceAsHard).toBeNull();
+		});
+	});
+
+	describe("what it was worth to the week", () => {
+		const weeks = [
+			{ start: "2026-08-03", actualKm: 48, targetKm: 60 },
+			{ start: "2026-08-10", actualKm: 12, targetKm: 55 },
+		];
+
+		it("places the run in its week and takes its share of the target", () => {
+			const runs = [run("2026-08-09", { distanceM: 24000 })];
+			const { week } = lastRunDetail({ runs, weeks, today: "2026-08-11" }).impact;
+
+			expect(week.start).toBe("2026-08-03");
+			expect(week.targetKm).toBe(60);
+			expect(week.sharePct).toBe(40);
+		});
+
+		it("has no share to quote for a week the plan doesn't cover", () => {
+			const runs = [run("2026-08-09", { distanceM: 24000 })];
+			const unplanned = [{ start: "2026-08-03", actualKm: 48, targetKm: null }];
+			const { week } = lastRunDetail({ runs, weeks: unplanned, today: "2026-08-11" }).impact;
+
+			expect(week.sharePct).toBeNull();
+			expect(week.actualKm).toBe(48);
+		});
+
+		it("says nothing at all about a run outside every known week", () => {
+			const runs = [run("2026-09-30")];
+			const { week } = lastRunDetail({ runs, weeks, today: "2026-09-30" }).impact;
+
+			expect(week).toBeNull();
+		});
+	});
+
+	describe("how it was paced", () => {
+		it("compares the halves and names the edges", () => {
+			const runs = [run("2026-08-09", { splits: splits([300, 300, 320, 320]) })];
+			const { pacing } = lastRunDetail({ runs, today: "2026-08-09" });
+
+			expect(pacing.firstHalfPaceSecPerKm).toBe(300);
+			expect(pacing.secondHalfPaceSecPerKm).toBe(320);
+			expect(pacing.fadePct).toBeCloseTo(6.67, 2);
+			expect(pacing.fastest.km).toBe(1);
+			expect(pacing.slowest.km).toBe(4);
+		});
+
+		it("calls a negative split negative", () => {
+			const runs = [run("2026-08-09", { splits: splits([320, 320, 300, 300]) })];
+			const { pacing } = lastRunDetail({ runs, today: "2026-08-09" });
+
+			expect(pacing.fadePct).toBeLessThan(0);
+		});
+
+		it("won't let a 200 m finish be the fastest kilometre", () => {
+			const runs = [
+				run("2026-08-09", { splits: splits([300, 305, 298, 200], { lastDistanceM: 200 }) }),
+			];
+			const { pacing } = lastRunDetail({ runs, today: "2026-08-09" });
+
+			expect(pacing.fastest.km).toBe(3);
+		});
+
+		it("keeps quiet about a run too short to have halves", () => {
+			const runs = [run("2026-08-09", { splits: splits([300, 305]) })];
+			expect(lastRunDetail({ runs, today: "2026-08-09" }).pacing).toBeNull();
+		});
+	});
+
+	describe("how hard it was", () => {
+		it("reads the effort off the zones when there's a heart rate", () => {
+			const easy = run("2026-08-09", { zoneSeconds: [1200, 1500, 200, 0, 0] });
+			const workout = run("2026-08-09", { zoneSeconds: [600, 600, 300, 900, 300] });
+
+			expect(lastRunDetail({ runs: [easy], today: "2026-08-09" }).effort).toBe("easy");
+			expect(lastRunDetail({ runs: [workout], today: "2026-08-09" }).effort).toBe("hard");
+		});
+
+		it("rolls the zones up the way the intensity panel does", () => {
+			const runs = [run("2026-08-09", { zoneSeconds: [1000, 1000, 500, 400, 100] })];
+			const { zoneMix } = lastRunDetail({ runs, today: "2026-08-09" });
+
+			expect(zoneMix.totalSec).toBe(3000);
+			expect(zoneMix.easyPct).toBeCloseTo(66.67, 2);
+			expect(zoneMix.moderatePct).toBeCloseTo(16.67, 2);
+			expect(zoneMix.hardPct).toBeCloseTo(16.67, 2);
+		});
+
+		it("falls back to grade-adjusted pace for a run with no strap", () => {
+			const runs = [run("2026-08-09", { averageHr: null, gapPaceSecPerKm: 240 })];
+			const detail = lastRunDetail({ runs, thresholds: THRESHOLDS, today: "2026-08-09" });
+
+			expect(detail.zoneMix).toBeNull();
+			expect(detail.effort).toBe("hard");
+		});
+	});
+
+	it("carries the plan match it was handed", () => {
+		const planMatch = { planned: true, type: "long run", detail: "24 km easy", distanceKm: 24 };
+		const detail = lastRunDetail({ runs: [run("2026-08-09")], planMatch, today: "2026-08-09" });
+
+		expect(detail.plan).toEqual(planMatch);
+	});
+});

--- a/netlify/functions/_shared/training/lastRun.test.js
+++ b/netlify/functions/_shared/training/lastRun.test.js
@@ -105,6 +105,17 @@ describe("lastRunDetail", () => {
 		}
 	});
 
+	// Found on real data: a 34 m tail at 9:40/km stretched the chart's axis
+	// from five minutes to ten and flattened the run itself into the top inch.
+	it("leaves the closing fragment of a kilometre off the chart", () => {
+		const detail = lastRunDetail({
+			runs: [run("2026-08-09", { splits: splits([300, 305, 298, 580], { lastDistanceM: 34 }) })],
+			today: "2026-08-09",
+		});
+
+		expect(detail.splits.map((s) => s.km)).toEqual([1, 2, 3]);
+	});
+
 	describe("what it did to fitness, fatigue and form", () => {
 		const range = { from: "2026-07-01", to: "2026-08-09" };
 
@@ -238,14 +249,17 @@ describe("lastRunDetail", () => {
 			expect(pacing.fadePct).toBeLessThan(0);
 		});
 
-		it("won't let a 200 m finish be the fastest kilometre", () => {
-			const runs = [
-				run("2026-08-09", { splits: splits([300, 305, 298, 200], { lastDistanceM: 200 }) }),
-			];
-			const { pacing } = lastRunDetail({ runs, today: "2026-08-09" });
+	it("won't let a 200 m finish be the fastest kilometre", () => {
+		const runs = [
+			run("2026-08-09", { splits: splits([300, 305, 298, 200], { lastDistanceM: 200 }) }),
+		];
+		const { pacing } = lastRunDetail({ runs, today: "2026-08-09" });
 
-			expect(pacing.fastest.km).toBe(3);
-		});
+		expect(pacing.fastest.km).toBe(3);
+		// It still counts towards the halves, where its own short distance
+		// weights it down to what it was.
+		expect(pacing.secondHalfPaceSecPerKm).toBeLessThan(298);
+	});
 
 		it("keeps quiet about a run too short to have halves", () => {
 			const runs = [run("2026-08-09", { splits: splits([300, 305]) })];

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -9,6 +9,7 @@ import { acwr, fitnessSeries, longRunShare, rampRate, weeklySummaries } from "./
 import { hrZoneFloors, intensitySplit } from "./zones.js";
 import { efficiencyTrend } from "./efficiency.js";
 import { collectBestEfforts, publicRun } from "./shape.js";
+import { lastRunDetail } from "./lastRun.js";
 import { goalDelta, goalPaceSecPerKm, predictRace } from "./predict.js";
 import {
 	blockRange,
@@ -150,6 +151,11 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 		.reverse()
 		.find((a) => a.distanceM >= LONG_RUN_MIN_M && Number.isFinite(a.decouplingPct));
 
+	// Matched over the whole block rather than per view: a day whose first run
+	// falls outside the log would otherwise let its second run claim the
+	// session the first one already did.
+	const planMatches = matchRunsToPlan(runs, plan);
+
 	const remainingDays = daysToRace(plan, day);
 	const totals = runs.reduce(
 		(acc, a) => {
@@ -256,19 +262,25 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 		week: current ? { start: current.start, days: planDays(current, runs, day) } : null,
 		upcoming: upcomingWeeks(plan, day),
 		recommendations: advice,
+		// The freshest run, read against the athlete's own recent history —
+		// the one panel that's about a single session rather than a trend.
+		lastRun: lastRunDetail({
+			runs,
+			series,
+			weeks,
+			planMatch: planMatches.at(-1) ?? null,
+			thresholds,
+			today: day,
+		}),
 		// The log carries its plan match so the page can say which runs were
 		// the plan and which were extra. The match comes from the plan file
 		// rather than from Strava, so it adds nothing to what publicRun()
 		// allows out.
 		runs: (() => {
-			// Matched over the whole block, then sliced: a day whose first run
-			// falls outside the log would otherwise let its second run claim
-			// the session the first one already did.
-			const matches = matchRunsToPlan(runs, plan);
 			const from = Math.max(0, runs.length - RUN_LOG_LIMIT);
 			return runs
 				.slice(from)
-				.map((run, i) => ({ ...publicRun(run), plan: matches[from + i] }))
+				.map((run, i) => ({ ...publicRun(run), plan: planMatches[from + i] }))
 				.reverse();
 		})(),
 		thresholds,

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -20,6 +20,7 @@ import {
 	matchRunsToPlan,
 	upcomingWeeks,
 	weekDays,
+	weekLongRun,
 	weeksToRace,
 } from "./plan.js";
 import { recommendations } from "./recommend.js";
@@ -259,7 +260,15 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 		series: series.filter((d) => d.date <= day),
 		efficiency: { points: efficiency.points, trend: efficiency.trend },
 		weeks,
-		week: current ? { start: current.start, days: planDays(current, runs, day) } : null,
+		week: current
+			? {
+					start: current.start,
+					days: planDays(current, runs, day),
+					// The week's anchor session, reported as a day rather than
+					// as a total that fills up alongside the volume bar.
+					longRun: weekLongRun(current, runs, day),
+				}
+			: null,
 		upcoming: upcomingWeeks(plan, day),
 		recommendations: advice,
 		// The freshest run, read against the athlete's own recent history —

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -292,6 +292,25 @@ describe("buildDashboard", () => {
 		expect(out.runs[0].startDateLocal > out.runs[1].startDateLocal).toBe(true);
 	});
 
+	it("singles out the last run, with what it did to the week and to form", () => {
+		const out = buildDashboard({
+			activities: block("2026-08-11", 12),
+			plan: PLAN,
+			today: "2026-08-11",
+		});
+
+		expect(out.lastRun.date).toBe("2026-08-11");
+		expect(out.lastRun.id).toBe(out.runs[0].id);
+		expect(out.lastRun.impact.form.atlDelta).toBeGreaterThan(0);
+		expect(out.lastRun.impact.week.start).toBe("2026-08-10");
+		expect(out.lastRun.impact.load.vsTypicalPct).toBeGreaterThan(0);
+	});
+
+	it("has no last run to describe before anything is synced", () => {
+		const out = buildDashboard({ activities: [], plan: PLAN, today: "2026-08-11" });
+		expect(out.lastRun).toBeNull();
+	});
+
 	it("predicts a race time from best efforts", () => {
 		const runs = block("2026-08-11", 6);
 		runs[5].bestEfforts = [
@@ -358,5 +377,18 @@ describe("buildDashboard privacy, end to end", () => {
 		expect(json).not.toContain("polyline");
 		expect(json).not.toContain("latlng");
 		expect(json).not.toContain("43.65");
+	});
+
+	// The deep dive is the one place per-kilometre data is served, so it gets
+	// the same treatment: what it needs to draw a pace profile, and no more.
+	it("serves the last run's splits without their hill profile", () => {
+		expect(payload.lastRun.id).toBe(2);
+		expect(payload.lastRun.splits).toHaveLength(1);
+		expect(Object.keys(payload.lastRun.splits[0]).sort()).toEqual([
+			"averageHr",
+			"gapPaceSecPerKm",
+			"km",
+			"paceSecPerKm",
+		]);
 	});
 });

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -104,6 +104,36 @@ describe("buildDashboard", () => {
 		expect(days[3].planned).toEqual([]);
 	});
 
+	it("reports the long run as Sunday's session, not as Tuesday's progress", () => {
+		// The week's only run so far is Tuesday's 8 km. None of it is part of
+		// Sunday's 24, though reading the week's longest run as the long run
+		// used to say it was a third done.
+		const planned = {
+			...PLAN,
+			weeks: [
+				{
+					start: "2026-08-10",
+					sessions: [
+						{ day: "Tuesday", type: "easy run", distanceKm: 8 },
+						{ day: "Sunday", type: "long run", distanceKm: 24, detail: "24km Long Run" },
+					],
+				},
+			],
+		};
+		const out = buildDashboard({
+			activities: block("2026-08-11", 1, { distanceM: 8000 }),
+			plan: planned,
+			today: "2026-08-11",
+		});
+
+		expect(out.week.longRun).toEqual({
+			date: "2026-08-16",
+			targetKm: 24,
+			actualKm: 0,
+			status: "ahead",
+		});
+	});
+
 	it("tells the run log which runs were the plan and which were extra", () => {
 		// Monday and Tuesday planned; the runs land on Tuesday and Wednesday.
 		const planned = {
@@ -330,27 +360,27 @@ describe("buildDashboard privacy, end to end", () => {
 		{
 			id: 1,
 			name: "Private Long Run",
-			sport_type: "Run",
+			"sport_type": "Run",
 			private: true,
-			start_date_local: "2026-08-09T07:00:00",
+			"start_date_local": "2026-08-09T07:00:00",
 			distance: 32000,
-			moving_time: 10000,
-			average_heartrate: 145,
-			map: { summary_polyline: "SECRETPOLYLINE" },
-			start_latlng: [43.6532, -79.3832],
+			"moving_time": 10000,
+			"average_heartrate": 145,
+			map: { "summary_polyline": "SECRETPOLYLINE" },
+			"start_latlng": [43.6532, -79.3832],
 		},
 		{
 			id: 2,
 			name: "Public Easy Run",
-			sport_type: "Run",
+			"sport_type": "Run",
 			private: false,
-			start_date_local: "2026-08-11T07:00:00",
+			"start_date_local": "2026-08-11T07:00:00",
 			distance: 10000,
-			moving_time: 3300,
-			average_heartrate: 140,
-			map: { summary_polyline: "PUBLICPOLYLINE" },
-			start_latlng: [43.6532, -79.3832],
-			splits_metric: [{ distance: 1000, moving_time: 330, elevation_difference: 5 }],
+			"moving_time": 3300,
+			"average_heartrate": 140,
+			map: { "summary_polyline": "PUBLICPOLYLINE" },
+			"start_latlng": [43.6532, -79.3832],
+			"splits_metric": [{ distance: 1000, "moving_time": 330, "elevation_difference": 5 }],
 		},
 	];
 

--- a/netlify/functions/_shared/training/plan.js
+++ b/netlify/functions/_shared/training/plan.js
@@ -104,6 +104,59 @@ export function plannedLongRunKm(week) {
 }
 
 /**
+ * The week's long run, as the session it is rather than a running total.
+ *
+ * The long run happens on one day. Measuring it the way volume is measured —
+ * kilometres so far against the target — gives "9.3 of 24" on a Tuesday, which
+ * isn't a partly-finished long run but the longest easy run of the week so far,
+ * counted a second time. The same kilometres fill both bars, and by Saturday
+ * the long run looks two thirds done without having been started.
+ *
+ * So it's answered as a question about a day: is it still ahead of you, did you
+ * do it, or did the day go by. Day-anchored like the rest of the plan matching,
+ * which means a long run moved to Saturday reads as a missed Sunday and an
+ * extra Saturday — the same story the day list tells directly below it.
+ *
+ * @param {object} week a week from comparePlan(), carrying its sessions.
+ * @param {object[]} runs shaped activities.
+ * @param {string} today day key.
+ * @returns {{date: string, targetKm: number|null, actualKm: number,
+ *   status: "done"|"missed"|"ahead"}|null} null for a week with no long run
+ *   planned, which is a normal week rather than a failed one.
+ */
+export function weekLongRun(week, runs, today) {
+	const session = (week?.sessions || []).find((s) => LONG_RUN_TYPES.has(typeOf(s)));
+	if (!session?.date) {
+		return null;
+	}
+
+	// The longest run of that day, not the day's total: a shakeout after the
+	// long run is a double, not twenty-nine kilometres of long run.
+	const onTheDay = (runs || [])
+		.filter((run) => toDayKey(run?.startDateLocal) === session.date)
+		.map((run) => (Number(run.distanceM) || 0) / 1000);
+	const actualKm = onTheDay.length > 0 ? Math.max(...onTheDay) : 0;
+	const targetKm = Number(session.distanceKm) || null;
+
+	return {
+		date: session.date,
+		targetKm,
+		actualKm,
+		status: longRunStatus(actualKm, session.date, today),
+	};
+}
+
+function longRunStatus(actualKm, date, today) {
+	if (actualKm > 0) {
+		return "done";
+	}
+	// A day is only missed once it's over: at 8am on Sunday the long run is
+	// still ahead of you, and calling it missed would be both wrong and
+	// demoralising.
+	return date < toDayKey(today) ? "missed" : "ahead";
+}
+
+/**
  * The planned week whose Monday matches a given week start.
  *
  * @param {object} plan the parsed plan file.
@@ -159,18 +212,15 @@ export function comparePlan(weeks, plan) {
 		const targetKm = plannedKm(planned);
 		const actualKm = week.distanceM / 1000;
 		const longRunKm = plannedLongRunKm(planned);
-		const actualLongRunKm = week.longestRunM / 1000;
 
 		return {
 			...week,
 			actualKm,
-			actualLongRunKm,
 			// null rather than 0 so "no plan entered" is distinguishable from
 			// "planned zero", which the UI and the rules both care about.
 			targetKm: targetKm > 0 ? targetKm : null,
 			longRunTargetKm: longRunKm > 0 ? longRunKm : null,
 			volumePct: targetKm > 0 ? (actualKm / targetKm) * 100 : null,
-			longRunPct: longRunKm > 0 ? (actualLongRunKm / longRunKm) * 100 : null,
 			keySessions: Array.isArray(planned?.key) ? planned.key : [],
 			sessions: weekSessions(planned),
 			// A planned week with no running is a scheduled down week, which

--- a/netlify/functions/_shared/training/plan.js
+++ b/netlify/functions/_shared/training/plan.js
@@ -103,6 +103,24 @@ export function plannedLongRunKm(week) {
 	return longs.length === 0 ? 0 : Math.max(...longs.map((s) => Number(s.distanceKm) || 0));
 }
 
+function longRunStatus(actualKm, date, today) {
+	if (actualKm > 0) {
+		return "done";
+	}
+	// A day is only missed once it's over: at 8am on Sunday the long run is
+	// still ahead of you, and calling it missed would be both wrong and
+	// demoralising.
+	return date < toDayKey(today) ? "missed" : "ahead";
+}
+
+/** The longest single run of a day, in kilometres. */
+function longestRunOn(runs, date) {
+	const distances = (runs || [])
+		.filter((run) => toDayKey(run?.startDateLocal) === date)
+		.map((run) => (Number(run.distanceM) || 0) / 1000);
+	return distances.length > 0 ? Math.max(...distances) : 0;
+}
+
 /**
  * The week's long run, as the session it is rather than a running total.
  *
@@ -132,28 +150,14 @@ export function weekLongRun(week, runs, today) {
 
 	// The longest run of that day, not the day's total: a shakeout after the
 	// long run is a double, not twenty-nine kilometres of long run.
-	const onTheDay = (runs || [])
-		.filter((run) => toDayKey(run?.startDateLocal) === session.date)
-		.map((run) => (Number(run.distanceM) || 0) / 1000);
-	const actualKm = onTheDay.length > 0 ? Math.max(...onTheDay) : 0;
-	const targetKm = Number(session.distanceKm) || null;
+	const actualKm = longestRunOn(runs, session.date);
 
 	return {
 		date: session.date,
-		targetKm,
+		targetKm: Number(session.distanceKm) || null,
 		actualKm,
 		status: longRunStatus(actualKm, session.date, today),
 	};
-}
-
-function longRunStatus(actualKm, date, today) {
-	if (actualKm > 0) {
-		return "done";
-	}
-	// A day is only missed once it's over: at 8am on Sunday the long run is
-	// still ahead of you, and calling it missed would be both wrong and
-	// demoralising.
-	return date < toDayKey(today) ? "missed" : "ahead";
 }
 
 /**

--- a/netlify/functions/_shared/training/plan.test.js
+++ b/netlify/functions/_shared/training/plan.test.js
@@ -18,6 +18,7 @@ import {
 	plannedLongRunKm,
 	plannedRunsByDay,
 	matchRunsToPlan,
+	weekLongRun,
 } from "./plan.js";
 
 const PLAN = {
@@ -81,6 +82,86 @@ describe("comparePlan", () => {
 		expect(out[1].targetKm).toBeNull();
 		expect(out[1].volumePct).toBeNull();
 		expect(out[1].actualKm).toBe(50);
+	});
+
+	it("doesn't report a long run's progress as a weekly total", () => {
+		// The longest run so far isn't the long run partly done, and reporting
+		// it as one had every easy run filling the long-run bar as well as the
+		// volume one.
+		const out = comparePlan(weeks, PLAN);
+		expect(out[0]).not.toHaveProperty("actualLongRunKm");
+		expect(out[0]).not.toHaveProperty("longRunPct");
+	});
+});
+
+describe("weekLongRun", () => {
+	const week = {
+		start: "2026-06-22",
+		sessions: weekSessions({
+			start: "2026-06-22",
+			sessions: [
+				{ day: "Wednesday", type: "tempo", distanceKm: 7.5 },
+				{ day: "Sunday", type: "long run", distanceKm: 17 },
+			],
+		}),
+	};
+	const run = (date, km) => ({ startDateLocal: `${date}T07:00:00Z`, distanceM: km * 1000 });
+
+	it("stays ahead of you while the day is still to come", () => {
+		const out = weekLongRun(week, [run("2026-06-24", 7.6)], "2026-06-24");
+		expect(out).toMatchObject({ date: "2026-06-28", targetKm: 17, actualKm: 0, status: "ahead" });
+	});
+
+	it("is not filled in by the rest of the week's running", () => {
+		// Four easy days, the longest of them 12 km: none of that is any part
+		// of Sunday's 17.
+		const runs = [
+			run("2026-06-23", 8),
+			run("2026-06-24", 12),
+			run("2026-06-26", 9),
+			run("2026-06-27", 6),
+		];
+		expect(weekLongRun(week, runs, "2026-06-27").actualKm).toBe(0);
+	});
+
+	it("reports what was actually run once the day comes", () => {
+		const out = weekLongRun(week, [run("2026-06-28", 16.4)], "2026-06-28");
+		expect(out).toMatchObject({ actualKm: 16.4, status: "done" });
+	});
+
+	it("counts the longer of a double rather than the day's total", () => {
+		const runs = [run("2026-06-28", 17.2), run("2026-06-28", 4)];
+		expect(weekLongRun(week, runs, "2026-06-29").actualKm).toBe(17.2);
+	});
+
+	it("calls it missed only once the day is over", () => {
+		expect(weekLongRun(week, [], "2026-06-28").status).toBe("ahead");
+		expect(weekLongRun(week, [], "2026-06-29").status).toBe("missed");
+	});
+
+	it("says nothing about a week with no long run planned", () => {
+		const easyWeek = {
+			sessions: weekSessions({
+				start: "2026-06-22",
+				sessions: [{ day: "Wednesday", type: "easy run", distanceKm: 8 }],
+			}),
+		};
+		expect(weekLongRun(easyWeek, [], "2026-06-24")).toBeNull();
+		expect(weekLongRun(null, [], "2026-06-24")).toBeNull();
+	});
+
+	it("treats race day as the long run it is", () => {
+		const raceWeek = {
+			sessions: weekSessions({
+				start: "2026-10-05",
+				sessions: [{ day: "Sunday", type: "race", distanceKm: 42.2 }],
+			}),
+		};
+		expect(weekLongRun(raceWeek, [], "2026-10-06")).toMatchObject({
+			date: "2026-10-11",
+			targetKm: 42.2,
+			status: "ahead",
+		});
 	});
 });
 

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -192,6 +192,45 @@ export function publicRun(activity) {
 }
 
 /**
+ * The same, for the one run the dashboard looks at in detail.
+ *
+ * The log carries thirty runs and draws two numbers from each, so publicRun is
+ * as narrow as that job allows. A single run being examined on its own is a
+ * different trade: the sync has already computed its splits, its time in each
+ * heart-rate zone, its decoupling and its load, and none of that is derivable
+ * in the browser from what the log carries.
+ *
+ * The privacy line is the same one shape.js draws everywhere else — nothing
+ * here is geographic. Per-kilometre pace, heart rate and grade adjustment
+ * describe an effort, not a place, and unlike the stored splits the
+ * per-kilometre elevation isn't carried: a hill profile is the one part of a
+ * split list that starts to describe a route rather than a run. The total climb
+ * is enough to read the pace by, and is already public on the log.
+ *
+ * @param {object} activity a stored, shaped activity.
+ * @returns {object|null} safe to serve.
+ */
+export function publicLastRun(activity) {
+	if (!activity) return null;
+	return {
+		...publicRun(activity),
+		elapsedTimeSec: activity.elapsedTimeSec ?? null,
+		maxHr: activity.maxHr ?? null,
+		averageCadence: activity.averageCadence ?? null,
+		load: Number.isFinite(activity.load) ? activity.load : null,
+		loadMethod: activity.loadMethod ?? null,
+		decouplingPct: activity.decouplingPct ?? null,
+		zoneSeconds: Array.isArray(activity.zoneSeconds) ? [...activity.zoneSeconds] : null,
+		splits: (activity.splits || []).map((s) => ({
+			km: s.km,
+			paceSecPerKm: s.paceSecPerKm ?? null,
+			gapPaceSecPerKm: s.gapPaceSecPerKm ?? null,
+			averageHr: s.averageHr ?? null,
+		})),
+	};
+}
+
+/**
  * Shape a batch, dropping everything that isn't a public run.
  *
  * @param {object[]} rawActivities

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -50,6 +50,13 @@ export function isTrackableRun(raw) {
 	return RUN_TYPES.has(raw.sport_type || raw.type);
 }
 
+// What counts as a kilometre when reading splits. A run almost never ends on a
+// round number, so the last split is usually a fragment whose "pace" is an
+// artefact of where you happened to stop — a 40 m tail at 9:00/km is a walk to
+// the door, not a collapse. Kept in storage, left out of anything that ranks or
+// plots splits.
+export const WHOLE_SPLIT_M = 600;
+
 // Per-kilometre splits, keeping only what the charts and GAP need.
 function shapeSplits(splits) {
 	return (splits || [])
@@ -221,7 +228,7 @@ export function publicLastRun(activity) {
 		loadMethod: activity.loadMethod ?? null,
 		decouplingPct: activity.decouplingPct ?? null,
 		zoneSeconds: Array.isArray(activity.zoneSeconds) ? [...activity.zoneSeconds] : null,
-		splits: (activity.splits || []).map((s) => ({
+		splits: (activity.splits || []).filter((s) => s.distanceM >= WHOLE_SPLIT_M).map((s) => ({
 			km: s.km,
 			paceSecPerKm: s.paceSecPerKm ?? null,
 			gapPaceSecPerKm: s.gapPaceSecPerKm ?? null,

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -198,6 +198,22 @@ export function publicRun(activity) {
 	};
 }
 
+function publicZoneSeconds(zoneSeconds) {
+	return Array.isArray(zoneSeconds) ? [...zoneSeconds] : null;
+}
+
+// Pace, grade adjustment and heart rate, for the kilometres that were one.
+function publicSplits(splits) {
+	return (splits || [])
+		.filter((s) => s.distanceM >= WHOLE_SPLIT_M)
+		.map((s) => ({
+			km: s.km,
+			paceSecPerKm: s.paceSecPerKm,
+			gapPaceSecPerKm: s.gapPaceSecPerKm,
+			averageHr: s.averageHr,
+		}));
+}
+
 /**
  * The same, for the one run the dashboard looks at in detail.
  *
@@ -218,22 +234,19 @@ export function publicRun(activity) {
  * @returns {object|null} safe to serve.
  */
 export function publicLastRun(activity) {
-	if (!activity) return null;
+	if (!activity) {
+		return null;
+	}
 	return {
 		...publicRun(activity),
-		elapsedTimeSec: activity.elapsedTimeSec ?? null,
-		maxHr: activity.maxHr ?? null,
-		averageCadence: activity.averageCadence ?? null,
-		load: Number.isFinite(activity.load) ? activity.load : null,
-		loadMethod: activity.loadMethod ?? null,
-		decouplingPct: activity.decouplingPct ?? null,
-		zoneSeconds: Array.isArray(activity.zoneSeconds) ? [...activity.zoneSeconds] : null,
-		splits: (activity.splits || []).filter((s) => s.distanceM >= WHOLE_SPLIT_M).map((s) => ({
-			km: s.km,
-			paceSecPerKm: s.paceSecPerKm ?? null,
-			gapPaceSecPerKm: s.gapPaceSecPerKm ?? null,
-			averageHr: s.averageHr ?? null,
-		})),
+		elapsedTimeSec: activity.elapsedTimeSec,
+		maxHr: activity.maxHr,
+		averageCadence: activity.averageCadence,
+		load: activity.load,
+		loadMethod: activity.loadMethod,
+		decouplingPct: activity.decouplingPct,
+		zoneSeconds: publicZoneSeconds(activity.zoneSeconds),
+		splits: publicSplits(activity.splits),
 	};
 }
 

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -41,14 +41,25 @@
     // row underneath. A panel can sit in any of them; the charts and the run
     // log all reflow to their container, so a "narrow" chart is a narrower
     // chart rather than a broken one.
+    //
+    // The split is by height as much as by subject, because the columns are
+    // independent and a heavy one just runs on past the other: with the last
+    // run and the recommendations — the two tallest panels — both on the left,
+    // it ended a thousand pixels below the right. Left is how the training is
+    // going, right is what to do and what's on. Worth re-measuring whenever a
+    // panel is added, since nothing here keeps the two columns level on its
+    // own.
     const DEFAULT_ORDER = [
-        "lastRun", "volume", "fitness", "efficiency", "recommendations",
-        "prediction", "load", "intensity", "week",
+        "lastRun", "volume", "fitness", "efficiency", "prediction",
+        "recommendations", "week", "load", "intensity",
         "runs",
     ];
     const WIDE_SLOTS = 5;
     const NARROW_SLOTS = 4;
-    const LAYOUT_KEY = "training-layout";
+    // Versioned: a layout saved against the old order would keep the imbalance
+    // this fixes, and the arrangement is a convenience rather than anything
+    // worth carrying forward at the cost of the fix.
+    const LAYOUT_KEY = "training-layout-2";
 
     let data = $state(null);
     let error = $state("");

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -24,6 +24,7 @@
     import { createPoller } from "../../lib/data/poller.js";
     import RaceHeader from "./sections/RaceHeader.svelte";
     import SyncNotice from "./sections/SyncNotice.svelte";
+    import LastRun from "./sections/LastRun.svelte";
     import Recommendations from "./sections/Recommendations.svelte";
     import VolumeChart from "./sections/VolumeChart.svelte";
     import FitnessChart from "./sections/FitnessChart.svelte";
@@ -36,16 +37,16 @@
 
     const ENDPOINT = "/.netlify/functions/trainingData";
 
-    // Slots 0–3 are the wide column, 4–7 the narrow one, 8 the full-width
+    // Slots 0–4 are the wide column, 5–8 the narrow one, 9 the full-width
     // row underneath. A panel can sit in any of them; the charts and the run
     // log all reflow to their container, so a "narrow" chart is a narrower
     // chart rather than a broken one.
     const DEFAULT_ORDER = [
-        "volume", "fitness", "efficiency", "recommendations",
+        "lastRun", "volume", "fitness", "efficiency", "recommendations",
         "prediction", "load", "intensity", "week",
         "runs",
     ];
-    const WIDE_SLOTS = 4;
+    const WIDE_SLOTS = 5;
     const NARROW_SLOTS = 4;
     const LAYOUT_KEY = "training-layout";
 
@@ -141,7 +142,9 @@
 {/snippet}
 
 {#snippet panelBody(id)}
-    {#if id === "volume"}
+    {#if id === "lastRun"}
+        <LastRun run={data.lastRun} />
+    {:else if id === "volume"}
         <VolumeChart weeks={data.weeks} today={data.today} />
     {:else if id === "fitness"}
         <FitnessChart series={data.series} today={data.today} />

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -101,17 +101,6 @@ export function weekday(dayKey) {
 	return date.toLocaleDateString("en-GB", { weekday: "short", timeZone: "UTC" });
 }
 
-/**
- * The week a Monday starts, as the range it actually covers: "17–23 Aug",
- * or "31 Aug – 6 Sept" where the week straddles two months.
- *
- * A training week is seven days, and labelling it with its Monday alone asks
- * the reader to do the arithmetic every time they want to know whether a
- * given Saturday falls inside it.
- *
- * @param {string} weekStart Monday day key.
- * @returns {string}
- */
 /** The day key as a UTC-noon Date, or null if there isn't a usable one. */
 function utcNoon(dayKey) {
 	const date = new Date(`${String(dayKey ?? "").slice(0, 10)}T12:00:00Z`);
@@ -134,9 +123,50 @@ function span(start, end) {
 		: `${dayMonth(start)} – ${dayMonth(end)}`;
 }
 
+/**
+ * The week a Monday starts, as the range it actually covers: "17–23 Aug",
+ * or "31 Aug – 6 Sept" where the week straddles two months.
+ *
+ * A training week is seven days, and labelling it with its Monday alone asks
+ * the reader to do the arithmetic every time they want to know whether a
+ * given Saturday falls inside it.
+ *
+ * @param {string} weekStart Monday day key.
+ * @returns {string}
+ */
 export function weekRange(weekStart) {
 	const start = utcNoon(weekStart);
 	return start ? span(start, sixDaysOn(start)) : "";
+}
+
+/**
+ * How long ago a day was, in the words you'd use out loud.
+ *
+ * @param {number} days whole days between the day and today.
+ * @returns {string}
+ */
+export function daysAgo(days) {
+	if (!Number.isFinite(days) || days < 0) return "";
+	if (days === 0) return "Today";
+	if (days === 1) return "Yesterday";
+	if (days < 7) return `${days} days ago`;
+	const weeks = Math.round(days / 7);
+	return weeks === 1 ? "Last week" : `${weeks} weeks ago`;
+}
+
+/**
+ * A number with its sign kept, for deltas where "+0.3" and "0.3" mean
+ * different things.
+ *
+ * @param {number} value
+ * @param {number} [digits]
+ * @returns {string}
+ */
+export function signed(value, digits = 1) {
+	if (!Number.isFinite(value)) return "—";
+	const rounded = value.toFixed(digits);
+	// Rounding can land on a signed zero, and "-0.0" reads as a decrease.
+	return Number(rounded) > 0 ? `+${rounded}` : rounded.replace(/^-0(\.0+)?$/, "0$1");
 }
 
 /**

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -139,6 +139,22 @@ export function weekRange(weekStart) {
 	return start ? span(start, sixDaysOn(start)) : "";
 }
 
+// The days that have a name rather than a count. A Map rather than an object
+// so looking one up by a number isn't an indexing expression.
+const NAMED_DAYS = new Map([
+	[0, "Today"],
+	[1, "Yesterday"],
+]);
+
+// Number.isFinite, not `>= 0`: null compares as zero, and "null days ago" is
+// how that gets found out.
+const isDayCount = (days) => Number.isFinite(days) && days >= 0;
+
+function weeksAgo(days) {
+	const weeks = Math.round(days / 7);
+	return weeks === 1 ? "Last week" : `${weeks} weeks ago`;
+}
+
 /**
  * How long ago a day was, in the words you'd use out loud.
  *
@@ -146,12 +162,16 @@ export function weekRange(weekStart) {
  * @returns {string}
  */
 export function daysAgo(days) {
-	if (!Number.isFinite(days) || days < 0) return "";
-	if (days === 0) return "Today";
-	if (days === 1) return "Yesterday";
-	if (days < 7) return `${days} days ago`;
-	const weeks = Math.round(days / 7);
-	return weeks === 1 ? "Last week" : `${weeks} weeks ago`;
+	if (!isDayCount(days)) {
+		return "";
+	}
+	if (NAMED_DAYS.has(days)) {
+		return NAMED_DAYS.get(days);
+	}
+	if (days < 7) {
+		return `${days} days ago`;
+	}
+	return weeksAgo(days);
 }
 
 /**
@@ -163,10 +183,17 @@ export function daysAgo(days) {
  * @returns {string}
  */
 export function signed(value, digits = 1) {
-	if (!Number.isFinite(value)) return "—";
-	const rounded = value.toFixed(digits);
-	// Rounding can land on a signed zero, and "-0.0" reads as a decrease.
-	return Number(rounded) > 0 ? `+${rounded}` : rounded.replace(/^-0(\.0+)?$/, "0$1");
+	if (!Number.isFinite(value)) {
+		return "—";
+	}
+	// Round first, then read the sign off the result: -0.04 to one decimal is
+	// zero, and "-0.0" reads as a decrease that didn't happen.
+	const rounded = Number(value.toFixed(digits));
+	const magnitude = Math.abs(rounded).toFixed(digits);
+	if (rounded > 0) {
+		return `+${magnitude}`;
+	}
+	return rounded < 0 ? `-${magnitude}` : magnitude;
 }
 
 /**

--- a/src/components/Training/lib/format.test.js
+++ b/src/components/Training/lib/format.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { weekRange, pace, clock, km, pct, shortDate } from "./format.js";
+import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed } from "./format.js";
 
 describe("weekRange", () => {
 	it("covers the seven days from the Monday", () => {
@@ -17,6 +17,41 @@ describe("weekRange", () => {
 	it("has nothing to say about a missing or unparseable week", () => {
 		expect(weekRange(null)).toBe("");
 		expect(weekRange("not-a-date")).toBe("");
+	});
+});
+
+describe("daysAgo", () => {
+	it("says today and yesterday rather than counting them", () => {
+		expect(daysAgo(0)).toBe("Today");
+		expect(daysAgo(1)).toBe("Yesterday");
+	});
+
+	it("counts days inside the week and weeks beyond it", () => {
+		expect(daysAgo(3)).toBe("3 days ago");
+		expect(daysAgo(7)).toBe("Last week");
+		expect(daysAgo(18)).toBe("3 weeks ago");
+	});
+
+	it("has nothing to say about a day it can't place", () => {
+		expect(daysAgo(null)).toBe("");
+		expect(daysAgo(-2)).toBe("");
+	});
+});
+
+describe("signed", () => {
+	it("keeps the sign on both directions", () => {
+		expect(signed(0.34)).toBe("+0.3");
+		expect(signed(-1.25)).toBe("-1.3");
+	});
+
+	// A change of -0.04 is not a decrease worth drawing a minus sign for.
+	it("never prints a negative zero", () => {
+		expect(signed(-0.04)).toBe("0.0");
+		expect(signed(0)).toBe("0.0");
+	});
+
+	it("takes the precision it's given", () => {
+		expect(signed(12.4, 0)).toBe("+12");
 	});
 });
 

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -126,6 +126,7 @@ export const GLOSSARY = {
 		terms: [
 			{ term: "Missed", definition: "A past day that had a run planned and none recorded." },
 			{ term: "Extra", definition: "A day you ran that had no run planned." },
+			{ term: "Long run", definition: "The week's long run is a single session on a single day, so it's reported as one: still ahead of you, done, or gone by. It deliberately doesn't have a progress bar — kilometres from the rest of the week aren't part of it." },
 		],
 	},
 

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -13,6 +13,20 @@
 // into saying different things.
 
 export const GLOSSARY = {
+	lastRun: {
+		title: "Last run",
+		body: [
+			"The most recent run in the block, read against your own recent history rather than in isolation — a load of 90 is a big day or an ordinary Tuesday depending entirely on whose 90 it is.",
+			"The chart is pace for each kilometre, drawn with faster higher up. The dotted line across it is the run's own average, so the shape tells you whether it held together; grade-adjusted pace appears over it only when the hills made the two differ.",
+		],
+		terms: [
+			{ term: "Load", definition: "This run's training stress, from time spent at each heart rate. Compared here against the median run of your last six weeks, so 130% means half again as hard as your usual." },
+			{ term: "Fitness, fatigue and form", definition: "What the day's running moved. Fitness is the 42-day average of load, fatigue the 7-day one, form the difference. A hard run always adds more fatigue than fitness — that's the trade you're making." },
+			{ term: "Fade", definition: "How much slower the second half of the run was than the first. Under about 2% is even pacing; a negative number means you finished quicker than you started." },
+			{ term: "Drift", definition: "Aerobic decoupling: how far pace-per-heartbeat slipped between the halves of the run. Under 5% means the distance is within your aerobic base." },
+		],
+	},
+
 	volume: {
 		title: "Weekly volume",
 		body: [

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -22,8 +22,8 @@ export const GLOSSARY = {
 		terms: [
 			{ term: "Load", definition: "This run's training stress, from time spent at each heart rate. Compared here against the median run of your last six weeks, so 130% means half again as hard as your usual." },
 			{ term: "Fitness, fatigue and form", definition: "What the day's running moved. Fitness is the 42-day average of load, fatigue the 7-day one, form the difference. A hard run always adds more fatigue than fitness — that's the trade you're making." },
-			{ term: "Fade", definition: "How much slower the second half of the run was than the first. Under about 2% is even pacing; a negative number means you finished quicker than you started." },
-			{ term: "Drift", definition: "Aerobic decoupling: how far pace-per-heartbeat slipped between the halves of the run. Under 5% means the distance is within your aerobic base." },
+			{ term: "Fade", definition: "How much slower the second half of the run was than the first. Under about 2% is even pacing; a negative number means you finished quicker than you started. On a workout the halves are just describing the session — intervals, then a jog home." },
+			{ term: "Drift", definition: "Aerobic decoupling: how far pace-per-heartbeat slipped between the halves of the run. Under 5% means the distance is within your aerobic base. Only shown for runs held at one effort, since on an interval session it measures the intervals rather than your base." },
 		],
 	},
 

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -190,6 +190,12 @@
         return list;
     });
 
+    // "An easy run", "a moderate run". Only ever applied to the three efforts,
+    // so the first letter settles it.
+    function article(word) {
+        return /^[aeiou]/i.test(word) ? "An" : "A";
+    }
+
     function relativeLoadNote() {
         return load?.vsTypicalPct > 0 && load.runsCompared >= 3
             ? `${Math.round(load.vsTypicalPct)}% of typical`
@@ -286,7 +292,8 @@
                         The day's change, across {run.runsThatDay} runs.
                     {/if}
                     {#if relativeSize}
-                        A {run.effort || "steady"} run, {relativeSize}{standout ? `, and ${standout}` : ""}.
+                        {article(run.effort || "steady")} {run.effort || "steady"} run,
+                        {relativeSize}{standout ? `, and ${standout}` : ""}.
                     {/if}
                 </p>
             </div>

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -1,0 +1,517 @@
+<!--
+    The last run, and what it did to the training.
+
+    Every other panel here is a trend: twelve weeks of volume, a block of
+    fitness, four weeks of intensity. None of them answer the question you
+    actually have on the walk home — what that run was, and what it cost. This
+    one is about a single session.
+
+    Three parts, in the order you'd ask them in. What it was (the headline
+    numbers). How it went (the kilometre-by-kilometre pace, and whether it held
+    together). What it changed (fitness, fatigue and form, plus what it was
+    worth against the week's target).
+
+    The pace chart is drawn with a flipped y-axis so faster is higher, which is
+    the only orientation people read without translating; the axis is labelled
+    in pace so there's nothing to translate anyway. Grade-adjusted pace goes
+    over it as a second line whenever the two actually diverge — on a hilly run
+    that gap is the explanation for a slow kilometre, and on a flat one drawing
+    it twice would just be noise.
+-->
+<script>
+    import Card from "../../../lib/ui/Card.svelte";
+    import ChartFrame from "../charts/ChartFrame.svelte";
+    import { linePath, niceScale, scaleLinear } from "../lib/chart.js";
+    import { daysAgo, formatDistance, formatDuration, km, pace, pct, signed } from "../lib/format.js";
+    import { GLOSSARY } from "../lib/glossary.js";
+
+    let { run = null } = $props();
+
+    const WIDTH = 720;
+    const HEIGHT = 150;
+
+    // Strava reports running cadence one leg at a time; every watch and every
+    // coach talks in steps per minute.
+    const STEPS_PER_CYCLE = 2;
+
+    // Below this the two pace lines are the same line with a wobble.
+    const GAP_DIVERGENCE_SEC = 4;
+
+    // Strava's workout_type, as the run log reads it.
+    const TAGS = { 1: "Race", 2: "Long run", 3: "Workout" };
+
+    const splits = $derived((run?.splits || []).filter((s) => s.paceSecPerKm > 0));
+
+    const scale = $derived(
+        niceScale(
+            [
+                Math.min(...splits.map((s) => s.paceSecPerKm)) - 8,
+                Math.max(...splits.map((s) => s.paceSecPerKm)) + 8,
+            ],
+            4,
+        ),
+    );
+
+    // Pace runs the other way to every other axis on the page: the smallest
+    // number is the best one, so it belongs at the top.
+    const y = $derived(scaleLinear([scale.min, scale.max], [0, HEIGHT]));
+    const yTicks = $derived(
+        scale.ticks.map((value) => ({
+            value,
+            label: pace(value).replace("/km", ""),
+            pct: 100 - ((value - scale.min) / (scale.max - scale.min)) * 100,
+        })),
+    );
+
+    const step = $derived(splits.length > 1 ? WIDTH / (splits.length - 1) : 0);
+    const pacePoints = $derived(splits.map((s, i) => ({ x: i * step, y: y(s.paceSecPerKm) })));
+    const gapPoints = $derived(
+        splits.every((s) => s.gapPaceSecPerKm > 0)
+            ? splits.map((s, i) => ({ x: i * step, y: y(s.gapPaceSecPerKm) }))
+            : [],
+    );
+    const showGap = $derived(
+        gapPoints.length > 0
+            && splits.some((s) => Math.abs(s.gapPaceSecPerKm - s.paceSecPerKm) >= GAP_DIVERGENCE_SEC),
+    );
+
+    const averageY = $derived(run?.paceSecPerKm > 0 ? y(run.paceSecPerKm) : null);
+
+    // A number under every kilometre is unreadable on a phone, so label the
+    // ends and every fifth in between, dropping any that would crowd the last.
+    const xTicks = $derived(
+        splits
+            .map((s, i) => ({ s, i }))
+            .filter(({ i }) => {
+                const last = splits.length - 1;
+                if (i === 0 || i === last) return true;
+                return (i + 1) % 5 === 0 && last - i >= 3;
+            })
+            .map(({ s, i }) => ({
+                key: s.km,
+                label: `${s.km}`,
+                pct: (i / Math.max(1, splits.length - 1)) * 100,
+                anchor: i === 0 ? "start" : i === splits.length - 1 ? "end" : "middle",
+            })),
+    );
+
+    const form = $derived(run?.impact?.form || null);
+    const load = $derived(run?.impact?.load || null);
+    const week = $derived(run?.impact?.week || null);
+    const planned = $derived(run?.plan?.planned === true);
+
+    // Fitness and fatigue both rise from a run; the difference is that one is
+    // what you keep. Colour the direction that's working for you.
+    const changes = $derived(
+        form
+            ? [
+                    { key: "fitness", label: "Fitness", value: form.ctl, delta: form.ctlDelta, good: form.ctlDelta > 0 },
+                    { key: "fatigue", label: "Fatigue", value: form.atl, delta: form.atlDelta, good: form.atlDelta < 0 },
+                    { key: "form", label: "Form", value: form.tsb, delta: form.tsbDelta, good: form.tsbDelta > 0 },
+                ]
+            : [],
+    );
+
+    /** How this run's load sat against the athlete's own recent median. */
+    const relativeSize = $derived.by(() => {
+        if (!(load?.vsTypicalPct > 0) || load.runsCompared < 3) return null;
+        const ratio = load.vsTypicalPct;
+        if (ratio >= 140) return "much bigger than your usual run";
+        if (ratio >= 110) return "bigger than your usual run";
+        if (ratio > 90) return "about the size of your usual run";
+        if (ratio > 60) return "smaller than your usual run";
+        return "much smaller than your usual run";
+    });
+
+    /** "…and the hardest in three weeks", where that's true and worth saying. */
+    const standout = $derived.by(() => {
+        if (!load || !(load.load > 0) || load.runsCompared < 5) return null;
+        if (load.daysSinceAsHard === null) return "the hardest run of the block so far";
+        if (load.daysSinceAsHard >= 7) return `the hardest since ${daysAgo(load.daysSinceAsHard).toLowerCase()}`;
+        return null;
+    });
+
+    const fade = $derived(run?.pacing?.fadePct ?? null);
+    const pacingNote = $derived.by(() => {
+        if (fade === null) return null;
+        if (fade <= -2) return "negative split — the second half was quicker";
+        if (fade < 2) return "even pace, start to finish";
+        if (fade < 5) return `faded ${fade.toFixed(1)}% over the second half`;
+        return `faded ${fade.toFixed(1)}% — the second half cost you`;
+    });
+
+    // Only what this run actually recorded: a facts grid with "—" in half of
+    // its cells says less than a shorter grid.
+    const facts = $derived.by(() => {
+        const list = [];
+        if (Number.isFinite(load?.load)) {
+            list.push({ term: "Load", value: Math.round(load.load), note: relativeLoadNote() });
+        }
+        if (week?.sharePct > 0) {
+            list.push({ term: "Of the week", value: pct(week.sharePct), note: `${km((week.targetKm || 0) * 1000)} planned` });
+        }
+        if (run?.elevationGainM > 0) {
+            list.push({ term: "Climb", value: `${Math.round(run.elevationGainM)} m` });
+        }
+        if (run?.gapPaceSecPerKm > 0) {
+            list.push({ term: "Grade adjusted", value: pace(run.gapPaceSecPerKm) });
+        }
+        if (run?.averageCadence > 0) {
+            list.push({ term: "Cadence", value: `${Math.round(run.averageCadence * STEPS_PER_CYCLE)} spm` });
+        }
+        if (Number.isFinite(run?.decouplingPct)) {
+            list.push({
+                term: "Drift",
+                value: `${run.decouplingPct.toFixed(1)}%`,
+                note: run.decouplingPct < 5 ? "aerobically sound" : "ahead of the base",
+            });
+        }
+        if (run?.zoneMix) {
+            list.push({ term: "Easy time", value: pct(run.zoneMix.easyPct), note: `${pct(run.zoneMix.hardPct)} hard` });
+        }
+        return list;
+    });
+
+    function relativeLoadNote() {
+        return load?.vsTypicalPct > 0 && load.runsCompared >= 3
+            ? `${Math.round(load.vsTypicalPct)}% of typical`
+            : null;
+    }
+</script>
+
+<Card title="Last run" info={GLOSSARY.lastRun}>
+    {#snippet aside()}
+        {#if run}
+            <span class="when">{daysAgo(run.daysAgo)}</span>
+        {/if}
+    {/snippet}
+
+    {#if !run}
+        <p class="empty">Nothing synced yet.</p>
+    {:else}
+        <a class="title" href="https://www.strava.com/activities/{run.id}" target="_blank" rel="noreferrer">
+            {run.name}
+        </a>
+
+        <p class="tags">
+            {#if planned}
+                <span class="tag plan" title={run.plan.detail || ""}>{run.plan.type || "planned"}</span>
+            {:else}
+                <span class="tag extra">extra</span>
+            {/if}
+            {#if TAGS[run.workoutType]}<span class="tag">{TAGS[run.workoutType]}</span>{/if}
+            {#if run.effort}<span class="tag effort-{run.effort}">{run.effort}</span>{/if}
+            {#if planned && run.plan.distanceKm}<span class="planned-km">{run.plan.distanceKm} km asked for</span>{/if}
+        </p>
+
+        <div class="headline">
+            <div class="stat">
+                <strong>{formatDistance(run.distanceM)}</strong>
+                <span>distance</span>
+            </div>
+            <div class="stat">
+                <strong>{formatDuration(run.movingTimeSec)}</strong>
+                <span>moving</span>
+            </div>
+            <div class="stat">
+                <strong>{pace(run.paceSecPerKm)}</strong>
+                <span>average pace</span>
+            </div>
+            <div class="stat">
+                <strong>{run.averageHr ? `${Math.round(run.averageHr)}` : "—"}</strong>
+                <span>{run.maxHr ? `bpm · ${Math.round(run.maxHr)} max` : "bpm average"}</span>
+            </div>
+        </div>
+
+        {#if splits.length > 1}
+            <div class="chart">
+                <ChartFrame height={HEIGHT} {yTicks} {xTicks} label="Pace for each kilometre of the run">
+                    <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
+                        {#if averageY !== null}
+                            <line class="average" x1="0" x2={WIDTH} y1={averageY} y2={averageY} />
+                        {/if}
+                        {#if showGap}
+                            <path class="gap" d={linePath(gapPoints)} />
+                        {/if}
+                        <path class="line" d={linePath(pacePoints)} />
+                        {#each pacePoints as point, i}
+                            <circle class="dot" cx={point.x} cy={point.y} r="4">
+                                <title>km {splits[i].km} — {pace(splits[i].paceSecPerKm)}{splits[i].averageHr ? ` at ${Math.round(splits[i].averageHr)} bpm` : ""}</title>
+                            </circle>
+                        {/each}
+                    </svg>
+                </ChartFrame>
+                <p class="legend">
+                    kilometre · faster is higher
+                    {#if showGap}<span class="swatch gap-swatch"></span> grade adjusted{/if}
+                    {#if pacingNote}<span class="pacing">{pacingNote}</span>{/if}
+                </p>
+            </div>
+        {/if}
+
+        {#if changes.length}
+            <div class="impact">
+                <h3>What it did</h3>
+                <div class="changes">
+                    {#each changes as change (change.key)}
+                        <div class="change" class:good={change.good}>
+                            <span class="change-label">{change.label}</span>
+                            <strong>{signed(change.delta)}</strong>
+                            <span class="change-value">to {change.value.toFixed(1)}</span>
+                        </div>
+                    {/each}
+                </div>
+                <p class="verdict">
+                    {#if run.runsThatDay > 1}
+                        The day's change, across {run.runsThatDay} runs.
+                    {/if}
+                    {#if relativeSize}
+                        A {run.effort || "steady"} run, {relativeSize}{standout ? `, and ${standout}` : ""}.
+                    {/if}
+                </p>
+            </div>
+        {/if}
+
+        {#if facts.length}
+            <dl class="facts">
+                {#each facts as fact (fact.term)}
+                    <div>
+                        <dt>{fact.term}</dt>
+                        <dd>{fact.value}</dd>
+                        {#if fact.note}<dd class="note">{fact.note}</dd>{/if}
+                    </div>
+                {/each}
+            </dl>
+        {/if}
+    {/if}
+</Card>
+
+<style>
+    .when {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+    }
+
+    .title {
+        display: block;
+        font-family: var(--font-serif);
+        font-size: var(--font-lg);
+        font-weight: 600;
+        color: var(--header-colour);
+        text-decoration: none;
+        line-height: 1.2;
+    }
+    .title:hover { color: var(--main-green); }
+
+    .tags {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin: var(--space-2) 0 0;
+        font-size: var(--font-2xs);
+    }
+    .tag {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: var(--radius-pill);
+        background: var(--main-green-translucent);
+        color: var(--main-green);
+        font-weight: 600;
+        letter-spacing: 0.04em;
+    }
+    .tag.plan {
+        background: var(--tone-good-bg);
+        color: var(--tone-good);
+        text-transform: lowercase;
+    }
+    .tag.extra {
+        background: transparent;
+        border: 1px solid var(--main-green-translucent);
+        color: var(--paragraph-colour);
+        opacity: 0.8;
+    }
+    /* The effort a run turned out to be, which is not always the one it was
+       meant to be — worth its own colour rather than another green pill. */
+    .tag.effort-hard { background: var(--tone-bad-bg); color: var(--tone-bad); }
+    .tag.effort-moderate { background: var(--tone-warn-bg); color: var(--tone-warn); }
+    .tag.effort-easy { background: var(--tone-good-bg); color: var(--tone-good); }
+    .planned-km {
+        color: var(--paragraph-colour);
+        opacity: 0.65;
+    }
+
+    .headline {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+        gap: var(--space-3);
+        margin-top: var(--space-4);
+        padding: var(--space-3) var(--space-4);
+        background: var(--item-background);
+        border-radius: var(--radius-sm);
+    }
+    .stat { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+    .stat strong {
+        font-family: var(--font-serif);
+        font-size: var(--font-md);
+        font-weight: 700;
+        color: var(--header-colour);
+        line-height: 1.1;
+    }
+    .stat span {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--paragraph-colour);
+        opacity: 0.65;
+    }
+
+    .chart { margin-top: var(--space-5); }
+    .line {
+        fill: none;
+        stroke: var(--main-green);
+        stroke-width: 2;
+        stroke-linejoin: round;
+        vector-effect: non-scaling-stroke;
+    }
+    .dot {
+        fill: var(--main-green);
+        /* The line is stretched by the viewBox; a circle mustn't be. */
+        vector-effect: non-scaling-stroke;
+    }
+    .gap {
+        fill: none;
+        stroke: var(--paragraph-colour);
+        stroke-width: 1.5;
+        stroke-dasharray: 4 4;
+        opacity: 0.55;
+        vector-effect: non-scaling-stroke;
+    }
+    .average {
+        stroke: var(--header-colour);
+        stroke-width: 1;
+        stroke-dasharray: 2 5;
+        opacity: 0.45;
+        vector-effect: non-scaling-stroke;
+    }
+    .legend {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin: var(--space-2) 0 0;
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--paragraph-colour);
+        opacity: 0.55;
+    }
+    .swatch {
+        display: inline-block;
+        width: 14px;
+        height: 0;
+        border-top: 1.5px dashed var(--paragraph-colour);
+        margin-left: var(--space-2);
+    }
+    .pacing {
+        padding-left: var(--space-2);
+        border-left: 1px solid var(--main-green-translucent);
+        text-transform: none;
+        letter-spacing: 0;
+        opacity: 0.9;
+    }
+
+    .impact { margin-top: var(--space-5); }
+    .impact h3 {
+        margin: 0 0 var(--space-2);
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--main-green);
+        font-weight: 600;
+    }
+    .changes {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-2);
+    }
+    .change {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        padding: var(--space-3);
+        background: var(--item-background);
+        border-radius: var(--radius-sm);
+        border-left: 2px solid var(--main-green-translucent);
+    }
+    .change.good { border-left-color: var(--tone-good); }
+    .change-label {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+    }
+    .change strong {
+        font-family: var(--font-serif);
+        font-size: var(--font-md);
+        font-weight: 700;
+        color: var(--header-colour);
+        line-height: 1.2;
+    }
+    .change.good strong { color: var(--tone-good); }
+    .change-value {
+        font-size: var(--font-2xs);
+        color: var(--paragraph-colour);
+        opacity: 0.6;
+    }
+    .verdict {
+        margin: var(--space-3) 0 0;
+        font-size: var(--font-sm);
+        line-height: 1.5;
+        color: var(--paragraph-colour);
+    }
+
+    .facts {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(104px, 1fr));
+        gap: var(--space-3);
+        margin: var(--space-4) 0 0;
+    }
+    .facts div { display: flex; flex-direction: column; gap: 1px; }
+    dt {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--main-green);
+    }
+    dd {
+        margin: 0;
+        font-family: var(--font-serif);
+        font-size: var(--font-md);
+        font-weight: 600;
+        color: var(--header-colour);
+    }
+    dd.note {
+        font-family: inherit;
+        font-size: var(--font-2xs);
+        font-weight: 400;
+        color: var(--paragraph-colour);
+        opacity: 0.65;
+    }
+
+    .empty {
+        font-size: var(--font-sm);
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+        margin: 0;
+    }
+
+    @media (max-width: 540px) {
+        /* Three deltas side by side leave room for "+0.3" and nothing else. */
+        .changes { grid-template-columns: repeat(auto-fit, minmax(86px, 1fr)); }
+    }
+</style>

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -22,7 +22,7 @@
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
     import { linePath, niceScale, scaleLinear } from "../lib/chart.js";
-    import { daysAgo, formatDistance, formatDuration, km, pace, pct, signed } from "../lib/format.js";
+    import { daysAgo, formatDistance, formatDuration, pace, pct, signed } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { run = null } = $props();
@@ -39,6 +39,15 @@
 
     // Strava's workout_type, as the run log reads it.
     const TAGS = { 1: "Race", 2: "Long run", 3: "Workout" };
+
+    // And on the same terms as the log: Strava's label only earns space when
+    // it says something the plan match doesn't. "long run · Long run" doesn't.
+    const stravaTag = $derived.by(() => {
+        const tag = TAGS[run?.workoutType];
+        if (!tag) return null;
+        const planType = run?.plan?.planned ? String(run.plan.type || "") : "";
+        return tag.toLowerCase() === planType.toLowerCase() ? null : tag;
+    });
 
     const splits = $derived((run?.splits || []).filter((s) => s.paceSecPerKm > 0));
 
@@ -77,15 +86,17 @@
 
     const averageY = $derived(run?.paceSecPerKm > 0 ? y(run.paceSecPerKm) : null);
 
-    // A number under every kilometre is unreadable on a phone, so label the
-    // ends and every fifth in between, dropping any that would crowd the last.
+    // A number under every kilometre is unreadable on a phone, so thin them to
+    // about half a dozen: both ends, then an even step in between, dropping
+    // any that would crowd the last one.
+    const tickStep = $derived(Math.max(1, Math.ceil(splits.length / 6)));
     const xTicks = $derived(
         splits
             .map((s, i) => ({ s, i }))
             .filter(({ i }) => {
                 const last = splits.length - 1;
                 if (i === 0 || i === last) return true;
-                return (i + 1) % 5 === 0 && last - i >= 3;
+                return i % tickStep === 0 && last - i >= tickStep;
             })
             .map(({ s, i }) => ({
                 key: s.km,
@@ -116,19 +127,20 @@
     const relativeSize = $derived.by(() => {
         if (!(load?.vsTypicalPct > 0) || load.runsCompared < 3) return null;
         const ratio = load.vsTypicalPct;
-        if (ratio >= 140) return "much bigger than your usual run";
-        if (ratio >= 110) return "bigger than your usual run";
-        if (ratio > 90) return "about the size of your usual run";
-        if (ratio > 60) return "smaller than your usual run";
-        return "much smaller than your usual run";
+        if (ratio >= 140) return "much bigger than usual for you";
+        if (ratio >= 110) return "bigger than usual for you";
+        if (ratio > 90) return "about your usual size";
+        if (ratio > 60) return "smaller than usual for you";
+        return "much smaller than usual for you";
     });
 
     /** "…and the hardest in three weeks", where that's true and worth saying. */
     const standout = $derived.by(() => {
         if (!load || !(load.load > 0) || load.runsCompared < 5) return null;
         if (load.daysSinceAsHard === null) return "the hardest run of the block so far";
-        if (load.daysSinceAsHard >= 7) return `the hardest since ${daysAgo(load.daysSinceAsHard).toLowerCase()}`;
-        return null;
+        if (load.daysSinceAsHard < 7) return null;
+        const weeks = Math.round(load.daysSinceAsHard / 7);
+        return weeks === 1 ? "the hardest in a week" : `the hardest in ${weeks} weeks`;
     });
 
     const fade = $derived(run?.pacing?.fadePct ?? null);
@@ -148,12 +160,18 @@
             list.push({ term: "Load", value: Math.round(load.load), note: relativeLoadNote() });
         }
         if (week?.sharePct > 0) {
-            list.push({ term: "Of the week", value: pct(week.sharePct), note: `${km((week.targetKm || 0) * 1000)} planned` });
+            list.push({
+                term: "Of the week",
+                value: pct(week.sharePct),
+                note: `${Math.round(week.targetKm)} km target`,
+            });
         }
         if (run?.elevationGainM > 0) {
             list.push({ term: "Climb", value: `${Math.round(run.elevationGainM)} m` });
         }
-        if (run?.gapPaceSecPerKm > 0) {
+        // Only worth its own cell on a run where the hills moved it; on a flat
+        // one it's the average pace again, printed twice.
+        if (Math.abs((run?.gapPaceSecPerKm ?? 0) - (run?.paceSecPerKm ?? 0)) >= GAP_DIVERGENCE_SEC) {
             list.push({ term: "Grade adjusted", value: pace(run.gapPaceSecPerKm) });
         }
         if (run?.averageCadence > 0) {
@@ -199,7 +217,7 @@
             {:else}
                 <span class="tag extra">extra</span>
             {/if}
-            {#if TAGS[run.workoutType]}<span class="tag">{TAGS[run.workoutType]}</span>{/if}
+            {#if stravaTag}<span class="tag">{stravaTag}</span>{/if}
             {#if run.effort}<span class="tag effort-{run.effort}">{run.effort}</span>{/if}
             {#if planned && run.plan.distanceKm}<span class="planned-km">{run.plan.distanceKm} km asked for</span>{/if}
         </p>
@@ -242,8 +260,10 @@
                     </svg>
                 </ChartFrame>
                 <p class="legend">
-                    kilometre · faster is higher
-                    {#if showGap}<span class="swatch gap-swatch"></span> grade adjusted{/if}
+                    <span>kilometre · faster is higher</span>
+                    <!-- Swatch and label in one span: wrapped apart, a dash
+                         sitting alone at the end of a line is just a dash. -->
+                    {#if showGap}<span class="key"><span class="swatch"></span> grade adjusted</span>{/if}
                     {#if pacingNote}<span class="pacing">{pacingNote}</span>{/if}
                 </p>
             </div>
@@ -409,12 +429,17 @@
         color: var(--paragraph-colour);
         opacity: 0.55;
     }
+    .key {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        white-space: nowrap;
+    }
     .swatch {
         display: inline-block;
         width: 14px;
         height: 0;
         border-top: 1.5px dashed var(--paragraph-colour);
-        margin-left: var(--space-2);
     }
     .pacing {
         padding-left: var(--space-2);

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -143,14 +143,26 @@
         return weeks === 1 ? "the hardest in a week" : `the hardest in ${weeks} weeks`;
     });
 
+    // A workout is meant to have uneven halves — intervals, then a jog home —
+    // and the same is true of the drift between them. Both read as a verdict on
+    // a steady run and as a description of a hard one.
+    const steady = $derived(run?.effort !== "hard");
+
     const fade = $derived(run?.pacing?.fadePct ?? null);
-    const pacingNote = $derived.by(() => {
-        if (fade === null) return null;
-        if (fade <= -2) return "negative split — the second half was quicker";
-        if (fade < 2) return "even pace, start to finish";
-        if (fade < 5) return `faded ${fade.toFixed(1)}% over the second half`;
-        return `faded ${fade.toFixed(1)}% — the second half cost you`;
-    });
+    const pacingNote = $derived(fade === null ? null : (steady ? heldOrFaded(fade) : halves(fade)));
+
+    function heldOrFaded(pct) {
+        if (pct <= -2) return "negative split — the second half was quicker";
+        if (pct < 2) return "even pace, start to finish";
+        if (pct < 5) return `faded ${pct.toFixed(1)}% over the second half`;
+        return `faded ${pct.toFixed(1)}% — the second half cost you`;
+    }
+
+    function halves(pct) {
+        if (Math.abs(pct) < 2) return "even halves";
+        const direction = pct > 0 ? "slower" : "quicker";
+        return `second half ${Math.abs(pct).toFixed(1)}% ${direction}`;
+    }
 
     // Only what this run actually recorded: a facts grid with "—" in half of
     // its cells says less than a shorter grid.
@@ -177,7 +189,11 @@
         if (run?.averageCadence > 0) {
             list.push({ term: "Cadence", value: `${Math.round(run.averageCadence * STEPS_PER_CYCLE)} spm` });
         }
-        if (Number.isFinite(run?.decouplingPct)) {
+        // Drift measures how far pace-per-heartbeat slipped between the halves
+        // of a run held at one effort. On an interval session it measures the
+        // intervals, and 34% doesn't mean what it means on a long run — so it
+        // sits out the ones it can't describe, as the efficiency trend does.
+        if (steady && Number.isFinite(run?.decouplingPct)) {
             list.push({
                 term: "Drift",
                 value: `${run.decouplingPct.toFixed(1)}%`,

--- a/src/components/Training/sections/WeekPlan.svelte
+++ b/src/components/Training/sections/WeekPlan.svelte
@@ -17,11 +17,11 @@
             ? Math.min(100, (currentWeek.actualKm / currentWeek.targetKm) * 100)
             : null,
     );
-    const longRunProgress = $derived(
-        currentWeek?.longRunTargetKm > 0
-            ? Math.min(100, (currentWeek.actualLongRunKm / currentWeek.longRunTargetKm) * 100)
-            : null,
-    );
+
+    // The long run is one session on one day, so it gets a line rather than a
+    // bar: a bar would fill up all week on whichever easy run happened to be
+    // the longest so far, which is not a long run in progress.
+    const longRun = $derived(week?.longRun || null);
 
     // A day is only "missed" once it's over. Today's session is still ahead of
     // you at 8am, and calling it missed would be both wrong and demoralising.
@@ -65,18 +65,24 @@
             {/if}
         </div>
 
-        <div class="metric">
-            <div class="metric-head">
-                <span>Long run</span>
-                <strong>
-                    {currentWeek.actualLongRunKm.toFixed(1)} km
-                    {#if currentWeek.longRunTargetKm}<span class="target">of {currentWeek.longRunTargetKm}</span>{/if}
-                </strong>
-            </div>
-            {#if longRunProgress !== null}
-                <div class="track"><div class="fill" style="width: {longRunProgress}%"></div></div>
-            {/if}
-        </div>
+        {#if longRun}
+            <p class="long-run {longRun.status}">
+                <span class="long-run-label">Long run</span>
+                <!-- A distance actually run is what says it happened, so the
+                     done state doesn't need a word for it; the other two do. -->
+                {#if longRun.status === "done"}
+                    <strong>{longRun.actualKm.toFixed(1)} km</strong>
+                    <span class="long-run-note">
+                        {longRun.targetKm ? `of ${longRun.targetKm} · ` : ""}{weekday(longRun.date)}
+                    </span>
+                {:else}
+                    <strong>{longRun.targetKm ? `${longRun.targetKm} km` : "planned"}</strong>
+                    <span class="long-run-note">
+                        · {weekday(longRun.date)}{longRun.status === "missed" ? " · not run" : ""}
+                    </span>
+                {/if}
+            </p>
+        {/if}
 
         {#if days.length}
             <ol class="days">
@@ -198,6 +204,29 @@
         opacity: 0.55;
         margin: 0;
     }
+
+    .long-run {
+        display: flex;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin: 0 0 var(--space-4) 0;
+        font-size: var(--font-xs);
+    }
+    .long-run-label {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--main-green);
+    }
+    .long-run strong {
+        font-family: var(--font-serif);
+        font-weight: 600;
+        color: var(--header-colour);
+    }
+    .long-run.done strong { color: var(--tone-good); }
+    .long-run.missed strong { color: var(--tone-warn); }
+    .long-run-note { color: var(--paragraph-colour); opacity: 0.6; }
 
     .days {
         list-style: none;

--- a/src/lib/ui/layoutStore.js
+++ b/src/lib/ui/layoutStore.js
@@ -3,33 +3,46 @@
 // reorder.svelte.js) so it can be tested without compiling runes — this is
 // where the interesting failure cases are.
 
-/**
- * A stored layout is only usable if it is still a permutation of the panels
- * the page has today: same length, no duplicates, no unknown ids.
- */
-function isPermutationOf(stored, defaults) {
-	return stored.length === defaults.length
-		&& new Set(stored).size === stored.length
-		&& stored.every((id) => defaults.includes(id));
+/** The stored ids the page still has panels for, in the order they were saved. */
+function keepKnown(stored, defaults) {
+	const known = new Set(defaults);
+	return [...new Set(stored.filter((id) => known.has(id)))];
 }
 
 /**
- * A renamed panel, a truncated write, or a layout saved by an older version of
- * the page all fail validation and fall back to the default, which is much
- * better than rendering a grid with holes or duplicates in it.
+ * Put back whatever the stored layout didn't account for, each at the position
+ * it holds by default. A panel added since the layout was saved therefore turns
+ * up where the page meant it to be, and everything already arranged keeps its
+ * order around it.
+ */
+function withMissing(layout, defaults) {
+	const filled = [...layout];
+	for (const [idx, id] of defaults.entries()) {
+		if (!filled.includes(id)) {
+			filled.splice(Math.min(idx, filled.length), 0, id);
+		}
+	}
+	return filled;
+}
+
+/**
+ * Reconcile a stored layout with the panels the page has today.
+ *
+ * Anything that can't be trusted is discarded rather than rendered: a duplicate
+ * would draw one panel twice, an unknown id would draw a hole. What is trusted
+ * is the order — so adding or removing a panel costs the reader the position of
+ * that one panel, not the arrangement they made.
  *
  * @param {unknown} stored parsed value from storage.
  * @param {string[]} defaults the page's default order.
- * @returns {string[] | null} the layout, or null if it can't be trusted.
+ * @returns {string[] | null} a full layout, or null if there was nothing to
+ *   read at all.
  */
 function validateLayout(stored, defaults) {
 	if (!Array.isArray(stored)) {
 		return null;
 	}
-	if (!isPermutationOf(stored, defaults)) {
-		return null;
-	}
-	return [...stored];
+	return withMissing(keepKnown(stored, defaults), defaults);
 }
 
 /**
@@ -96,8 +109,4 @@ function swapSlots(layout, srcIdx, dstIdx) {
 	});
 }
 
-// Exported down here rather than inline. Static analysis reads this repo's JS
-// with a parser that predates ES modules: an `export` keyword mid-file makes
-// it lose the thread and misread everything after it, which it then reports as
-// phantom findings against the try/catch above. A trailing list parses.
 export { validateLayout, readLayout, writeLayout, swapSlots };

--- a/src/lib/ui/layoutStore.test.js
+++ b/src/lib/ui/layoutStore.test.js
@@ -15,14 +15,24 @@ describe("validateLayout", () => {
 		expect(stored[0]).toBe("c");
 	});
 
-	it("rejects a layout from a version with different panels", () => {
-		expect(validateLayout(["a", "b", "gone"], DEFAULTS)).toBeNull();
-		expect(validateLayout(["a", "b"], DEFAULTS)).toBeNull();
-		expect(validateLayout(["a", "b", "c", "d"], DEFAULTS)).toBeNull();
+	// Adding a panel used to cost everyone the arrangement they'd made, since
+	// a saved list of three isn't a permutation of four.
+	it("keeps the saved order and slots a new panel into its default place", () => {
+		expect(validateLayout(["c", "a", "b"], ["a", "b", "c", "d"])).toEqual(["c", "a", "b", "d"]);
+		expect(validateLayout(["c", "a", "b"], ["new", "a", "b", "c"])).toEqual(["new", "c", "a", "b"]);
 	});
 
-	it("rejects duplicates, which would leave a slot empty", () => {
-		expect(validateLayout(["a", "a", "b"], DEFAULTS)).toBeNull();
+	it("drops a panel the page no longer has", () => {
+		expect(validateLayout(["a", "b", "gone", "c"], DEFAULTS)).toEqual(["a", "b", "c"]);
+	});
+
+	it("drops duplicates, which would otherwise leave a slot empty", () => {
+		expect(validateLayout(["a", "a", "b"], DEFAULTS)).toEqual(["a", "b", "c"]);
+	});
+
+	it("always returns a full layout, whatever it was handed", () => {
+		expect(validateLayout([], DEFAULTS)).toEqual(DEFAULTS);
+		expect(validateLayout([1, 2, 3], DEFAULTS)).toEqual(DEFAULTS);
 	});
 
 	it("rejects anything that isn't an array", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The dashboard could tell you how twelve weeks were going but not how this morning went. Every panel on it is trend-shaped, and none of them answer the question you actually have on the walk home: what that run was, and what it changed.

Here it is on the deploy preview, against a real tempo session:

[The last-run panel showing a real 9.3 km tempo run](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flastrun-real-tempo.png)

## The data was already there

The sync stores per-kilometre splits, time in each heart-rate zone, aerobic decoupling and a load score for every activity. `publicRun()` strips all of it on the way out — reasonable for a log that draws two numbers a row, but it means none of it is derivable in the browser. `publicLastRun()` is a second, wider allow-list for the one run being read in detail, and `lastRun.js` reads that run against the athlete's own recent history, because none of these numbers mean anything alone: a load of 90 is a big day or an ordinary Tuesday depending entirely on whose 90 it is.

## What the panel says

Three questions, in the order you'd ask them.

**What it was** — distance, time, pace, heart rate; the session the plan asked for, or a tag saying it was extra; and whether it turned out easy, moderate or hard by where the heart rate actually sat rather than what it was labelled.

**How it went** — pace for every kilometre, plotted with faster higher up and the axis labelled in paces so there's nothing to translate. The run's own average is dotted across it; grade-adjusted pace goes over the top only when the hills made the two differ.

**What it changed** — what the day did to fitness, fatigue and form, each with a signed delta; what fraction of the week's target the run delivered; and how its load compares with the median run of the last six weeks, including how long it's been since one cost as much.

Everything degrades: a run with no heart-rate strap loses the zone mix and gets its effort from grade-adjusted pace, a run too short to halve says nothing about pacing, and a first-day-of-block run has no day before it to compare against.

[The panel at 390px](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Flastrun-real-phone.png)

## The long run was being filled in by every other run

Reported separately: "This week" had a long-run progress bar beside the volume one, and the two were drawn from the same kilometres. The target came from the plan's long-run session, correctly, but the actual was the week's longest run *so far* — whatever that run happened to be. Tuesday's 9 km easy run therefore put 9 km into both bars, and by Saturday a long run that hadn't been started looked two thirds done.

A long run is one session on one day, so it's now answered as a question about that day: still ahead of you, done, or gone by. It's day-anchored like the rest of the plan matching, so a long run moved to Saturday reads as a missed Sunday and an extra Saturday — the story the day list directly below it already tells. A double takes the longer run of the day rather than the day's total, since a shakeout afterwards isn't more long run. The bar is gone, along with `actualLongRunKm` and `longRunPct`, which existed only to draw it; `longRunShare`, the share of a *completed* week taken by its longest run, is a different measure and is untouched.

[The week panel with one bar and the long run as a line](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fweek-long-run.png)

## Balancing the columns

The slots are fixed and the columns are independent, so a heavy column doesn't pull anything up beside it — it just ends further down the page. With the last run and the recommendations, the two tallest panels, both on the left, it finished a thousand pixels below the right: 2566px against 1562px, a column of white space down one side.

Every panel was measured and two moved. Projected finish goes left, the recommendations and the week go right, which lands the columns 45px apart on real data and reads as a split rather than a shuffle: how the training is going down the left, what to do about it and what's on down the right. An e2e test holds them to within a quarter of each other, since hand-balancing is exactly the sort of thing that rots the next time a panel is added. The layout storage key is versioned, because an arrangement saved against the old order would keep the imbalance this fixes.

[Both columns ending on the same line](https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbalanced-columns.png)

## What the deploy preview changed

Running against real Strava data rather than the fixture turned up three things no test would have caught.

A 10.0 km run has eleven splits, and the eleventh is a 34 m tail. Its "pace" is where you happened to stop — 9:40/km — which stretched the chart's axis from five minutes to ten and flattened the run itself into the top inch. Whole kilometres only now, via a `WHOLE_SPLIT_M` rule shared with the fastest/slowest ranking that already had it; the fragment still counts in the halves, weighted by its own short distance. The e2e fixture generates that stub too, since inventing runs that end on round numbers is what hid it.

The last real run was a tempo session, and the panel narrated it like a long run: "Drift 34.2% — ahead of the base", when decoupling between the halves of an interval session is measuring the intervals, and "faded 12.6% — the second half cost you", when a workout is supposed to have uneven halves. Drift now sits out the runs it can't describe, the same way the efficiency trend excludes non-aerobic ones, and the fade is stated rather than judged on anything hard.

## On serving splits

Per-kilometre data is the one thing this site has never served, and `shape.js` says why: with coordinates gone, a hill profile is the closest thing left to a route. So the per-kilometre elevation stays behind. Pace, grade adjustment and heart rate describe an effort rather than a place, and the total climb was already on the log. The existing end-to-end privacy test covers the new field, and a new one pins the exact key set.

## Also here

Saved layouts are now reconciled against the panels the page has rather than discarded. A stored list of nine ids isn't a permutation of ten, so adding the last-run panel would have quietly reset the arrangement of anyone who had made one; now the saved order is kept, unknown ids are dropped, and the newcomer is slotted into its default position.

The new JavaScript is written to the analyser's stricter profile — braces on every guard, functions under its complexity ceiling, Strava's field names quoted, `.at()` and `findLast()` instead of computed indexing — matching how `reorder`, `editMode` and `layoutStore` were already written. The older engine files keep their one-line guards; nothing here rewrites them.

## Verification

- 525 unit tests, including 23 for the last-run module and 7 for the week's long run, covering the form deltas either side of a run, the six-week load comparison, pacing halves, the zone rollup, the closing fragment, a long run moved, doubled and missed, and every degraded path.
- 19 Playwright specs. New ones assert the last-run panel's three parts, that the week has exactly one progress bar, and that neither column runs on past the other; the drag tests were made order-agnostic and taught to scroll two tall panels onto the screen together.
- The e2e fixture now synthesises heart-rate streams and a trailing partial kilometre, so zone time, aerobic drift and the split-fragment rule are exercised rather than rendering their absent paths.
- Checked on the deploy preview against real runs at desktop and phone widths — which is where several of these commits came from.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

