### PR TITLE
Track rides as fatigue, and nothing else

### DIFF
--- a/netlify/functions/_shared/training/fitness.js
+++ b/netlify/functions/_shared/training/fitness.js
@@ -32,6 +32,8 @@ export const ACWR_CEILING = 1.5;
 // The conventional cap on week-over-week volume growth.
 export const SAFE_RAMP_PCT = 10;
 
+const asMap = (loads) => (loads instanceof Map ? loads : new Map(Object.entries(loads || {})));
+
 /**
  * Daily fitness/fatigue/form series across a date range.
  *
@@ -39,12 +41,21 @@ export const SAFE_RAMP_PCT = 10;
  * what lets fatigue actually decay during a taper — so the range is filled in
  * densely rather than iterating only the days that have activities.
  *
- * @param {Map<string, number>|object} loadsByDay day key to total load.
- * @param {{from: string, to: string}} range
+ * Fitness and fatigue can be fed from different books. Cross-training is the
+ * reason: a long ride genuinely costs you recovery, so it belongs in fatigue,
+ * but it builds none of the running-specific durability that CTL is standing in
+ * for here, and letting it inflate fitness would flatter a marathon build for
+ * work the legs never did. Pass `fatigueLoadsByDay` to say "these days cost
+ * this much, even though only some of it was running".
+ *
+ * @param {Map<string, number>|object} loadsByDay day key to running load.
+ * @param {{from: string, to: string, fatigueLoadsByDay?: Map<string, number>|object}} range
  * @returns {{date: string, load: number, ctl: number, atl: number, tsb: number}[]}
+ *   `load` is the running load for the day; fatigue may have been fed more.
  */
-export function fitnessSeries(loadsByDay, { from, to }) {
-	const lookup = loadsByDay instanceof Map ? loadsByDay : new Map(Object.entries(loadsByDay || {}));
+export function fitnessSeries(loadsByDay, { from, to, fatigueLoadsByDay = null }) {
+	const lookup = asMap(loadsByDay);
+	const fatigueLookup = fatigueLoadsByDay ? asMap(fatigueLoadsByDay) : lookup;
 	const days = eachDay(from, to);
 	if (days.length === 0) return [];
 
@@ -58,7 +69,7 @@ export function fitnessSeries(loadsByDay, { from, to }) {
 		const tsb = ctl - atl;
 		const load = Number(lookup.get(date)) || 0;
 		ctl += (load - ctl) * ctlAlpha;
-		atl += (load - atl) * atlAlpha;
+		atl += ((Number(fatigueLookup.get(date)) || 0) - atl) * atlAlpha;
 		return { date, load, ctl, atl, tsb };
 	});
 }

--- a/netlify/functions/_shared/training/load.js
+++ b/netlify/functions/_shared/training/load.js
@@ -120,6 +120,13 @@ export function activityLoad(activity, thresholds = {}) {
 	const trimp = banisterTrimp(durationSec, activity?.averageHr, thresholds);
 	if (trimp !== null) return { load: normalizeTrimp(trimp), method: "hr" };
 
+	// TRIMP is the one part of this model that doesn't care which sport you
+	// did — heart-rate reserve is heart-rate reserve. The fallback below very
+	// much does care: it reads a threshold *running* pace, so applying it to a
+	// bike would invent load out of the fact that bikes are faster. A ride
+	// without heart rate is therefore unscored rather than guessed at.
+	if (activity?.sport === "ride") return null;
+
 	const gap =
 		Number(activity?.gapPaceSecPerKm) ||
 		activityGap(activity)?.gapPaceSecPerKm ||

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -98,16 +98,31 @@ function planDays(week, runs, today) {
  */
 export function buildDashboard({ activities = [], plan = {}, today }) {
 	const day = toDayKey(today) || toDayKey(new Date());
-	const runs = [...activities].sort((a, b) =>
+	const sorted = [...activities].sort((a, b) =>
 		String(a.startDateLocal).localeCompare(String(b.startDateLocal)),
 	);
+
+	// Everything on this page is a running measure unless it says otherwise.
+	// Rides are held apart from the first line so that volume, long-run share,
+	// intensity, efficiency, race prediction and the acute:chronic ratio all
+	// keep meaning exactly what they meant before rides existed.
+	const runs = sorted.filter((a) => a?.sport !== "ride");
+	const rides = sorted.filter((a) => a?.sport === "ride");
 
 	const thresholds = plan?.thresholds || {};
 	const race = plan?.race || {};
 	const range = blockRange(plan, runs, day);
 
 	const loads = dailyLoads(runs);
-	const series = range ? fitnessSeries(loads, range) : [];
+	// The one place a ride is allowed to count. It reaches fatigue, because a
+	// long ride genuinely leaves you less ready for tomorrow's session, and
+	// stops there — it earns no fitness and, deliberately, no place in ACWR,
+	// whose injury-risk evidence is about the tissue loading of the sport being
+	// ramped. Cycling load in that ratio would dilute the best warning here.
+	const fatigueLoads = rides.length > 0 ? dailyLoads(sorted) : null;
+	const series = range
+		? fitnessSeries(loads, { ...range, fatigueLoadsByDay: fatigueLoads })
+		: [];
 	// Report against today, not the end of the block — the series runs forward
 	// to race day, where CTL has decayed to nothing because no runs exist yet.
 	const latest = series.find((d) => d.date === day) || series.at(-1) || null;
@@ -287,9 +302,18 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 		// allows out.
 		runs: (() => {
 			const from = Math.max(0, runs.length - RUN_LOG_LIMIT);
-			return runs
+			const logged = runs
 				.slice(from)
-				.map((run, i) => ({ ...publicRun(run), plan: planMatches[from + i] }))
+				.map((run, i) => ({ ...publicRun(run), plan: planMatches[from + i] }));
+			// Rides join the log across the span it already covers rather than
+			// competing for its thirty places. This stays a log of runs that
+			// admits what else was tiring you out, not a feed of everything.
+			const earliest = toDayKey(logged[0]?.startDateLocal);
+			const alongside = earliest
+				? rides.filter((r) => toDayKey(r.startDateLocal) >= earliest).map(publicRun)
+				: [];
+			return [...logged, ...alongside]
+				.sort((a, b) => String(a.startDateLocal).localeCompare(String(b.startDateLocal)))
 				.reverse();
 		})(),
 		thresholds,

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -422,3 +422,97 @@ describe("buildDashboard privacy, end to end", () => {
 		]);
 	});
 });
+
+// A ride is allowed to make you tired and nothing else. These are the lines it
+// must not cross: every running measure on the page has to read the same with
+// a ride in the block as without one.
+describe("buildDashboard with rides", () => {
+	const RIDE = {
+		id: 9001,
+		name: "Long ride",
+		sport: "ride",
+		type: "Ride",
+		// Yesterday, so its fatigue has actually landed by today. Form is read
+		// from the state you woke up with, so a ride logged this morning
+		// rightly hasn't reached today's number yet.
+		startDateLocal: "2026-08-10T07:00:00",
+		distanceM: 60000,
+		movingTimeSec: 7200,
+		averageHr: 140,
+		load: 90,
+	};
+
+	const runsOnly = () =>
+		buildDashboard({ activities: block("2026-08-11", 10), plan: PLAN, today: "2026-08-11" });
+	const withRide = () =>
+		buildDashboard({
+			activities: [...block("2026-08-11", 10), RIDE],
+			plan: PLAN,
+			today: "2026-08-11",
+		});
+
+	it("leaves weekly volume and long-run share to the runs", () => {
+		const before = runsOnly();
+		const after = withRide();
+		expect(after.weeks.map((w) => w.distanceM)).toEqual(before.weeks.map((w) => w.distanceM));
+		expect(after.weeks.map((w) => w.longRunSharePct)).toEqual(
+			before.weeks.map((w) => w.longRunSharePct),
+		);
+		// 60 km on a bike is not a 60 km long run.
+		expect(after.weeks.every((w) => w.longestRunM <= 12000)).toBe(true);
+	});
+
+	it("keeps rides out of the acute:chronic ratio", () => {
+		// ACWR earns its keep as a running injury signal, and cycling doesn't
+		// load the same tissues. Diluting it would cost more than it adds.
+		expect(withRide().summary.acwr).toEqual(runsOnly().summary.acwr);
+	});
+
+	it("leaves totals, intensity and race prediction untouched", () => {
+		const before = runsOnly();
+		const after = withRide();
+		expect(after.summary.totals).toEqual(before.summary.totals);
+		expect(after.summary.intensity).toEqual(before.summary.intensity);
+		expect(after.summary.prediction).toEqual(before.summary.prediction);
+	});
+
+	it("builds no fitness", () => {
+		expect(withRide().summary.latest.ctl).toBeCloseTo(runsOnly().summary.latest.ctl, 10);
+	});
+
+	it("costs fatigue, and so costs form", () => {
+		const before = runsOnly();
+		const after = withRide();
+		expect(after.summary.latest.atl).toBeGreaterThan(before.summary.latest.atl);
+		// Form is fitness minus fatigue, so a ride you haven't recovered from
+		// should leave you reading as less ready, not more.
+		expect(after.summary.latest.tsb).toBeLessThan(before.summary.latest.tsb);
+	});
+
+	it("shows the ride in the log, in date order, marked as a ride", () => {
+		const log = withRide().runs;
+		const ride = log.find((a) => a.id === RIDE.id);
+		expect(ride).toBeTruthy();
+		expect(ride.sport).toBe("ride");
+		expect(ride.load).toBe(90);
+		expect(log.filter((a) => a.sport === "run")).toHaveLength(10);
+		const dates = log.map((a) => a.startDateLocal);
+		expect([...dates].sort().reverse()).toEqual(dates);
+	});
+
+	it("does not displace runs from the log", () => {
+		expect(withRide().runs.filter((a) => a.sport === "run")).toHaveLength(
+			runsOnly().runs.length,
+		);
+	});
+
+	it("treats a record with no sport as a run, as every stored one is", () => {
+		// Everything already in Blobs was written before rides were tracked,
+		// and is served for as long as it takes the sync to re-shape it.
+		const legacy = block("2026-08-11", 3);
+		expect(legacy.every((a) => a.sport === undefined)).toBe(true);
+		const out = buildDashboard({ activities: legacy, plan: PLAN, today: "2026-08-11" });
+		expect(out.summary.totals.runs).toBe(3);
+		expect(out.runs.every((a) => a.sport === "run")).toBe(true);
+	});
+});

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -28,6 +28,18 @@ import { toDayKey } from "./dates.js";
 // (VirtualRun) — the training stress is real even if the GPS isn't.
 const RUN_TYPES = new Set(["Run", "TrailRun", "VirtualRun"]);
 
+// Rides are tracked for one reason: they cost recovery. They build no
+// running-specific durability, so they're kept well away from weekly volume,
+// long-run share and the acute:chronic ratio (see metrics.js) — they only ever
+// reach fatigue.
+const RIDE_TYPES = new Set(["Ride", "GravelRide", "MountainBikeRide", "VirtualRide"]);
+
+// Below this a ride is transport, not training. A few kilometres to the office
+// costs nothing worth modelling, and letting commutes through would put a small
+// bump of fatigue on most weekdays — enough to drag form down and make the
+// model answer for rides that were never training in the first place.
+export const RIDE_MIN_M = 20000;
+
 // Stamped onto every stored record. Several fields here are derived at sync
 // time from streams we don't keep (zone seconds, decoupling, GAP), so changing
 // how they're computed can't retroactively fix what's already in Blobs. Bumping
@@ -37,7 +49,8 @@ const RUN_TYPES = new Set(["Run", "TrailRun", "VirtualRun"]);
 // Bump on any change to the derived fields below or the maths behind them.
 // 2: HR zone floors moved to heart-rate reserve; GAP anchored to moving time
 //    and no longer thrown off by stopped time or GPS jumps.
-export const SHAPE_VERSION = 2;
+// 3: records carry `sport`, and rides over RIDE_MIN_M are tracked.
+export const SHAPE_VERSION = 3;
 
 /**
  * Is this a public run we should track?
@@ -48,6 +61,28 @@ export const SHAPE_VERSION = 2;
 export function isTrackableRun(raw) {
 	if (!raw || raw.private === true) return false;
 	return RUN_TYPES.has(raw.sport_type || raw.type);
+}
+
+/**
+ * Is this a ride long enough to have cost anything?
+ *
+ * @param {object} raw a Strava summary or detailed activity.
+ * @returns {boolean}
+ */
+export function isTrackableRide(raw) {
+	if (!raw || raw.private === true) return false;
+	if (!RIDE_TYPES.has(raw.sport_type || raw.type)) return false;
+	return (reading(raw.distance) || 0) > RIDE_MIN_M;
+}
+
+/**
+ * Is this anything the dashboard tracks at all?
+ *
+ * @param {object} raw a Strava summary or detailed activity.
+ * @returns {boolean}
+ */
+export function isTrackableActivity(raw) {
+	return isTrackableRun(raw) || isTrackableRide(raw);
 }
 
 // What counts as a kilometre when reading splits. A run almost never ends on a
@@ -111,7 +146,8 @@ function shapeBestEfforts(efforts, startDateLocal) {
  *   carries nothing measurable.
  */
 export function shapeActivity(raw, options = {}) {
-	if (!isTrackableRun(raw)) return null;
+	const isRide = isTrackableRide(raw);
+	if (!isRide && !isTrackableRun(raw)) return null;
 
 	const { streams = null, thresholds = {}, athleteZones = null } = options;
 
@@ -119,17 +155,23 @@ export function shapeActivity(raw, options = {}) {
 	const movingTimeSec = reading(raw.moving_time) || 0;
 	if (!(distanceM > 0) || !(movingTimeSec > 0)) return null;
 
-	const splits = shapeSplits(raw.splits_metric);
-	const gap = activityGap({
-		streams,
-		splits: raw.splits_metric,
-		distanceM,
-		movingTimeSec,
-	});
+	// Pace, grade adjustment, per-kilometre splits and best efforts are all
+	// foot-running measures. A bike's versions would be arithmetically valid
+	// and thoroughly misleading sitting in a column beside a run's, so a ride
+	// carries none of them rather than carrying numbers nobody should read.
+	const splits = isRide ? [] : shapeSplits(raw.splits_metric);
+	const gap = isRide
+		? null
+		: activityGap({
+				streams,
+				splits: raw.splits_metric,
+				distanceM,
+				movingTimeSec,
+			});
 
 	const floors = hrZoneFloors(thresholds, athleteZones);
 	const zoneSeconds = floors ? zoneSecondsFromStreams(streams, floors) : null;
-	const decoupling = aerobicDecoupling(streams);
+	const decoupling = isRide ? null : aerobicDecoupling(streams);
 
 	const averageHr = Number.isFinite(reading(raw.average_heartrate))
 		? reading(raw.average_heartrate)
@@ -138,7 +180,8 @@ export function shapeActivity(raw, options = {}) {
 	const shaped = {
 		id: raw.id,
 		v: SHAPE_VERSION,
-		name: String(raw.name || "Run"),
+		name: String(raw.name || (isRide ? "Ride" : "Run")),
+		sport: isRide ? "ride" : "run",
 		type: raw.sport_type || raw.type,
 		startDateLocal: raw.start_date_local || raw.start_date || null,
 		distanceM,
@@ -151,13 +194,15 @@ export function shapeActivity(raw, options = {}) {
 		sufferScore: Number.isFinite(reading(raw.suffer_score)) ? reading(raw.suffer_score) : null,
 		// 1 = race, 2 = long run, 3 = workout, 0/null = default.
 		workoutType: Number.isFinite(reading(raw.workout_type)) ? reading(raw.workout_type) : null,
-		paceSecPerKm: movingTimeSec / (distanceM / 1000),
+		paceSecPerKm: isRide ? null : movingTimeSec / (distanceM / 1000),
 		gapPaceSecPerKm: gap?.gapPaceSecPerKm ?? null,
 		gapSource: gap?.source ?? null,
 		zoneSeconds,
 		decouplingPct: decoupling?.decouplingPct ?? null,
 		splits,
-		bestEfforts: shapeBestEfforts(raw.best_efforts, raw.start_date_local || raw.start_date),
+		bestEfforts: isRide
+			? []
+			: shapeBestEfforts(raw.best_efforts, raw.start_date_local || raw.start_date),
 	};
 
 	const load = activityLoad(shaped, thresholds);
@@ -186,6 +231,9 @@ export function publicRun(activity) {
 	return {
 		id: activity?.id,
 		name: activity?.name,
+		// Records written before rides were tracked have no `sport`, and every
+		// one of them is a run.
+		sport: activity?.sport === "ride" ? "ride" : "run",
 		type: activity?.type,
 		startDateLocal: activity?.startDateLocal,
 		distanceM: activity?.distanceM,
@@ -195,6 +243,9 @@ export function publicRun(activity) {
 		workoutType: activity?.workoutType,
 		paceSecPerKm: activity?.paceSecPerKm,
 		gapPaceSecPerKm: activity?.gapPaceSecPerKm,
+		// What the session cost. It's the only thing a ride has to say for
+		// itself in the log, and it describes an effort rather than a place.
+		load: activity?.load,
 	};
 }
 

--- a/netlify/functions/_shared/training/shape.test.js
+++ b/netlify/functions/_shared/training/shape.test.js
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
+	RIDE_MIN_M,
 	SHAPE_VERSION,
+	isTrackableRide,
 	isTrackableRun,
 	shapeActivity,
 	shapeActivities,
@@ -203,5 +205,92 @@ describe("collectBestEfforts", () => {
 
 	it("handles activities with no efforts", () => {
 		expect(collectBestEfforts([{}, { bestEfforts: [] }])).toEqual([]);
+	});
+});
+
+function rawRide(overrides = {}) {
+	return {
+		id: 555,
+		name: "Evening Ride",
+		type: "Ride",
+		sport_type: "Ride",
+		private: false,
+		start_date_local: "2026-08-11T18:00:00Z",
+		distance: 45000,
+		moving_time: 5400,
+		elapsed_time: 5600,
+		total_elevation_gain: 320,
+		average_heartrate: 138,
+		max_heartrate: 165,
+		start_latlng: [43.6532, -79.3832],
+		map: { summary_polyline: "_p~iF~ps|U_ulLnnqC" },
+		...overrides,
+	};
+}
+
+describe("isTrackableRide", () => {
+	it("takes a ride long enough to have cost something", () => {
+		expect(isTrackableRide(rawRide())).toBe(true);
+		expect(isTrackableRide(rawRide({ sport_type: "GravelRide" }))).toBe(true);
+		expect(isTrackableRide(rawRide({ sport_type: "MountainBikeRide" }))).toBe(true);
+	});
+
+	it("ignores the commute", () => {
+		// The whole point of the threshold: a few kilometres to the office is
+		// transport, and letting it through would put a smear of fatigue on
+		// most weekdays.
+		expect(isTrackableRide(rawRide({ distance: 3000 }))).toBe(false);
+		expect(isTrackableRide(rawRide({ distance: RIDE_MIN_M }))).toBe(false);
+		expect(isTrackableRide(rawRide({ distance: RIDE_MIN_M + 1 }))).toBe(true);
+	});
+
+	it("keeps private rides private", () => {
+		expect(isTrackableRide(rawRide({ private: true }))).toBe(false);
+	});
+
+	it("is not fooled by a run", () => {
+		expect(isTrackableRide(rawRun())).toBe(false);
+		expect(isTrackableRun(rawRide())).toBe(false);
+	});
+});
+
+describe("shapeActivity for rides", () => {
+	const shaped = () => shapeActivity(rawRide(), { thresholds: THRESHOLDS });
+
+	it("marks it as a ride so nothing downstream mistakes it for a run", () => {
+		expect(shaped().sport).toBe("ride");
+		expect(shapeActivity(rawRun(), { thresholds: THRESHOLDS }).sport).toBe("run");
+	});
+
+	it("carries no running measures at all", () => {
+		const ride = shaped();
+		// All of these would be arithmetically fine and completely misleading
+		// in a column beside a run's.
+		expect(ride.paceSecPerKm).toBeNull();
+		expect(ride.gapPaceSecPerKm).toBeNull();
+		expect(ride.decouplingPct).toBeNull();
+		expect(ride.splits).toEqual([]);
+		expect(ride.bestEfforts).toEqual([]);
+	});
+
+	it("scores it from heart rate, on the same scale as a run", () => {
+		const ride = shaped();
+		expect(ride.load).toBeGreaterThan(0);
+		expect(ride.loadMethod).toBe("hr");
+	});
+
+	it("leaves a ride with no heart rate unscored rather than guessing", () => {
+		// The pace fallback reads a threshold *running* pace. Pointing it at a
+		// bike would mint load out of the fact that bikes are faster.
+		const ride = shapeActivity(rawRide({ average_heartrate: null }), { thresholds: THRESHOLDS });
+		expect(ride.load).toBe(0);
+		expect(ride.loadMethod).toBeNull();
+	});
+
+	it("drops a ride's route just as thoroughly", () => {
+		const json = JSON.stringify(shaped());
+		expect(json).not.toContain("43.65");
+		expect(json).not.toContain("_p~iF");
+		expect(json).not.toContain("polyline");
 	});
 });

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -24,7 +24,12 @@
 
 import { createJsonResponder, cacheControl } from "./_shared/http.js";
 import { STRAVA_API_BASE, callsRemaining, getAccessToken, readQuota } from "./_shared/strava.js";
-import { SHAPE_VERSION, isTrackableRun, shapeActivity } from "./_shared/training/shape.js";
+import {
+	SHAPE_VERSION,
+	isTrackableActivity,
+	isTrackableRide,
+	shapeActivity,
+} from "./_shared/training/shape.js";
 import { loadPlan } from "./_shared/training/planFile.js";
 import {
 	ATHLETE_KEY,
@@ -206,9 +211,9 @@ export default async function handler(req) {
 
 	const thresholds = plan.thresholds;
 
-	// Private runs and other sports are dropped here, before we spend any
-	// upstream budget enriching them.
-	const candidates = summaries.filter(isTrackableRun);
+	// Private activities, other sports and short rides are dropped here, before
+	// we spend any upstream budget enriching them.
+	const candidates = summaries.filter(isTrackableActivity);
 
 	// Anything we've never seen, plus anything shaped by an older version of
 	// the shaping logic. Version checking is what makes a re-shape finish:
@@ -243,6 +248,16 @@ export default async function handler(req) {
 	let quotaPaused = false;
 	const fetched = await mapWithConcurrency(needsDetail, FETCH_CONCURRENCY, async (summary) => {
 		if (rateLimited) return null;
+
+		// A ride is complete as it stands. Everything the detailed activity
+		// and the streams would add — splits, best efforts, grade-adjusted
+		// pace, decoupling — is a running measure a ride doesn't carry, so it
+		// shapes straight from the summary for no API calls at all. Tracking
+		// rides therefore takes nothing from the budget the runs need.
+		if (isTrackableRide(summary)) {
+			return shapeActivity(summary, { thresholds, athleteZones: zones });
+		}
+
 		if (Date.now() > deadline) {
 			timedOut = true;
 			return null;

--- a/src/components/Training/sections/RunLog.svelte
+++ b/src/components/Training/sections/RunLog.svelte
@@ -24,18 +24,36 @@
     let { runs = [], total = null } = $props();
 
     const plannedCount = $derived(runs.filter((r) => r.plan?.planned).length);
+    const runCount = $derived(runs.filter((r) => r.sport !== "ride").length);
+    const rideCount = $derived(runs.filter((r) => r.sport === "ride").length);
+
+    // What a ride actually did to the training, spelled out. It's the one row
+    // type whose numbers need explaining, because the honest answer is that
+    // most of the page ignored it on purpose.
+    const RIDE_NOTE =
+        "Counts as fatigue only: a ride costs recovery, but builds no running-specific"
+        + " durability, so it adds nothing to weekly volume, fitness or injury risk.";
+
+    // Load comes from heart rate, which is the one measure that means the same
+    // thing on a bike as on foot. Without it there's nothing to score a ride
+    // by — running pace would just mint load out of bikes being faster — so it
+    // counts for nothing at all rather than for a guess.
+    const RIDE_UNSCORED =
+        "No heart rate recorded, so this ride is left unscored rather than guessed at from"
+        + " running pace. It adds nothing to the model.";
 </script>
 
 <Card title="Runs this block" info={GLOSSARY.runs}>
     {#snippet aside()}
         {#if runs.length}
             <span class="count">
-                {#if Number.isFinite(total) && total > runs.length}
-                    latest {runs.length} of {total}
+                {#if Number.isFinite(total) && total > runCount}
+                    latest {runCount} of {total}
                 {:else}
-                    {runs.length} runs
+                    {runCount} runs
                 {/if}
                 · {plannedCount} planned
+                {#if rideCount}· {rideCount} {rideCount === 1 ? "ride" : "rides"}{/if}
             </span>
         {/if}
     {/snippet}
@@ -45,6 +63,7 @@
     {:else}
         <ul class="log">
             {#each runs as run (run.id)}
+                {@const isRide = run.sport === "ride"}
                 {@const tag = stravaTag(run)}
                 {@const planned = run.plan?.planned === true}
                 {@const hilly = Number.isFinite(run.gapPaceSecPerKm)
@@ -52,7 +71,8 @@
                 <li>
                     <a
                         class="row"
-                        class:extra={!planned}
+                        class:extra={!planned && !isRide}
+                        class:ride={isRide}
                         href="https://www.strava.com/activities/{run.id}"
                         target="_blank"
                         rel="noreferrer"
@@ -61,14 +81,16 @@
                             <span class="row-name">{run.name}</span>
                             <span class="row-meta">
                                 {shortDate(run.startDateLocal)}
-                                {#if planned}
+                                {#if isRide}
+                                    <span class="tag ride-tag" title={RIDE_NOTE}>ride</span>
+                                {:else if planned}
                                     <span class="tag plan" title={run.plan.detail || ""}>
                                         {run.plan.type || "planned"}
                                     </span>
                                 {:else}
                                     <span class="tag extra">extra</span>
                                 {/if}
-                                {#if tag}<span class="tag">{tag}</span>{/if}
+                                {#if tag && !isRide}<span class="tag">{tag}</span>{/if}
                                 {#if run.averageHr}· {Math.round(run.averageHr)} bpm{/if}
                                 {#if run.elevationGainM > 50}· {Math.round(run.elevationGainM)} m up{/if}
                             </span>
@@ -80,10 +102,24 @@
                         </div>
 
                         <div class="row-stat">
-                            <strong>{pace(run.paceSecPerKm)}</strong>
-                            <span class:adjusted={hilly}>
-                                {Number.isFinite(run.gapPaceSecPerKm) ? `${pace(run.gapPaceSecPerKm)} GAP` : "—"}
-                            </span>
+                            {#if isRide}
+                                <!-- A ride has no pace worth putting beside a
+                                     run's, so the column says what it did
+                                     instead of what it ran. An unscored ride
+                                     says so rather than showing a 0, which
+                                     would read as "this cost nothing" when it
+                                     means "this couldn't be measured". -->
+                                {@const scored = run.load > 0}
+                                <strong>{scored ? Math.round(run.load) : "—"}</strong>
+                                <span class="cost" title={scored ? RIDE_NOTE : RIDE_UNSCORED}>
+                                    {scored ? "fatigue only" : "no heart rate"}
+                                </span>
+                            {:else}
+                                <strong>{pace(run.paceSecPerKm)}</strong>
+                                <span class:adjusted={hilly}>
+                                    {Number.isFinite(run.gapPaceSecPerKm) ? `${pace(run.gapPaceSecPerKm)} GAP` : "—"}
+                                </span>
+                            {/if}
                         </div>
                     </a>
                 </li>
@@ -128,6 +164,9 @@
     /* Runs the plan didn't ask for still belong here, but shouldn't read with
        the same weight as the sessions that were the point of the week. */
     .row.extra { border-left-color: transparent; }
+    /* A ride is context rather than training, so it sits a step back from even
+       an unplanned run: dashed edge, and the whole row a touch quieter. */
+    .row.ride { border-left-style: dashed; border-left-color: var(--paragraph-colour); opacity: 0.75; }
     .row:hover { background: var(--main-green-translucent); }
 
     .row-main { flex: 1; min-width: 0; }
@@ -151,6 +190,16 @@
     }
     /* The pill itself is a card convention; a row just needs it to breathe. */
     .tag { margin: 0 2px; }
+    /* Its own tag rather than borrowing "extra", which already means a run the
+       plan didn't ask for. A ride isn't a run at all. Local rather than a card
+       convention because this is the only panel that shows one. */
+    .tag.ride-tag {
+        background: transparent;
+        border: 1px dashed var(--paragraph-colour);
+        color: var(--paragraph-colour);
+        text-transform: lowercase;
+        opacity: 0.9;
+    }
 
     .row-stat {
         display: flex;
@@ -172,6 +221,9 @@
         color: var(--paragraph-colour);
         opacity: 0.65;
     }
+    /* Says which book the number went into, since it isn't the one every
+       other row's numbers went into. */
+    .row-stat span.cost { font-style: italic; }
     /* Highlight GAP only when it actually differs from raw pace — otherwise
        it's noise on a flat run. */
     .row-stat span.adjusted {


### PR DESCRIPTION
## Summary

A long ride leaves you less ready for tomorrow's session, and the model had no way to know one had happened. Rides now sync from Strava and reach fatigue (ATL), so form reflects them.

**That is the only line they cross.** Cycling builds no running-specific durability, so rides earn no fitness, and they stay out of weekly volume, long-run share, intensity mix, aerobic efficiency and race prediction.

Most deliberately, they stay out of **ACWR**. That ratio earns its keep as a *running* injury signal, and its evidence is specifically about the tissue loading of the sport being ramped — putting cycling load into it would dilute the best warning on the page.

### Rides under 20 km are dropped at the shaping boundary

A few kilometres to the office is transport, not training. Letting commutes through would smear a little fatigue across most weekdays and have the model answer for rides that were never training in the first place.

### Scoring is honest about what it can't measure

TRIMP carries the weight here: heart-rate reserve means the same thing on a bike as on foot, so a ride is scored by the existing maths with no new sports science. The pace fallback very much does *not* transfer — it reads a threshold **running** pace, so pointing it at a bike would mint load out of the fact that bikes are faster.

A ride without heart rate is therefore left unscored rather than guessed at, and the log says `— no heart rate` rather than showing a `0`, which would read as "this cost nothing" when it means "this couldn't be measured".

### Costs no upstream budget

Everything a ride needs is already in the Strava summary, because splits, best efforts, GAP and decoupling are all running measures it doesn't carry. No detail call, no streams call — tracking rides takes nothing from the quota the runs need.

## Test plan

- [x] 547 tests pass (17 new)
- [x] `metrics.test.js` pins the guarantees down by asserting a block reads **identically** with a ride in it: same weekly `distanceM`, same `longRunSharePct`, same `acwr`, same totals, intensity and prediction, same CTL — while ATL rises and form falls
- [x] Asserted a ride with no HR is unscored rather than pace-guessed, and that a record with no `sport` (everything currently in Blobs) still reads as a run
- [x] Asserted a ride's route is dropped as thoroughly as a run's — no coordinates, no polyline
- [x] End-to-end through the real engine: a 62 km ride scored 103 from HR, a 48 km ride with no strap left unscored, a 3.1 km commute rejected, no coordinates anywhere in the payload
- [x] Verified in the browser: ride rows render dashed and faded (`borderLeftStyle: dashed`, `opacity: 0.75`) against runs (`solid`, `1`), header reads "29 runs · 29 planned · 2 rides", commute absent
- [x] Rebased onto `master` after #67 and #68 merged; resolved the `RunLog.svelte` conflict in favour of #67's shared `stravaTag` and `.tag.extra`
- [ ] After deploy: `SHAPE_VERSION` is bumped to 3, so the sync will re-shape stored records a batch at a time. Worth watching `outstanding` fall to zero over a few runs.
- [ ] After deploy: confirm real rides actually carry heart rate — that's what decides whether they score at all.

## Note

`SHAPE_VERSION` 2 → 3, since records now carry `sport`. Existing records re-enrich incrementally through the normal stale-record path; until a record is re-shaped it reads as a run, which is what all of them are.

Made with [Cursor](https://cursor.com)