### PR TITLE
Left-align the home section titles again, and note Chicago in the running modal

### DIFF
--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -278,6 +278,13 @@ video::-webkit-media-controls-overlay-play-button {
     letter-spacing: -0.02em;
 }
 
+/* `.grid-container h1` centres every h1 in the layout and outranks the rule
+   above on specificity, so the left alignment it asks for never landed. Only
+   section titles are named here — the profile name stays centred. */
+.grid-container h1.section-title {
+    text-align: left;
+}
+
 .blog-subsection {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/components/Home/sections/Intro.svelte
+++ b/src/components/Home/sections/Intro.svelte
@@ -161,7 +161,7 @@
             icon: 'running',
             modal: {
                 image: 'run',
-                description: 'Running the 2025 <a href="https://www.torontowaterfrontmarathon.com/" rel="noreferrer" target="_blank">Toronto Waterfront Half Marathon</a>',
+                description: 'Running the 2025 <a href="https://www.torontowaterfrontmarathon.com/" rel="noreferrer" target="_blank">Toronto Waterfront Half Marathon</a><br>Training for the 2026 <a href="/training">Chicago Marathon</a>.',
                 strava: 'run'
             }
         },


### PR DESCRIPTION
## Summary

Two small home page fixes.

**Section titles were centred by accident.** `.section-title` has always asked for `text-align: left`, but `.grid-container h1` centres every h1 in the layout and outranks it on specificity (0,1,1 vs 0,1,0). What was actually winning was the inline `style="text-align: left"` on each heading — so when `7e59c30` removed those as redundant, Experience, Projects and Foundations silently became centred.

Fixed by saying it once at a weight that sticks, naming section titles specifically so nothing else moves.

**The running modal now mentions the Chicago block** and links to `/training`, using the same `<br>` + link pattern the photos entry already uses for a second line.

## Test plan

- [x] Build clean
- [x] Verified computed `textAlign` in the browser: `Experience`, `Projects` and `Foundations` are now `left`
- [x] Verified the profile name (`h1.profile-name`) is still `center`, and the `h2` subheadings under it (`SDE @ Wealthsimple`, `Toronto, ON`) are still `center`
- [x] Opened the running modal and confirmed both lines render, that `Chicago Marathon` links to `/training`, and that the existing Toronto Waterfront link is unchanged
- [x] No console errors
- [ ] Deploy preview: sanity-check the headings at mobile widths (no `text-align` rule differs by breakpoint, so none should move, but worth a look)

Made with [Cursor](https://cursor.com)