### PR TITLE
Show rides, count them nowhere

### DIFF
--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -70,12 +70,35 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 	const end = new Date(`${today}T00:00:00Z`);
 	for (const day = new Date(start); day <= end; day.setUTCDate(day.getUTCDate() + 1)) {
 		const dow = day.getUTCDay();
-		if (dow === 1 || dow === 6) continue; // strength / rest
+		if (dow === 1) continue; // strength
+		const date = day.toISOString().slice(0, 10);
+
+		// Saturday is a ride. It's here so the log renders one: a ride reaches
+		// that list and no metric on the page, and a fixture of nothing but
+		// runs can't tell the difference between that working and the ride
+		// support having quietly disappeared.
+		if (dow === 6) {
+			const rideDistance = 45000 + next() * 25000;
+			raw.push({
+				id: id++,
+				name: "Saturday Ride",
+				type: "Ride",
+				"sport_type": "Ride",
+				private: false,
+				"start_date_local": `${date}T09:00:00Z`,
+				distance: rideDistance,
+				// Around 25–30 km/h, which is the number the row shows.
+				"moving_time": Math.round(rideDistance / (7 + next())),
+				"total_elevation_gain": Math.round(next() * 400),
+				"average_heartrate": 132 + next() * 12,
+			});
+			continue;
+		}
+
 		const isLong = dow === 0;
 		const distance = isLong ? 16000 + next() * 8000 : 6000 + next() * 6000;
 		const paceSecPerKm = isLong ? 330 + next() * 25 : 300 + next() * 40;
 		const movingTime = Math.round((distance / 1000) * paceSecPerKm);
-		const date = day.toISOString().slice(0, 10);
 		const averageHr = 138 + next() * 22;
 
 		raw.push({

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -29,7 +29,7 @@ test("training route renders its sections", async ({ page }) => {
 	await expect(page).toHaveTitle(/Road to Chicago/i);
 	await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
 	await expect(page.getByRole("heading", { name: "Weekly volume" })).toBeVisible();
-	await expect(page.getByRole("heading", { name: "Runs this block" })).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Recent activity" })).toBeVisible();
 });
 
 test("every card explains its own metrics on demand", async ({ page }) => {
@@ -49,11 +49,22 @@ test("every card explains its own metrics on demand", async ({ page }) => {
 
 test("the run log says which runs were the plan", async ({ page }) => {
 	await page.goto("/training");
-	const log = page.locator("section.card").filter({ hasText: "Runs this block" }).first();
+	const log = page.locator("section.card").filter({ hasText: "Recent activity" }).first();
 	// The fixture runs the real plan file, which has day-level sessions, so
 	// both kinds have to appear: matched sessions and unplanned extras.
 	await expect(log.locator(".tag.plan").first()).toBeVisible();
 	await expect(log.locator(".tag.extra-tag").first()).toBeVisible();
+});
+
+test("a ride is listed as context, in a cyclist's units", async ({ page }) => {
+	await page.goto("/training");
+	const log = page.locator("section.card").filter({ hasText: "Recent activity" }).first();
+	const ride = log.locator(".row.ride").first();
+
+	await expect(ride.locator(".tag.ride-tag")).toHaveText("ride");
+	// km/h rather than the min/km every run in the list is reported in.
+	await expect(ride).toContainText(/\d+\.\d km\/h/);
+	await expect(ride).toContainText("avg speed");
 });
 
 test("the last run is reported with what it did to the training", async ({ page }) => {

--- a/netlify/functions/_shared/training/fitness.js
+++ b/netlify/functions/_shared/training/fitness.js
@@ -41,21 +41,23 @@ const asMap = (loads) => (loads instanceof Map ? loads : new Map(Object.entries(
  * what lets fatigue actually decay during a taper — so the range is filled in
  * densely rather than iterating only the days that have activities.
  *
- * Fitness and fatigue can be fed from different books. Cross-training is the
- * reason: a long ride genuinely costs you recovery, so it belongs in fatigue,
- * but it builds none of the running-specific durability that CTL is standing in
- * for here, and letting it inflate fitness would flatter a marathon build for
- * work the legs never did. Pass `fatigueLoadsByDay` to say "these days cost
- * this much, even though only some of it was running".
+ * Both traces are fed from the same book, and that is what makes form readable
+ * rather than a number that happens to be negative. Because fitness and fatigue
+ * are averages of the same daily load, they converge at a steady training rate
+ * and form settles around zero, so "+5 is fresh, −20 is buried" means something.
+ * Feed fatigue from a wider source than fitness — cross-training was the
+ * tempting one — and that equilibrium breaks: fatigue settles higher than
+ * fitness can ever climb, and form sits permanently negative by roughly the
+ * daily load of whatever the extra source was, no matter how recovered you
+ * actually are. Anything that costs recovery either earns fitness too, or stays
+ * out of both.
  *
- * @param {Map<string, number>|object} loadsByDay day key to running load.
- * @param {{from: string, to: string, fatigueLoadsByDay?: Map<string, number>|object}} range
+ * @param {Map<string, number>|object} loadsByDay day key to load.
+ * @param {{from: string, to: string}} range
  * @returns {{date: string, load: number, ctl: number, atl: number, tsb: number}[]}
- *   `load` is the running load for the day; fatigue may have been fed more.
  */
-export function fitnessSeries(loadsByDay, { from, to, fatigueLoadsByDay = null }) {
+export function fitnessSeries(loadsByDay, { from, to }) {
 	const lookup = asMap(loadsByDay);
-	const fatigueLookup = fatigueLoadsByDay ? asMap(fatigueLoadsByDay) : lookup;
 	const days = eachDay(from, to);
 	if (days.length === 0) return [];
 
@@ -69,7 +71,7 @@ export function fitnessSeries(loadsByDay, { from, to, fatigueLoadsByDay = null }
 		const tsb = ctl - atl;
 		const load = Number(lookup.get(date)) || 0;
 		ctl += (load - ctl) * ctlAlpha;
-		atl += ((Number(fatigueLookup.get(date)) || 0) - atl) * atlAlpha;
+		atl += (load - atl) * atlAlpha;
 		return { date, load, ctl, atl, tsb };
 	});
 }

--- a/netlify/functions/_shared/training/load.js
+++ b/netlify/functions/_shared/training/load.js
@@ -120,13 +120,6 @@ export function activityLoad(activity, thresholds = {}) {
 	const trimp = banisterTrimp(durationSec, activity?.averageHr, thresholds);
 	if (trimp !== null) return { load: normalizeTrimp(trimp), method: "hr" };
 
-	// TRIMP is the one part of this model that doesn't care which sport you
-	// did — heart-rate reserve is heart-rate reserve. The fallback below very
-	// much does care: it reads a threshold *running* pace, so applying it to a
-	// bike would invent load out of the fact that bikes are faster. A ride
-	// without heart rate is therefore unscored rather than guessed at.
-	if (activity?.sport === "ride") return null;
-
 	const gap =
 		Number(activity?.gapPaceSecPerKm) ||
 		activityGap(activity)?.gapPaceSecPerKm ||

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -102,10 +102,16 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 		String(a.startDateLocal).localeCompare(String(b.startDateLocal)),
 	);
 
-	// Everything on this page is a running measure unless it says otherwise.
-	// Rides are held apart from the first line so that volume, long-run share,
-	// intensity, efficiency, race prediction and the acute:chronic ratio all
-	// keep meaning exactly what they meant before rides existed.
+	// This is a running dashboard, and rides are separated here so that every
+	// number below it is a running number. A ride reaches the log and nothing
+	// else: not volume, not fitness, not fatigue, not the acute:chronic ratio.
+	//
+	// Feeding fatigue alone was tried and reverted. It looks conservative and
+	// isn't: form is fitness minus fatigue, so raising one without the other
+	// pushes form permanently negative by roughly the daily ride load, forever,
+	// regardless of how recovered you are (see fitnessSeries). The alternative,
+	// letting rides earn fitness too, keeps form honest but then reads cycling
+	// as marathon fitness — which is the one thing this page must not do.
 	const runs = sorted.filter((a) => a?.sport !== "ride");
 	const rides = sorted.filter((a) => a?.sport === "ride");
 
@@ -114,15 +120,7 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 	const range = blockRange(plan, runs, day);
 
 	const loads = dailyLoads(runs);
-	// The one place a ride is allowed to count. It reaches fatigue, because a
-	// long ride genuinely leaves you less ready for tomorrow's session, and
-	// stops there — it earns no fitness and, deliberately, no place in ACWR,
-	// whose injury-risk evidence is about the tissue loading of the sport being
-	// ramped. Cycling load in that ratio would dilute the best warning here.
-	const fatigueLoads = rides.length > 0 ? dailyLoads(sorted) : null;
-	const series = range
-		? fitnessSeries(loads, { ...range, fatigueLoadsByDay: fatigueLoads })
-		: [];
+	const series = range ? fitnessSeries(loads, range) : [];
 	// Report against today, not the end of the block — the series runs forward
 	// to race day, where CTL has decayed to nothing because no runs exist yet.
 	const latest = series.find((d) => d.date === day) || series.at(-1) || null;
@@ -306,8 +304,9 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 				.slice(from)
 				.map((run, i) => ({ ...publicRun(run), plan: planMatches[from + i] }));
 			// Rides join the log across the span it already covers rather than
-			// competing for its thirty places. This stays a log of runs that
-			// admits what else was tiring you out, not a feed of everything.
+			// competing for its thirty places, and they arrive here having
+			// touched no metric on the page. Purely context: what else was in
+			// the week, for a reader wondering why a Sunday was quiet.
 			const earliest = toDayKey(logged[0]?.startDateLocal);
 			const alongside = earliest
 				? rides.filter((r) => toDayKey(r.startDateLocal) >= earliest).map(publicRun)

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -423,22 +423,32 @@ describe("buildDashboard privacy, end to end", () => {
 	});
 });
 
-// A ride is allowed to make you tired and nothing else. These are the lines it
-// must not cross: every running measure on the page has to read the same with
-// a ride in the block as without one.
+// A ride reaches the log and nothing else. The whole block below is one claim
+// checked from several directions: the dashboard reads identically with a ride
+// in it and without, apart from the row that shows it.
+//
+// Feeding fatigue alone was tried and reverted, and "costs fatigue, and so
+// costs form" used to be a test here. It passed, which was the problem — form
+// is fitness minus fatigue, so raising one and never the other doesn't make a
+// ride cost you a few days of freshness, it moves form permanently down by
+// roughly the daily ride load and never lets it back.
 describe("buildDashboard with rides", () => {
 	const RIDE = {
 		id: 9001,
 		name: "Long ride",
 		sport: "ride",
 		type: "Ride",
-		// Yesterday, so its fatigue has actually landed by today. Form is read
-		// from the state you woke up with, so a ride logged this morning
-		// rightly hasn't reached today's number yet.
+		// Yesterday rather than today: form is read from the state you woke up
+		// with, so a ride logged this morning couldn't move today's number
+		// even if rides counted. Dated to where it would show if it could.
 		startDateLocal: "2026-08-10T07:00:00",
 		distanceM: 60000,
 		movingTimeSec: 7200,
 		averageHr: 140,
+		// Deliberately carrying a load. Rides are shaped unscored now, but
+		// records written when they weren't are still in Blobs and served
+		// until the sync re-shapes them. Counting for nothing is a property of
+		// this module, not of the number happening to be zero.
 		load: 90,
 	};
 
@@ -474,19 +484,16 @@ describe("buildDashboard with rides", () => {
 		expect(after.summary.totals).toEqual(before.summary.totals);
 		expect(after.summary.intensity).toEqual(before.summary.intensity);
 		expect(after.summary.prediction).toEqual(before.summary.prediction);
+		// And so the advice, which is a reading of all of the above, says the
+		// same thing rather than telling you to back off because you cycled.
+		expect(after.recommendations).toEqual(before.recommendations);
 	});
 
-	it("builds no fitness", () => {
-		expect(withRide().summary.latest.ctl).toBeCloseTo(runsOnly().summary.latest.ctl, 10);
-	});
-
-	it("costs fatigue, and so costs form", () => {
-		const before = runsOnly();
-		const after = withRide();
-		expect(after.summary.latest.atl).toBeGreaterThan(before.summary.latest.atl);
-		// Form is fitness minus fatigue, so a ride you haven't recovered from
-		// should leave you reading as less ready, not more.
-		expect(after.summary.latest.tsb).toBeLessThan(before.summary.latest.tsb);
+	it("touches neither fitness, fatigue nor form, on any day", () => {
+		// The whole series, not just today: an offset that only shows up three
+		// weeks later is exactly the failure this is here to catch.
+		expect(withRide().series).toEqual(runsOnly().series);
+		expect(withRide().summary.latest).toEqual(runsOnly().summary.latest);
 	});
 
 	it("shows the ride in the log, in date order, marked as a ride", () => {
@@ -494,7 +501,11 @@ describe("buildDashboard with rides", () => {
 		const ride = log.find((a) => a.id === RIDE.id);
 		expect(ride).toBeTruthy();
 		expect(ride.sport).toBe("ride");
-		expect(ride.load).toBe(90);
+		// Distance and time are what the row draws its speed from; a load it
+		// doesn't count has no business being served.
+		expect(ride.distanceM).toBe(60000);
+		expect(ride.movingTimeSec).toBe(7200);
+		expect(ride.load).toBeUndefined();
 		expect(log.filter((a) => a.sport === "run")).toHaveLength(10);
 		const dates = log.map((a) => a.startDateLocal);
 		expect([...dates].sort().reverse()).toEqual(dates);

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -28,16 +28,16 @@ import { toDayKey } from "./dates.js";
 // (VirtualRun) — the training stress is real even if the GPS isn't.
 const RUN_TYPES = new Set(["Run", "TrailRun", "VirtualRun"]);
 
-// Rides are tracked for one reason: they cost recovery. They build no
-// running-specific durability, so they're kept well away from weekly volume,
-// long-run share and the acute:chronic ratio (see metrics.js) — they only ever
-// reach fatigue.
+// Rides are tracked so the log can show what else was in the week, and for
+// nothing else. They reach no metric on the page — not volume, not fitness,
+// not fatigue, not the acute:chronic ratio (see metrics.js, which explains why
+// the tempting middle option of counting them as fatigue alone is worse than
+// either end).
 const RIDE_TYPES = new Set(["Ride", "GravelRide", "MountainBikeRide", "VirtualRide"]);
 
 // Below this a ride is transport, not training. A few kilometres to the office
-// costs nothing worth modelling, and letting commutes through would put a small
-// bump of fatigue on most weekdays — enough to drag form down and make the
-// model answer for rides that were never training in the first place.
+// isn't context worth showing, and letting commutes through would bury the
+// week's actual running under a row for every trip to the shops.
 export const RIDE_MIN_M = 20000;
 
 // Stamped onto every stored record. Several fields here are derived at sync
@@ -205,7 +205,11 @@ export function shapeActivity(raw, options = {}) {
 			: shapeBestEfforts(raw.best_efforts, raw.start_date_local || raw.start_date),
 	};
 
-	const load = activityLoad(shaped, thresholds);
+	// A ride is stored to be listed and counted nowhere, so it's left unscored
+	// rather than carrying a load that sits in the record waiting to be summed
+	// by mistake. Nothing downstream reads it, and this is what makes that
+	// true by construction rather than by everyone remembering.
+	const load = isRide ? null : activityLoad(shaped, thresholds);
 	shaped.load = load?.load ?? 0;
 	shaped.loadMethod = load?.method ?? null;
 	return shaped;
@@ -243,9 +247,6 @@ export function publicRun(activity) {
 		workoutType: activity?.workoutType,
 		paceSecPerKm: activity?.paceSecPerKm,
 		gapPaceSecPerKm: activity?.gapPaceSecPerKm,
-		// What the session cost. It's the only thing a ride has to say for
-		// itself in the log, and it describes an effort rather than a place.
-		load: activity?.load,
 	};
 }
 

--- a/netlify/functions/_shared/training/shape.test.js
+++ b/netlify/functions/_shared/training/shape.test.js
@@ -273,16 +273,13 @@ describe("shapeActivity for rides", () => {
 		expect(ride.bestEfforts).toEqual([]);
 	});
 
-	it("scores it from heart rate, on the same scale as a run", () => {
+	it("is left unscored, having nothing to be scored for", () => {
+		// A ride is stored to be listed, and counted by nothing on the page.
+		// Scoring it anyway would leave a plausible number in the record for
+		// some later sum to pick up by accident. Heart rate is present here,
+		// so this fails if the load line ever stops asking whether it's a ride.
 		const ride = shaped();
-		expect(ride.load).toBeGreaterThan(0);
-		expect(ride.loadMethod).toBe("hr");
-	});
-
-	it("leaves a ride with no heart rate unscored rather than guessing", () => {
-		// The pace fallback reads a threshold *running* pace. Pointing it at a
-		// bike would mint load out of the fact that bikes are faster.
-		const ride = shapeActivity(rawRide({ average_heartrate: null }), { thresholds: THRESHOLDS });
+		expect(ride.averageHr).toBe(138);
 		expect(ride.load).toBe(0);
 		expect(ride.loadMethod).toBeNull();
 	});

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -278,13 +278,6 @@ video::-webkit-media-controls-overlay-play-button {
     letter-spacing: -0.02em;
 }
 
-/* `.grid-container h1` centres every h1 in the layout and outranks the rule
-   above on specificity, so the left alignment it asks for never landed. Only
-   section titles are named here — the profile name stays centred. */
-.grid-container h1.section-title {
-    text-align: left;
-}
-
 .blog-subsection {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/components/Home/sections/Intro.svelte
+++ b/src/components/Home/sections/Intro.svelte
@@ -161,7 +161,7 @@
             icon: 'running',
             modal: {
                 image: 'run',
-                description: 'Running the 2025 <a href="https://www.torontowaterfrontmarathon.com/" rel="noreferrer" target="_blank">Toronto Waterfront Half Marathon</a><br>Training for the 2026 <a href="/training">Chicago Marathon</a>.',
+                description: 'Running the 2025 <a href="https://www.torontowaterfrontmarathon.com/" rel="noreferrer" target="_blank">Toronto Waterfront Half Marathon</a><br>(Currently <a href="/training">training</a> for the 2026 Chicago Marathon).',
                 strava: 'run'
             }
         },

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -22,6 +22,19 @@ export function pace(secPerKm) {
 }
 
 /**
+ * Average speed as km/h — how a ride is read, where a runner's min/km would be
+ * a number nobody has an instinct for.
+ *
+ * @param {number} distanceM
+ * @param {number} movingTimeSec
+ * @returns {string}
+ */
+export function speed(distanceM, movingTimeSec) {
+	if (!(distanceM > 0) || !(movingTimeSec > 0)) return "—";
+	return `${(distanceM / 1000 / (movingTimeSec / 3600)).toFixed(1)} km/h`;
+}
+
+/**
  * A race time as h:mm:ss.
  *
  * @param {number} sec

--- a/src/components/Training/lib/format.test.js
+++ b/src/components/Training/lib/format.test.js
@@ -1,5 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed } from "./format.js";
+import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed, speed } from "./format.js";
+
+describe("speed", () => {
+	it("reads a ride in km/h", () => {
+		expect(speed(30000, 3600)).toBe("30.0 km/h");
+		expect(speed(45500, 5400)).toBe("30.3 km/h");
+	});
+
+	it("has nothing to say without both halves of it", () => {
+		expect(speed(30000, 0)).toBe("—");
+		expect(speed(0, 3600)).toBe("—");
+		expect(speed(null, null)).toBe("—");
+	});
+});
 
 describe("weekRange", () => {
 	it("covers the seven days from the Monday", () => {

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -131,14 +131,16 @@ export const GLOSSARY = {
 	},
 
 	runs: {
-		title: "Runs this block",
+		title: "Recent activity",
 		body: [
 			"Every run since the block started, newest first, matched against the plan for the day it fell on. Runs on a day with a planned session are tagged with that session; anything else is an extra.",
 			"Pace and grade-adjusted pace sit side by side, because on a hilly run they diverge a lot and that difference is the point — GAP is what the same effort would have been on the flat.",
+			"Longer rides are listed alongside them for context, and count towards nothing on this page. Cycling builds none of the running-specific durability the rest of these numbers are tracking, so it stays out of all of them rather than flattering the fitness or dragging down the form.",
 		],
 		terms: [
 			{ term: "GAP", definition: "Grade-adjusted pace: your pace corrected for the gradient you ran it on, so hilly and flat runs can be compared." },
 			{ term: "Extra", definition: "A run with no planned session on that day. Not a bad thing — just not part of the plan." },
+			{ term: "Ride", definition: "A ride over 20 km, shown so the week reads honestly. Nothing on this page counts it." },
 		],
 	},
 };

--- a/src/components/Training/sections/RunLog.svelte
+++ b/src/components/Training/sections/RunLog.svelte
@@ -1,5 +1,5 @@
 <!--
-    Every run of the block, newest first, matched against the plan.
+    The block's activity, newest first, with every run matched against the plan.
 
     "Recent runs" was the wrong name twice over: the list is scoped to the
     training block, and it says nothing about whether a run was the session the
@@ -11,13 +11,17 @@
     rather than hidden inside one blended number — on a hilly run they diverge
     a lot, and that difference is the point.
 
+    Rides appear as context and nothing more: they're the reason a week was
+    quiet, not part of it. Every metric on the page ignores them (see
+    metrics.js), so their row shows what they were rather than what they did.
+
     No route maps here: the payload deliberately carries no coordinates (see
     netlify/functions/_shared/training/shape.js), so each row links out to the
     activity on Strava for anyone who wants the map.
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
-    import { formatDistance, formatDuration, pace, shortDate } from "../lib/format.js";
+    import { formatDistance, formatDuration, pace, shortDate, speed } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
     import { stravaTag } from "../lib/runTags.js";
 
@@ -27,23 +31,15 @@
     const runCount = $derived(runs.filter((r) => r.sport !== "ride").length);
     const rideCount = $derived(runs.filter((r) => r.sport === "ride").length);
 
-    // What a ride actually did to the training, spelled out. It's the one row
-    // type whose numbers need explaining, because the honest answer is that
-    // most of the page ignored it on purpose.
+    // Why a ride's numbers don't show up anywhere else on the page. Worth
+    // saying plainly on the row, because the alternative is a reader assuming
+    // the model quietly took the cycling into account somewhere.
     const RIDE_NOTE =
-        "Counts as fatigue only: a ride costs recovery, but builds no running-specific"
-        + " durability, so it adds nothing to weekly volume, fitness or injury risk.";
-
-    // Load comes from heart rate, which is the one measure that means the same
-    // thing on a bike as on foot. Without it there's nothing to score a ride
-    // by — running pace would just mint load out of bikes being faster — so it
-    // counts for nothing at all rather than for a guess.
-    const RIDE_UNSCORED =
-        "No heart rate recorded, so this ride is left unscored rather than guessed at from"
-        + " running pace. It adds nothing to the model.";
+        "Shown for context only. Cycling builds no running-specific durability, so rides count"
+        + " towards nothing here — not weekly volume, fitness, fatigue or injury risk.";
 </script>
 
-<Card title="Runs this block" info={GLOSSARY.runs}>
+<Card title="Recent activity" info={GLOSSARY.runs}>
     {#snippet aside()}
         {#if runs.length}
             <span class="count">
@@ -103,17 +99,12 @@
 
                         <div class="row-stat">
                             {#if isRide}
-                                <!-- A ride has no pace worth putting beside a
-                                     run's, so the column says what it did
-                                     instead of what it ran. An unscored ride
-                                     says so rather than showing a 0, which
-                                     would read as "this cost nothing" when it
-                                     means "this couldn't be measured". -->
-                                {@const scored = run.load > 0}
-                                <strong>{scored ? Math.round(run.load) : "—"}</strong>
-                                <span class="cost" title={scored ? RIDE_NOTE : RIDE_UNSCORED}>
-                                    {scored ? "fatigue only" : "no heart rate"}
-                                </span>
+                                <!-- Minutes per kilometre is a runner's unit
+                                     and reads as nonsense on a bike, so the
+                                     column a run gives to pace and GAP gives
+                                     the speed a cyclist would actually quote. -->
+                                <strong>{speed(run.distanceM, run.movingTimeSec)}</strong>
+                                <span>avg speed</span>
                             {:else}
                                 <strong>{pace(run.paceSecPerKm)}</strong>
                                 <span class:adjusted={hilly}>
@@ -221,9 +212,6 @@
         color: var(--paragraph-colour);
         opacity: 0.65;
     }
-    /* Says which book the number went into, since it isn't the one every
-       other row's numbers went into. */
-    .row-stat span.cost { font-style: italic; }
     /* Highlight GAP only when it actually differs from raw pace — otherwise
        it's noise on a flat run. */
     .row-stat span.adjusted {


### PR DESCRIPTION
Reverts the modelling half of #69 and keeps the log half.

## Why

Rides fed fatigue and not fitness. That looked like the conservative choice and was the one indefensible option of the three.

Form is fitness minus fatigue, and both are exponential averages of the same daily load. That shared source is the whole reason form is readable: the two traces converge at a steady training rate, so form oscillates around zero and "+5 is fresh, −20 is buried" means something. Feed one and not the other and the equilibrium breaks — fatigue settles at running load *plus* ride load while fitness only ever reaches running load, so form sits permanently negative by roughly the average daily ride load, regardless of actual recovery.

Seven months of identical running, with and without two rides a week:

| | fitness | fatigue | form |
|---|---|---|---|
| runs only | 57.0 | 62.6 | **+2.4** |
| fatigue-only rides | 57.0 | 91.2 | **−30.9** |

It never decays, because there's nothing for it to decay towards. A dashboard reading "taper immediately" because the athlete owns a bike is worse than one that ignores cycling entirely.

That left both books or neither, and both would read cycling as marathon fitness — the one thing a marathon dashboard must not do. So: neither.

## What changed

- **`fitness.js`** — `fatigueLoadsByDay` is gone; one book feeds both traces.
- **`metrics.js`** — rides reach the log and nothing else. Not volume, fitness, fatigue, ACWR, intensity, prediction, or the recommendations that read them.
- **`shape.js`** — rides are no longer scored. Nothing reads a ride's load, and a plausible number left in the record is how it gets summed by accident later. Counting for nothing is now a property of the data rather than of every caller remembering.
- **`load.js`** — the ride guard became unreachable and is removed.
- **`RunLog.svelte`** — the panel is **Recent activity**, and a ride shows average speed in km/h. Min/km is a runner's unit and reads as nonsense on a bike.

Also carries a small commit of yours from the previous branch: the running modal wording and the reverted header alignment.

## Tests

`costs fatigue, and so costs form` used to pass — that was the bug. It's replaced by an assertion that the *entire* fitness series is identical with a ride in the block and without, not just today's numbers, since a drift that only appears three weeks later is precisely the failure this shipped. Recommendations are pinned the same way.

The ride fixture still carries `load: 90` on purpose: records written while rides were scored are in Blobs and served until the sync re-shapes them, and they have to count for nothing too.

New e2e coverage renders a real ride row from a Saturday ride in the fixture.

## Test plan

- [x] 547 unit tests pass
- [x] Production build clean, no lint errors
- [ ] Playwright suite — not run locally (no Chromium in the local cache); needs CI
- [ ] Check `/training` renders ride rows with km/h, and that form no longer reads deeply negative

Made with [Cursor](https://cursor.com)