### PR TITLE
Read sleep and overnight heart rate from Oura

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,47 @@ Polling cadences:
   `bach-state` (the hottest path) computes image readiness from blob-key
   presence instead of reading image bytes each poll.
 
+### Training data credentials
+
+`/training` reads from two accounts. Both are refreshed server-side by
+`trainingSync` and never reach the browser, and the page renders whatever is
+already in Blobs if either is absent — an unconfigured integration is a normal
+state, not an error.
+
+**Strava** (`STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET`, `STRAVA_REFRESH_TOKEN`)
+uses a long-lived refresh token: authorize once with
+`node scripts/get_strava_refresh_token.js`, paste the result into Netlify, and
+it keeps working.
+
+**Oura** (`OURA_CLIENT_ID`, `OURA_CLIENT_SECRET`, `OURA_REFRESH_TOKEN`) does
+not, and the difference matters. Personal access tokens were withdrawn at the
+end of 2025, so this is OAuth2 only, and **refresh tokens are single-use** —
+each refresh returns a successor and invalidates the token just spent. To set
+it up:
+
+1. Create an application at
+   [cloud.ouraring.com/oauth/applications](https://cloud.ouraring.com/oauth/applications)
+   with the redirect URI `http://localhost:8889/callback`.
+2. Put the client ID and secret in `.env`, then run
+   `node scripts/get_oura_refresh_token.js` and follow the printed link.
+3. Copy the refresh token it prints into Netlify as `OURA_REFRESH_TOKEN`.
+
+The `daily` scope is enough for everything the page shows. The portal will
+offer continuous heart rate, SpO2 and personal details too; `/training` is
+public, so the narrowest token that does the job is the one worth holding.
+
+`OURA_REFRESH_TOKEN` is a **bootstrap, not the live credential**. Live token
+state lives in Blobs and rotates on every refresh; the environment variable
+seeds the first one and is retried if the stored chain ever breaks, which makes
+recovery "run the script again and paste the new value" rather than a code
+change. Two consequences:
+
+- Don't run the token exchange locally against the value in Netlify. Oura
+  invalidates it on use and the successor would be written to your local blob
+  store, leaving production holding a dead token.
+- If the sync logs `Oura auth failed`, re-run the script rather than debugging
+  the code. That is the designed recovery path.
+
 ### Design tokens & theming
 
 `public/styles/global.css` is the single source of truth for design tokens —
@@ -241,10 +282,14 @@ unused CSS), which `vite build` prints too.
 Pull requests are also analysed by [Codacy](https://www.codacy.com). Two notes
 on making that agree with the above:
 
-- ESLint v8 there reads `.eslintrc.cjs`, but only once **Code patterns →
-  ESLint → Configuration file** is switched on for the repository. Until then
-  it analyses with its own defaults and reports several hundred issues that are
-  house style rather than defects.
+- ESLint v8 there reads `.eslintrc.cjs`, which requires **Code patterns →
+  ESLint → Configuration file** to be switched on for the repository. It is.
+  Turning it off makes Codacy analyse with its own defaults, which disagree
+  with the house style above on nearly every file — one-line guards, wire-format
+  field names, `console.warn` in Functions — and report a few hundred issues
+  that are convention rather than defects. Codacy doesn't re-analyse after a
+  pattern change, so a pull request open at the time needs a new commit before
+  it reflects one.
 - PMD is excluded from JavaScript in `.codacy.yaml`. Its JS parser predates ES
   modules and numeric separators, so it misreads the source rather than finding
   anything in it; the file explains the specific failures.

--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -55,6 +55,29 @@ function streamsFor({ distance, movingTime, averageHr, next }) {
 	return { time, distance: distanceStream, heartrate, "grade_smooth": grade };
 }
 
+// A month of nights, already shaped the way the sync stores them. Enough for
+// the baselines to exist, and varied enough that the panel's chart has
+// something to draw and at least one night falls under the seven-hour line —
+// a fixture of identical perfect nights would pass a rendering test while
+// hiding whether the "short night" case draws at all.
+function nightsUpTo(today, next) {
+	const end = new Date(`${today}T00:00:00Z`);
+	return Array.from({ length: 28 }, (_, i) => {
+		const day = new Date(end);
+		day.setUTCDate(day.getUTCDate() - (27 - i));
+		const sleepSec = Math.round((6.2 + next() * 2.2) * 3600);
+		return {
+			day: day.toISOString().slice(0, 10),
+			sleepSec,
+			efficiencyPct: Math.round(86 + next() * 8),
+			restingHr: Math.round(45 + next() * 5),
+			averageHrv: Math.round(55 + next() * 20),
+			sleepScore: Math.round(70 + next() * 22),
+			readinessScore: Math.round(70 + next() * 22),
+		};
+	});
+}
+
 /**
  * @param {object} [options]
  * @param {string} [options.today] day key the dashboard is built against.
@@ -149,6 +172,7 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 					shapeActivities([activity], { streams, thresholds: plan.thresholds })[0])
 				.filter(Boolean),
 			plan,
+			recovery: nightsUpTo(today, next),
 			today,
 		}),
 		sync: { lastRunAt: `${today}T12:00:00.000Z`, hasSynced: true, outstanding: 0, backfilling: false },

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -67,6 +67,21 @@ test("a ride is listed as context, in a cyclist's units", async ({ page }) => {
 	await expect(ride).toContainText("avg speed");
 });
 
+test("recovery is reported beside the training, not inside it", async ({ page }) => {
+	await page.goto("/training");
+	const panel = page.locator("section.card").filter({ hasText: "Recovery" }).first();
+
+	// An average night, in hours and minutes rather than a score out of 100.
+	await expect(panel.getByText(/^\d+h \d+m$/).first()).toBeVisible();
+	await expect(panel.getByText("average night, last 7")).toBeVisible();
+
+	// The measures that carry the argument: an overnight resting rate and a
+	// variability figure, each against the athlete's own baseline.
+	await expect(panel.getByText("Resting HR")).toBeVisible();
+	await expect(panel.getByText("HRV")).toBeVisible();
+	await expect(panel.locator(".bar").first()).toBeVisible();
+});
+
 test("the last run is reported with what it did to the training", async ({ page }) => {
 	await page.goto("/training");
 	const panel = page.locator("section.card").filter({ hasText: "Last run" }).first();

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -53,7 +53,7 @@ test("the run log says which runs were the plan", async ({ page }) => {
 	// The fixture runs the real plan file, which has day-level sessions, so
 	// both kinds have to appear: matched sessions and unplanned extras.
 	await expect(log.locator(".tag.plan").first()).toBeVisible();
-	await expect(log.locator(".tag.extra-tag").first()).toBeVisible();
+	await expect(log.locator(".tag.extra").first()).toBeVisible();
 });
 
 test("a ride is listed as context, in a cyclist's units", async ({ page }) => {

--- a/netlify/functions/_shared/oura.js
+++ b/netlify/functions/_shared/oura.js
@@ -1,0 +1,168 @@
+// Oura Cloud API access for the recovery half of /training.
+//
+// The awkward part here isn't the API, it's the tokens. Personal access tokens
+// were withdrawn at the end of 2025, so this is OAuth2 authorization-code only,
+// and Oura's refresh tokens are single-use: refreshing returns a new pair and
+// invalidates the one just spent. Strava and Spotify both hand back a refresh
+// token that keeps working, which is why those integrations can read one out of
+// an environment variable and never think about it again (see strava.js). Do
+// that here and the second refresh fails.
+//
+// So Oura's token state lives in Blobs and is written back on every rotation.
+// Two consequences worth knowing before changing anything below:
+//
+//   - The write has to happen before the token is handed out. A token used but
+//     never stored leaves the successor lost, and the only fix is a human
+//     re-authorising the app.
+//   - OURA_REFRESH_TOKEN is a bootstrap, not the live credential. It seeds the
+//     very first refresh, and is retried if the stored chain ever breaks, which
+//     makes recovery "paste a fresh token into the env var" rather than "change
+//     the code". Once stored state exists the variable is otherwise unused.
+//
+// Rate limits are a non-issue: 5000 requests per 5 minutes, against the handful
+// a day this makes. None of the Strava quota accounting has an equivalent here.
+
+import { getEnv } from "./env.js";
+import { OURA_KEY, readJson, writeJson } from "./training/store.js";
+
+export const OURA_API_BASE = "https://api.ouraring.com";
+
+// Refresh this far before expiry rather than on it. Oura access tokens last a
+// day, so this costs nothing and avoids racing the clock mid-sync.
+const EXPIRY_MARGIN_MS = 5 * 60_000;
+
+/** Thrown when there's nothing to authenticate with, matching strava.js. */
+function notConfigured(message) {
+	const err = new Error(message);
+	err.code = "not_configured";
+	return err;
+}
+
+/**
+ * Exchange a refresh token for a new pair.
+ *
+ * @param {string} refreshToken
+ * @param {{clientId: string, clientSecret: string}} credentials
+ * @returns {Promise<{accessToken: string, refreshToken: string, expiresAt: number}>}
+ */
+async function exchange(refreshToken, { clientId, clientSecret }) {
+	const res = await fetch(`${OURA_API_BASE}/oauth/token`, {
+		method: "POST",
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		body: new URLSearchParams({
+			grant_type: "refresh_token",
+			refresh_token: refreshToken,
+			client_id: clientId,
+			client_secret: clientSecret,
+		}),
+	});
+	if (!res.ok) {
+		const err = new Error(`Oura token refresh failed: ${res.status}`);
+		err.status = res.status;
+		throw err;
+	}
+	const data = await res.json();
+	if (!data?.access_token || !data?.refresh_token) {
+		throw new Error("Oura token refresh returned no token");
+	}
+	return {
+		accessToken: data.access_token,
+		refreshToken: data.refresh_token,
+		// expires_in is seconds from now. Stored absolute so a warm function
+		// instance can read it without knowing when it was issued.
+		expiresAt: Date.now() + (Number(data.expires_in) || 3600) * 1000,
+	};
+}
+
+/**
+ * A usable Oura access token, refreshing and persisting as needed.
+ *
+ * @param {object} store the training Blobs store.
+ * @returns {Promise<string>}
+ * @throws {Error} with code "not_configured" when credentials are absent, so
+ *   callers can tell "no Oura set up" apart from "Oura is broken".
+ */
+export async function getOuraAccessToken(store) {
+	const clientId = getEnv("OURA_CLIENT_ID");
+	const clientSecret = getEnv("OURA_CLIENT_SECRET");
+	if (!clientId || !clientSecret) throw notConfigured("Oura client credentials missing");
+
+	const stored = await readJson(store, OURA_KEY, null);
+	if (stored?.accessToken && Number(stored.expiresAt) > Date.now() + EXPIRY_MARGIN_MS) {
+		return stored.accessToken;
+	}
+
+	const bootstrap = getEnv("OURA_REFRESH_TOKEN");
+	if (!stored?.refreshToken && !bootstrap) throw notConfigured("Oura refresh token missing");
+
+	const credentials = { clientId, clientSecret };
+	let next;
+	try {
+		next = await exchange(stored?.refreshToken || bootstrap, credentials);
+	} catch (err) {
+		// The stored chain is broken: either a rotation was lost, or the app
+		// was re-authorised elsewhere and this token was superseded. Falling
+		// back to the environment is what makes that recoverable without a
+		// deploy — and it's only worth trying if it's a different token.
+		const canRetry = stored?.refreshToken && bootstrap && bootstrap !== stored.refreshToken;
+		if (!canRetry) throw err;
+		console.warn("Oura stored refresh token rejected, falling back to OURA_REFRESH_TOKEN");
+		next = await exchange(bootstrap, credentials);
+	}
+
+	// Before returning it, not after. If this write fails the successor is
+	// gone, and continuing would spend a token nothing can follow.
+	await writeJson(store, OURA_KEY, { ...next, updatedAt: new Date().toISOString() });
+	return next.accessToken;
+}
+
+/**
+ * GET an Oura endpoint.
+ *
+ * @param {string} path e.g. "/v2/usercollection/daily_sleep".
+ * @param {string} token
+ * @param {object} [params] query parameters, undefined values dropped.
+ * @returns {Promise<object>}
+ */
+export async function ouraGet(path, token, params = {}) {
+	const query = new URLSearchParams(
+		Object.entries(params).filter(([, v]) => v !== undefined && v !== null),
+	);
+	const url = `${OURA_API_BASE}${path}${query.size ? `?${query}` : ""}`;
+	const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+	if (!res.ok) {
+		// 403 is its own thing here: Oura returns it when the membership has
+		// lapsed, and the data simply stops rather than the app being wrong.
+		const err = new Error(`Oura ${path} failed: ${res.status}`);
+		err.status = res.status;
+		throw err;
+	}
+	return res.json();
+}
+
+/**
+ * Every document from a paginated collection between two days, inclusive.
+ *
+ * @param {string} path
+ * @param {string} token
+ * @param {{start: string, end: string}} range day keys.
+ * @returns {Promise<object[]>}
+ */
+export async function ouraCollection(path, token, { start, end }) {
+	const out = [];
+	let nextToken;
+	// Bounded rather than while(true): a paging bug upstream shouldn't be able
+	// to spin a scheduled function until it's killed. A training block is a few
+	// hundred documents at most, well inside this.
+	for (let page = 0; page < 10; page++) {
+		const body = await ouraGet(path, token, {
+			"start_date": start,
+			"end_date": end,
+			"next_token": nextToken,
+		});
+		for (const doc of body?.data || []) out.push(doc);
+		nextToken = body?.next_token || undefined;
+		if (!nextToken) break;
+	}
+	return out;
+}

--- a/netlify/functions/_shared/oura.test.js
+++ b/netlify/functions/_shared/oura.test.js
@@ -1,0 +1,201 @@
+// Oura token handling.
+//
+// Worth testing more carefully than the rest of this integration, because the
+// failure mode is unrecoverable without a human. Oura invalidates a refresh
+// token as it's spent, so the successor returned alongside the access token is
+// the only way back in — spend one and fail to store it and the next sync has
+// nothing to present. Every assertion below is some version of "the successor
+// survived".
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getOuraAccessToken, ouraCollection } from "./oura.js";
+
+const blobs = new Map();
+const store = {
+	get: vi.fn(async (key) => blobs.get(key) ?? null),
+	setJSON: vi.fn(async (key, value) => {
+		blobs.set(key, value);
+	}),
+};
+
+const stored = () => blobs.get("oura.json") || null;
+
+// A token response, with a successor that's deliberately never the token that
+// was spent to get it.
+function tokenReply({ access = "access-1", refresh = "refresh-2", expiresIn = 86400 } = {}) {
+	return new Response(
+		JSON.stringify({ access_token: access, refresh_token: refresh, expires_in: expiresIn }),
+		{ status: 200 },
+	);
+}
+
+beforeEach(() => {
+	blobs.clear();
+	store.get.mockClear();
+	store.setJSON.mockClear();
+	process.env.OURA_CLIENT_ID = "id";
+	process.env.OURA_CLIENT_SECRET = "secret";
+	process.env.OURA_REFRESH_TOKEN = "bootstrap";
+});
+
+describe("getOuraAccessToken", () => {
+	it("reports missing credentials as configuration rather than failure", async () => {
+		// The caller tells these apart: an unconfigured ring is the normal
+		// state of a fresh checkout and mustn't look like a broken sync.
+		delete process.env.OURA_CLIENT_ID;
+		await expect(getOuraAccessToken(store)).rejects.toMatchObject({ code: "not_configured" });
+
+		process.env.OURA_CLIENT_ID = "id";
+		delete process.env.OURA_REFRESH_TOKEN;
+		await expect(getOuraAccessToken(store)).rejects.toMatchObject({ code: "not_configured" });
+	});
+
+	it("bootstraps from the environment when nothing is stored yet", async () => {
+		globalThis.fetch = vi.fn(async () => tokenReply());
+
+		expect(await getOuraAccessToken(store)).toBe("access-1");
+
+		const body = globalThis.fetch.mock.calls[0][1].body;
+		expect(body.get("grant_type")).toBe("refresh_token");
+		expect(body.get("refresh_token")).toBe("bootstrap");
+	});
+
+	it("stores the successor, not the token it just spent", async () => {
+		// The single most important line in this file. Oura has already
+		// invalidated "bootstrap" by the time this resolves.
+		globalThis.fetch = vi.fn(async () => tokenReply({ refresh: "refresh-2" }));
+
+		await getOuraAccessToken(store);
+
+		expect(stored().refreshToken).toBe("refresh-2");
+		expect(stored().accessToken).toBe("access-1");
+		expect(stored().expiresAt).toBeGreaterThan(Date.now());
+	});
+
+	it("writes the successor before handing out the access token", async () => {
+		// Ordering, not just eventual state: returning first and writing
+		// after would lose the successor to any failure in between, and the
+		// access token would still have been spent.
+		let writtenBeforeReturn = false;
+		globalThis.fetch = vi.fn(async () => tokenReply());
+		store.setJSON.mockImplementationOnce(async (key, value) => {
+			writtenBeforeReturn = true;
+			blobs.set(key, value);
+		});
+
+		await getOuraAccessToken(store);
+		expect(writtenBeforeReturn).toBe(true);
+	});
+
+	it("reuses a stored access token rather than spending a refresh", async () => {
+		blobs.set("oura.json", {
+			accessToken: "still-good",
+			refreshToken: "refresh-9",
+			expiresAt: Date.now() + 3_600_000,
+		});
+		globalThis.fetch = vi.fn(async () => tokenReply());
+
+		expect(await getOuraAccessToken(store)).toBe("still-good");
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it("refreshes an access token that's about to expire", async () => {
+		// Not on expiry: a token with thirty seconds left would be spent
+		// mid-sync. The margin is what stops that being a race.
+		blobs.set("oura.json", {
+			accessToken: "nearly-done",
+			refreshToken: "refresh-9",
+			expiresAt: Date.now() + 60_000,
+		});
+		globalThis.fetch = vi.fn(async () => tokenReply({ access: "access-fresh" }));
+
+		expect(await getOuraAccessToken(store)).toBe("access-fresh");
+	});
+
+	it("prefers the stored refresh token over the bootstrap", async () => {
+		blobs.set("oura.json", { refreshToken: "refresh-9", expiresAt: 0 });
+		globalThis.fetch = vi.fn(async () => tokenReply());
+
+		await getOuraAccessToken(store);
+		expect(globalThis.fetch.mock.calls[0][1].body.get("refresh_token")).toBe("refresh-9");
+	});
+
+	it("falls back to the bootstrap when the stored chain is broken", async () => {
+		// The recovery path, and the reason OURA_REFRESH_TOKEN stays set
+		// after the first sync: re-run the script, paste the new value into
+		// Netlify, and the next sync heals itself without a deploy.
+		blobs.set("oura.json", { refreshToken: "stale", expiresAt: 0 });
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(new Response("nope", { status: 400 }))
+			.mockResolvedValueOnce(tokenReply({ access: "recovered" }));
+
+		expect(await getOuraAccessToken(store)).toBe("recovered");
+		expect(globalThis.fetch.mock.calls[1][1].body.get("refresh_token")).toBe("bootstrap");
+		expect(stored().refreshToken).toBe("refresh-2");
+	});
+
+	it("doesn't retry with a bootstrap that's the same token", async () => {
+		// It was just refused. Asking twice only spends another request to
+		// be told the same thing.
+		blobs.set("oura.json", { refreshToken: "bootstrap", expiresAt: 0 });
+		globalThis.fetch = vi.fn(async () => new Response("nope", { status: 400 }));
+
+		await expect(getOuraAccessToken(store)).rejects.toThrow(/400/);
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("refuses a response with no successor in it", async () => {
+		// An access token without its refresh token is a dead end one sync
+		// later, so it's treated as a failed refresh rather than stored.
+		globalThis.fetch = vi.fn(
+			async () => new Response(JSON.stringify({ access_token: "orphan" }), { status: 200 }),
+		);
+
+		await expect(getOuraAccessToken(store)).rejects.toThrow(/no token/);
+		expect(stored()).toBeNull();
+	});
+});
+
+describe("ouraCollection", () => {
+	it("follows the pages and returns every document", async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ data: [{ day: "2026-08-10" }], next_token: "n1" })),
+			)
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ data: [{ day: "2026-08-11" }], next_token: null })),
+			);
+
+		const out = await ouraCollection("/v2/usercollection/sleep", "tok", {
+			start: "2026-08-01",
+			end: "2026-08-11",
+		});
+
+		expect(out.map((d) => d.day)).toEqual(["2026-08-10", "2026-08-11"]);
+		expect(new URL(globalThis.fetch.mock.calls[0][0]).searchParams.get("start_date")).toBe("2026-08-01");
+		expect(new URL(globalThis.fetch.mock.calls[1][0]).searchParams.get("next_token")).toBe("n1");
+	});
+
+	it("gives up rather than paging for ever", async () => {
+		// A cursor that never terminates would otherwise spin a scheduled
+		// function until the platform kills it.
+		globalThis.fetch = vi.fn(
+			async () => new Response(JSON.stringify({ data: [{ day: "2026-08-10" }], next_token: "loop" })),
+		);
+
+		await ouraCollection("/v2/usercollection/sleep", "tok", { start: "a", end: "b" });
+		expect(globalThis.fetch.mock.calls.length).toBeLessThanOrEqual(10);
+	});
+
+	it("carries the status through on a refusal", async () => {
+		// 403 is the membership having lapsed rather than anything here
+		// being wrong, and the sync logs them differently.
+		globalThis.fetch = vi.fn(async () => new Response("no", { status: 403 }));
+
+		await expect(
+			ouraCollection("/v2/usercollection/sleep", "tok", { start: "a", end: "b" }),
+		).rejects.toMatchObject({ status: 403 });
+	});
+});

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -24,6 +24,7 @@ import {
 	weeksToRace,
 } from "./plan.js";
 import { recommendations } from "./recommend.js";
+import { recoverySummary } from "./recovery.js";
 import { toDayKey } from "./dates.js";
 
 // How far back the intensity distribution looks. A whole block averages away
@@ -94,9 +95,11 @@ function planDays(week, runs, today) {
  * @param {object[]} input.activities shaped activities, any order.
  * @param {object} input.plan parsed marathon-plan.json.
  * @param {string} input.today day key.
+ * @param {object[]} [input.recovery] shaped nights from the Oura ring. Optional
+ *   throughout: the page predates it and reads the same without it.
  * @returns {object}
  */
-export function buildDashboard({ activities = [], plan = {}, today }) {
+export function buildDashboard({ activities = [], plan = {}, today, recovery = [] }) {
 	const day = toDayKey(today) || toDayKey(new Date());
 	const sorted = [...activities].sort((a, b) =>
 		String(a.startDateLocal).localeCompare(String(b.startDateLocal)),
@@ -156,6 +159,12 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 	// efficiency trend needs in order to compare like with like.
 	const zoneFloors = hrZoneFloors(thresholds);
 	const efficiency = efficiencyTrend(runs, { aerobicCeilingHr: zoneFloors?.[3] ?? null });
+
+	// Deliberately computed after everything above it and read by none of it.
+	// Recovery is the one input here that isn't training load, and the fitness
+	// model stays a closed system fed only by load — see recovery.js. It
+	// reaches the payload and the recommendations, and nothing else.
+	const recovered = recoverySummary(recovery, { today: day });
 
 	const prediction = predictRace(collectBestEfforts(runs), race.distanceM || 42195);
 	const goalPace = goalPaceSecPerKm(race.goalTimeSec, race.distanceM || 42195);
@@ -262,6 +271,7 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 		goal: { goalTimeSec: race.goalTimeSec, goalPaceSecPerKm: goalPace },
 		daysToRace: remainingDays,
 		longRunDecouplingPct: lastLongRun?.decouplingPct ?? null,
+		recovery: recovered,
 	});
 
 	return {
@@ -272,6 +282,9 @@ export function buildDashboard({ activities = [], plan = {}, today }) {
 		// day is empty by construction and would draw a slide to zero.
 		series: series.filter((d) => d.date <= day),
 		efficiency: { points: efficiency.points, trend: efficiency.trend },
+		// Null rather than an empty shell when the ring has nothing to say, so
+		// the panel can be absent instead of drawing a row of dashes.
+		recovery: recovered,
 		weeks,
 		week: current
 			? {

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -527,3 +527,91 @@ describe("buildDashboard with rides", () => {
 		expect(out.runs.every((a) => a.sport === "run")).toBe(true);
 	});
 });
+
+// Recovery is the second input this page takes that isn't training load, and
+// the rides taught the expensive version of this lesson: the fitness model is
+// a closed system, and a second source reaching part of it breaks the
+// equilibrium that makes form mean anything. So the same assertion as the
+// rides get — every training number identical — except here it holds for the
+// whole payload rather than only the model, because recovery earns its place
+// in the recommendations instead.
+describe("buildDashboard with recovery", () => {
+	const HOURS = (h) => Math.round(h * 3600);
+
+	// Four weeks of nights ending today, so the baselines have something to
+	// be a baseline of.
+	const nights = (patch = {}) =>
+		Array.from({ length: 28 }, (_, i) => {
+			const date = new Date(Date.UTC(2026, 6, 16 + i));
+			return {
+				day: date.toISOString().slice(0, 10),
+				sleepSec: HOURS(8),
+				restingHr: 47,
+				averageHrv: 65,
+				...patch,
+			};
+		});
+
+	const withoutRing = () =>
+		buildDashboard({ activities: block("2026-08-11", 10), plan: PLAN, today: "2026-08-11" });
+	const withRing = (patch) =>
+		buildDashboard({
+			activities: block("2026-08-11", 10),
+			plan: PLAN,
+			today: "2026-08-11",
+			recovery: nights(patch),
+		});
+
+	it("moves no training number at all", () => {
+		const before = withoutRing();
+		const after = withRing({ sleepSec: HOURS(4), restingHr: 62 });
+		expect(after.series).toEqual(before.series);
+		expect(after.summary.latest).toEqual(before.summary.latest);
+		expect(after.summary.acwr).toEqual(before.summary.acwr);
+		expect(after.summary.totals).toEqual(before.summary.totals);
+		expect(after.weeks).toEqual(before.weeks);
+	});
+
+	it("carries the ring's own numbers into the payload", () => {
+		const out = withRing();
+		expect(out.recovery.sleep.recent).toBe(HOURS(8));
+		expect(out.recovery.restingHr.recent).toBe(47);
+		expect(out.recovery.latest.day).toBe("2026-08-11");
+		expect(out.recovery.series.length).toBeGreaterThan(0);
+	});
+
+	it("is absent rather than empty when there's no ring", () => {
+		// The panel should not exist at all, rather than drawing dashes.
+		expect(withoutRing().recovery).toBeNull();
+	});
+
+	it("reaches the advice, which is the whole point of collecting it", () => {
+		const ids = (out) => out.recommendations.map((r) => r.id);
+		expect(ids(withRing())).toContain("recovery-ok");
+		expect(ids(withoutRing())).not.toContain("recovery-ok");
+	});
+
+	it("reads sleep against the training rather than on its own", () => {
+		// This block is itself a ramp — ten runs in ten days against nothing
+		// before them — so five hours a night doesn't produce a note about
+		// sleep beside a note about load. It produces the one about both,
+		// which is the entire reason for collecting any of this.
+		const out = withRing({ sleepSec: HOURS(5) });
+		const ids = out.recommendations.map((r) => r.id);
+		expect(ids).toContain("sleep-and-ramp");
+		expect(ids).not.toContain("sleep-short");
+		expect(out.recommendations[0].severity).toBe("critical");
+	});
+});
+
+describe("legacy records", () => {
+	it("treats a record with no sport as a run, as every stored one is", () => {
+		// Everything already in Blobs was written before rides were tracked,
+		// and is served for as long as it takes the sync to re-shape it.
+		const legacy = block("2026-08-11", 3);
+		expect(legacy.every((a) => a.sport === undefined)).toBe(true);
+		const out = buildDashboard({ activities: legacy, plan: PLAN, today: "2026-08-11" });
+		expect(out.summary.totals.runs).toBe(3);
+		expect(out.runs.every((a) => a.sport === "run")).toBe(true);
+	});
+});

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -536,7 +536,7 @@ describe("buildDashboard with rides", () => {
 // whole payload rather than only the model, because recovery earns its place
 // in the recommendations instead.
 describe("buildDashboard with recovery", () => {
-	const HOURS = (h) => Math.round(h * 3600);
+	const hours = (h) => Math.round(h * 3600);
 
 	// Four weeks of nights ending today, so the baselines have something to
 	// be a baseline of.
@@ -545,7 +545,7 @@ describe("buildDashboard with recovery", () => {
 			const date = new Date(Date.UTC(2026, 6, 16 + i));
 			return {
 				day: date.toISOString().slice(0, 10),
-				sleepSec: HOURS(8),
+				sleepSec: hours(8),
 				restingHr: 47,
 				averageHrv: 65,
 				...patch,
@@ -564,7 +564,7 @@ describe("buildDashboard with recovery", () => {
 
 	it("moves no training number at all", () => {
 		const before = withoutRing();
-		const after = withRing({ sleepSec: HOURS(4), restingHr: 62 });
+		const after = withRing({ sleepSec: hours(4), restingHr: 62 });
 		expect(after.series).toEqual(before.series);
 		expect(after.summary.latest).toEqual(before.summary.latest);
 		expect(after.summary.acwr).toEqual(before.summary.acwr);
@@ -574,7 +574,7 @@ describe("buildDashboard with recovery", () => {
 
 	it("carries the ring's own numbers into the payload", () => {
 		const out = withRing();
-		expect(out.recovery.sleep.recent).toBe(HOURS(8));
+		expect(out.recovery.sleep.recent).toBe(hours(8));
 		expect(out.recovery.restingHr.recent).toBe(47);
 		expect(out.recovery.latest.day).toBe("2026-08-11");
 		expect(out.recovery.series.length).toBeGreaterThan(0);
@@ -596,7 +596,7 @@ describe("buildDashboard with recovery", () => {
 		// before them — so five hours a night doesn't produce a note about
 		// sleep beside a note about load. It produces the one about both,
 		// which is the entire reason for collecting any of this.
-		const out = withRing({ sleepSec: HOURS(5) });
+		const out = withRing({ sleepSec: hours(5) });
 		const ids = out.recommendations.map((r) => r.id);
 		expect(ids).toContain("sleep-and-ramp");
 		expect(ids).not.toContain("sleep-short");

--- a/netlify/functions/_shared/training/recommend.js
+++ b/netlify/functions/_shared/training/recommend.js
@@ -13,6 +13,7 @@
 
 import { ACWR_CEILING, ACWR_FLOOR, SAFE_RAMP_PCT } from "./fitness.js";
 import { EASY_SHARE_TARGET } from "./zones.js";
+import { HRV_DROP_PCT, RHR_RISE_BPM, SLEEP_TARGET_SEC } from "./recovery.js";
 
 // Ordering for display: the things that get you injured come before the things
 // that make you slower.
@@ -63,6 +64,7 @@ export function recommendations(metrics) {
 		goal = {},
 		daysToRace = null,
 		longRunDecouplingPct = null,
+		recovery = null,
 	} = metrics || {};
 
 	// --- Injury risk -------------------------------------------------------
@@ -152,6 +154,97 @@ export function recommendations(metrics) {
 				`The long run was ${share.toFixed(0)}% of ${thisOrLast}'s distance, above the ${LONG_RUN_SHARE_CEILING}% guideline. Add an easy midweek run rather than shortening the long one — the aerobic work is worth keeping.`,
 				share,
 				LONG_RUN_SHARE_CEILING,
+			),
+		);
+	}
+
+	// --- Recovery ----------------------------------------------------------
+	//
+	// The only rules here that read something other than training load. They
+	// exist because load is blind to the thing that decides whether a week of
+	// running is absorbed or merely survived, and the combination is what's
+	// worth saying: a 12% ramp on eight hours a night and the same ramp on six
+	// are different propositions, and neither number says so alone.
+	//
+	// Nothing in this section changes a metric. It reads them, and says what
+	// the pair implies.
+
+	const sleep = recovery?.sleep || {};
+	const restingHr = recovery?.restingHr || {};
+	const hrv = recovery?.hrv || {};
+
+	const shortSleep = Number.isFinite(sleep.recent) && sleep.recent < SLEEP_TARGET_SEC;
+	const ramping =
+		(Number.isFinite(acwr.ratio) && acwr.ratio > ACWR_CEILING) ||
+		(Number.isFinite(basis.rampPct) && basis.rampPct > SAFE_RAMP_PCT);
+
+	if (shortSleep && ramping) {
+		const why = Number.isFinite(acwr.ratio) && acwr.ratio > ACWR_CEILING
+			? `an acute:chronic ratio of ${acwr.ratio.toFixed(2)}`
+			: `a ${basis.rampPct.toFixed(0)}% jump in volume`;
+		out.push(
+			rule(
+				"sleep-and-ramp",
+				"critical",
+				"You're adding load faster than you're recovering from it",
+				`${duration(sleep.recent)} a night on average over the last week, against ${why}. Short sleep is one of the better-evidenced injury risk factors in athletes, and it compounds a ramp rather than sitting alongside it — the same week of running is a different proposition on eight hours than on ${duration(sleep.recent)}. Hold the volume where it is until sleep comes back up.`,
+				sleep.recent,
+				SLEEP_TARGET_SEC,
+			),
+		);
+	} else if (shortSleep) {
+		out.push(
+			rule(
+				"sleep-short",
+				"warning",
+				"You're running short on sleep",
+				`${duration(sleep.recent)} a night over the last week, against a ${duration(SLEEP_TARGET_SEC)} floor${Number.isFinite(sleep.baseline) ? ` and your own ${duration(sleep.baseline)} average` : ""}. Sleep is where the adaptation actually happens, so this quietly costs you more of the training than a missed easy run would.`,
+				sleep.recent,
+				SLEEP_TARGET_SEC,
+			),
+		);
+	}
+
+	if (Number.isFinite(restingHr.delta) && restingHr.delta >= RHR_RISE_BPM) {
+		out.push(
+			rule(
+				"rhr-elevated",
+				"warning",
+				"Your overnight heart rate is up",
+				`Averaging ${restingHr.recent.toFixed(0)} bpm over the last week against a ${restingHr.baseline.toFixed(0)} bpm baseline, up ${restingHr.delta.toFixed(0)}. A rise of ${RHR_RISE_BPM} or more usually means something the training log can't see: illness coming on, or work you haven't absorbed yet. Worth an easy few days before a key session rather than after one.`,
+				restingHr.delta,
+				RHR_RISE_BPM,
+			),
+		);
+	}
+
+	if (Number.isFinite(hrv.deltaPct) && hrv.deltaPct <= -HRV_DROP_PCT) {
+		out.push(
+			rule(
+				"hrv-suppressed",
+				"info",
+				"Heart-rate variability is below your baseline",
+				`${hrv.recent.toFixed(0)} ms over the last week against a ${hrv.baseline.toFixed(0)} ms baseline, down ${Math.abs(hrv.deltaPct).toFixed(0)}%. HRV is noisy night to night and this is a week against a month, so it's worth noting rather than acting on alone — but read it alongside the resting heart rate above.`,
+				hrv.deltaPct,
+				-HRV_DROP_PCT,
+			),
+		);
+	}
+
+	// Only worth saying when there was enough data to have said otherwise.
+	if (
+		Number.isFinite(sleep.recent) &&
+		!shortSleep &&
+		!(Number.isFinite(restingHr.delta) && restingHr.delta >= RHR_RISE_BPM)
+	) {
+		out.push(
+			rule(
+				"recovery-ok",
+				"good",
+				"You're recovering as fast as you're training",
+				`${duration(sleep.recent)} a night over the last week${Number.isFinite(restingHr.recent) ? `, with overnight heart rate at ${restingHr.recent.toFixed(0)} bpm` : ""}. Nothing here says the training isn't being absorbed.`,
+				sleep.recent,
+				SLEEP_TARGET_SEC,
 			),
 		);
 	}

--- a/netlify/functions/_shared/training/recommend.test.js
+++ b/netlify/functions/_shared/training/recommend.test.js
@@ -125,6 +125,98 @@ describe("recommendations", () => {
 		expect(out.at(-1).severity).toBe("good");
 	});
 
+	// The recovery rules are the only ones reading something other than
+	// training load. What they're for is the combination: load is blind to
+	// whether a week was absorbed or merely survived, and sleep alone doesn't
+	// know whether you were also ramping.
+	describe("recovery", () => {
+		const HOURS = (h) => Math.round(h * 3600);
+		const slept = (h) => ({ recovery: { sleep: { recent: HOURS(h), baseline: HOURS(8) } } });
+
+		it("says nothing at all without a ring", () => {
+			const out = recommendations({ acwr: { ratio: 1.9 } });
+			expect(ids(out)).not.toContain("sleep-short");
+			expect(ids(out)).not.toContain("recovery-ok");
+		});
+
+		it("flags sustained short sleep on its own", () => {
+			const rec = find(recommendations(slept(6)), "sleep-short");
+			expect(rec.severity).toBe("warning");
+			expect(rec.detail).toContain("6h 0m");
+			// Against the athlete's own normal, not just the floor.
+			expect(rec.detail).toContain("8h 0m");
+		});
+
+		it("raises it to critical when the volume is also climbing", () => {
+			const out = recommendations({
+				...slept(6),
+				acwr: { ratio: 1.7 },
+			});
+			const rec = find(out, "sleep-and-ramp");
+			expect(rec.severity).toBe("critical");
+			expect(rec.detail).toContain("1.70");
+			// One rule about the pair, not two rules about the halves.
+			expect(ids(out)).not.toContain("sleep-short");
+		});
+
+		it("counts a volume jump as ramping too, not just the ratio", () => {
+			const out = recommendations({
+				...slept(6),
+				rampBasis: { rampPct: 22, actualKm: 70, previousKm: 57 },
+			});
+			expect(find(out, "sleep-and-ramp").detail).toContain("22%");
+		});
+
+		it("leaves short sleep alone when the training is steady", () => {
+			const out = recommendations({ ...slept(6), acwr: { ratio: 1.0 } });
+			expect(ids(out)).toContain("sleep-short");
+			expect(ids(out)).not.toContain("sleep-and-ramp");
+		});
+
+		it("flags an overnight heart rate above baseline", () => {
+			const rec = find(
+				recommendations({ recovery: { restingHr: { recent: 54, baseline: 47, delta: 7 } } }),
+				"rhr-elevated",
+			);
+			expect(rec.severity).toBe("warning");
+			expect(rec.threshold).toBe(5);
+			expect(rec.detail).toContain("54 bpm");
+		});
+
+		it("stays quiet on a heart rate that has barely moved", () => {
+			const out = recommendations({ recovery: { restingHr: { recent: 49, baseline: 47, delta: 2 } } });
+			expect(ids(out)).not.toContain("rhr-elevated");
+		});
+
+		it("notes suppressed variability without making it an instruction", () => {
+			const rec = find(
+				recommendations({ recovery: { hrv: { recent: 48, baseline: 65, deltaPct: -26 } } }),
+				"hrv-suppressed",
+			);
+			// Noisy enough night to night that it's context, not a verdict.
+			expect(rec.severity).toBe("info");
+			expect(rec.detail).toContain("26%");
+		});
+
+		it("confirms recovery is keeping up rather than only ever warning", () => {
+			const out = recommendations({
+				recovery: { sleep: { recent: HOURS(8) }, restingHr: { recent: 47, baseline: 47, delta: 0 } },
+			});
+			expect(find(out, "recovery-ok").severity).toBe("good");
+		});
+
+		it("won't call it fine while the heart rate is up", () => {
+			const out = recommendations({
+				recovery: {
+					sleep: { recent: HOURS(8) },
+					restingHr: { recent: 55, baseline: 47, delta: 8 },
+				},
+			});
+			expect(ids(out)).toContain("rhr-elevated");
+			expect(ids(out)).not.toContain("recovery-ok");
+		});
+	});
+
 	it("carries the triggering metric and threshold on every rule", () => {
 		const out = recommendations({
 			acwr: { ratio: 1.9 },

--- a/netlify/functions/_shared/training/recommend.test.js
+++ b/netlify/functions/_shared/training/recommend.test.js
@@ -130,8 +130,8 @@ describe("recommendations", () => {
 	// whether a week was absorbed or merely survived, and sleep alone doesn't
 	// know whether you were also ramping.
 	describe("recovery", () => {
-		const HOURS = (h) => Math.round(h * 3600);
-		const slept = (h) => ({ recovery: { sleep: { recent: HOURS(h), baseline: HOURS(8) } } });
+		const hours = (h) => Math.round(h * 3600);
+		const slept = (h) => ({ recovery: { sleep: { recent: hours(h), baseline: hours(8) } } });
 
 		it("says nothing at all without a ring", () => {
 			const out = recommendations({ acwr: { ratio: 1.9 } });
@@ -200,7 +200,7 @@ describe("recommendations", () => {
 
 		it("confirms recovery is keeping up rather than only ever warning", () => {
 			const out = recommendations({
-				recovery: { sleep: { recent: HOURS(8) }, restingHr: { recent: 47, baseline: 47, delta: 0 } },
+				recovery: { sleep: { recent: hours(8) }, restingHr: { recent: 47, baseline: 47, delta: 0 } },
 			});
 			expect(find(out, "recovery-ok").severity).toBe("good");
 		});
@@ -208,7 +208,7 @@ describe("recommendations", () => {
 		it("won't call it fine while the heart rate is up", () => {
 			const out = recommendations({
 				recovery: {
-					sleep: { recent: HOURS(8) },
+					sleep: { recent: hours(8) },
 					restingHr: { recent: 55, baseline: 47, delta: 8 },
 				},
 			});

--- a/netlify/functions/_shared/training/recovery.js
+++ b/netlify/functions/_shared/training/recovery.js
@@ -1,0 +1,233 @@
+// Sleep and overnight heart rate, from the Oura ring.
+//
+// This is the one part of the dashboard fed by something other than training
+// load, and it is deliberately kept beside the fitness model rather than wired
+// into it. CTL, ATL and form are a closed system: both traces are averages of
+// the same daily load, which is what makes them converge and what makes form
+// readable at all (see fitness.js). Feeding a second source into part of that
+// system is exactly how rides put form permanently underwater. Recovery data
+// therefore has its own panel and its own recommendation rules, and touches no
+// existing number.
+//
+// What it's for is the thing training load genuinely can't see. Load says how
+// much work you did; it has no idea whether you slept five hours or nine
+// afterwards, and the same week of running is a different proposition depending
+// on the answer. Chronic short sleep is one of the better-evidenced injury risk
+// factors in athletes, and overnight resting heart rate is a long-standing
+// marker of illness and accumulated overreaching — both measured while asleep,
+// which is why a ring reads them better than a watch ever did.
+//
+// The windows are 7 days against 28, matching ACWR exactly. That's not a
+// coincidence worth hiding: the page already explains acute-versus-chronic in
+// those terms, and reusing the shape means "recent against established" means
+// the same thing everywhere.
+
+import { ACUTE_DAYS, CHRONIC_DAYS } from "./fitness.js";
+import { reading } from "./num.js";
+import { addDays, eachDay, toDayKey } from "./dates.js";
+
+// The night, as opposed to an afternoon nap. Oura types a main sleep period as
+// `long_sleep` once it passes three hours; `sleep` covers shorter main periods.
+// Naps and rest periods are excluded on purpose: a nap's lowest heart rate is
+// not your overnight resting rate, and counting one towards the night's total
+// would say you slept well when you slept twice.
+const MAIN_SLEEP_TYPES = new Set(["long_sleep", "sleep"]);
+
+// Sleep below this, sustained, is where the injury-risk association starts to
+// show up. Held as a nightly average rather than a single bad night, because
+// one short night is life and nine of them is a pattern.
+export const SLEEP_TARGET_SEC = 7 * 3600;
+
+// Overnight resting heart rate this far above baseline suggests something the
+// training log can't see: illness coming on, or work not being absorbed. Oura's
+// overnight figure is stable enough that five beats is well clear of noise.
+export const RHR_RISE_BPM = 5;
+
+// A fall in heart-rate variability of this much against baseline points the
+// same way. HRV is noisy night to night, which is why this reads a seven-day
+// average against a month rather than yesterday against the day before.
+export const HRV_DROP_PCT = 15;
+
+// Below this many nights in a window, an average is describing the gaps as much
+// as the sleep, so nothing is reported rather than reporting a number built
+// from two nights that happen to be in range.
+const MIN_NIGHTS = 3;
+
+/** The main sleep period of a night, or null if there wasn't one. */
+function mainPeriod(periods) {
+	const nights = (periods || []).filter((p) => MAIN_SLEEP_TYPES.has(p?.type));
+	if (nights.length === 0) return null;
+	// More than one main period in a night is a broken sleep recorded as two.
+	// The longer one carries the heart-rate figures; durations are summed
+	// below, since you did sleep for both of them.
+	return nights.reduce((best, p) =>
+		(reading(p?.total_sleep_duration) || 0) > (reading(best?.total_sleep_duration) || 0) ? p : best,
+	);
+}
+
+/**
+ * Reduce a day's Oura documents to the record we store.
+ *
+ * Nothing here is derived — Oura has already done the sleep staging and the
+ * scoring, and re-deriving any of it from raw samples would be inventing a
+ * second opinion. This is a projection, not a model.
+ *
+ * @param {object} input
+ * @param {string} input.day day key.
+ * @param {object[]} [input.periods] sleep documents for that day.
+ * @param {object} [input.dailySleep] the daily_sleep document.
+ * @param {object} [input.readiness] the daily_readiness document.
+ * @returns {object|null} null when there's no night to describe.
+ */
+export function shapeNight({ day, periods = [], dailySleep = null, readiness = null }) {
+	const main = mainPeriod(periods);
+	if (!main) return null;
+
+	const nights = (periods || []).filter((p) => MAIN_SLEEP_TYPES.has(p?.type));
+	const sleepSec = nights.reduce((sum, p) => sum + (reading(p?.total_sleep_duration) || 0), 0);
+	if (!(sleepSec > 0)) return null;
+
+	const finite = (value) => (Number.isFinite(reading(value)) ? reading(value) : null);
+
+	return {
+		day,
+		sleepSec,
+		timeInBedSec: finite(main.time_in_bed),
+		efficiencyPct: finite(main.efficiency),
+		latencySec: finite(main.latency),
+		remSec: finite(main.rem_sleep_duration),
+		deepSec: finite(main.deep_sleep_duration),
+		// Oura's own term is "lowest heart rate", and overnight it's the
+		// closest thing to a true resting rate anything here measures.
+		restingHr: finite(main.lowest_heart_rate),
+		averageHrv: finite(main.average_hrv),
+		sleepScore: finite(dailySleep?.score),
+		readinessScore: finite(readiness?.score),
+		temperatureDeviationC: finite(readiness?.temperature_deviation),
+	};
+}
+
+/**
+ * Shape whole collections into one record per day, oldest first.
+ *
+ * @param {object} input
+ * @param {object[]} [input.sleep] /v2/usercollection/sleep documents.
+ * @param {object[]} [input.dailySleep] /v2/usercollection/daily_sleep documents.
+ * @param {object[]} [input.readiness] /v2/usercollection/daily_readiness documents.
+ * @returns {object[]}
+ */
+export function shapeRecovery({ sleep = [], dailySleep = [], readiness = [] }) {
+	const byDay = new Map();
+	for (const doc of sleep) {
+		const day = toDayKey(doc?.day);
+		if (!day) continue;
+		if (!byDay.has(day)) byDay.set(day, []);
+		byDay.get(day).push(doc);
+	}
+	const index = (docs) => new Map((docs || []).map((d) => [toDayKey(d?.day), d]).filter(([k]) => k));
+	const sleepScores = index(dailySleep);
+	const readinessScores = index(readiness);
+
+	return [...byDay.entries()]
+		.map(([day, periods]) =>
+			shapeNight({
+				day,
+				periods,
+				dailySleep: sleepScores.get(day) || null,
+				readiness: readinessScores.get(day) || null,
+			}),
+		)
+		.filter(Boolean)
+		.sort((a, b) => a.day.localeCompare(b.day));
+}
+
+/**
+ * Mean of one field across a window ending on `to`, ignoring days with no
+ * reading at all.
+ *
+ * Missing days are skipped rather than counted as zero, which is the opposite
+ * of how daily training load works and matters more than it sounds. A day with
+ * no run really is a day of no load; a night with no record is a night the ring
+ * was on a bedside table, and averaging it in as "no sleep" would manufacture
+ * exactly the alarm this is supposed to raise honestly.
+ *
+ * @param {object[]} records
+ * @param {string} field
+ * @param {{to: string, days: number}} window
+ * @returns {{mean: number|null, nights: number}}
+ */
+export function windowMean(records, field, { to, days }) {
+	const from = addDays(to, -(days - 1));
+	if (!from) return { mean: null, nights: 0 };
+	const span = new Set(eachDay(from, to));
+	let total = 0;
+	let nights = 0;
+	for (const record of records || []) {
+		if (!span.has(record?.day)) continue;
+		const value = reading(record?.[field]);
+		if (!Number.isFinite(value)) continue;
+		total += value;
+		nights += 1;
+	}
+	return { mean: nights >= MIN_NIGHTS ? total / nights : null, nights };
+}
+
+// Recent against established, for one measure. Returns nulls rather than a
+// partial answer, so the panel can say "not enough nights yet" instead of
+// drawing a delta against a baseline of four numbers.
+function trend(records, field, today) {
+	const acute = windowMean(records, field, { to: today, days: ACUTE_DAYS });
+	const baseline = windowMean(records, field, { to: today, days: CHRONIC_DAYS });
+	const delta =
+		acute.mean !== null && baseline.mean !== null ? acute.mean - baseline.mean : null;
+	return {
+		recent: acute.mean,
+		baseline: baseline.mean,
+		delta,
+		deltaPct:
+			delta !== null && baseline.mean > 0 ? (delta / baseline.mean) * 100 : null,
+		nights: acute.nights,
+	};
+}
+
+/**
+ * The recovery half of the dashboard payload.
+ *
+ * @param {object[]} records shaped nights, any order.
+ * @param {{today: string, days?: number}} options
+ * @returns {object|null} null when there's nothing recorded at all, so the
+ *   panel can be absent rather than empty.
+ */
+export function recoverySummary(records, { today, days = CHRONIC_DAYS }) {
+	const day = toDayKey(today);
+	const sorted = [...(records || [])]
+		.filter((r) => r?.day && r.day <= day)
+		.sort((a, b) => a.day.localeCompare(b.day));
+	if (sorted.length === 0) return null;
+
+	const from = addDays(day, -(days - 1));
+	const window = new Set(eachDay(from, day));
+
+	return {
+		// The most recent night on record, which on a morning before the ring
+		// has synced is the night before last. Dated so the page can say so
+		// rather than implying it's last night.
+		latest: sorted.at(-1),
+		sleep: trend(sorted, "sleepSec", day),
+		restingHr: trend(sorted, "restingHr", day),
+		hrv: trend(sorted, "averageHrv", day),
+		// Enough to draw a month of sparklines, and no more: this is served
+		// publicly, and a longer history says more about the person than it
+		// does about the training.
+		series: sorted
+			.filter((r) => window.has(r.day))
+			.map((r) => ({
+				day: r.day,
+				sleepSec: r.sleepSec,
+				restingHr: r.restingHr,
+				averageHrv: r.averageHrv,
+				sleepScore: r.sleepScore,
+				readinessScore: r.readinessScore,
+			})),
+	};
+}

--- a/netlify/functions/_shared/training/recovery.test.js
+++ b/netlify/functions/_shared/training/recovery.test.js
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+	HRV_DROP_PCT,
+	RHR_RISE_BPM,
+	SLEEP_TARGET_SEC,
+	recoverySummary,
+	shapeNight,
+	shapeRecovery,
+	windowMean,
+} from "./recovery.js";
+import { addDays } from "./dates.js";
+
+const HOURS = (h) => Math.round(h * 3600);
+
+function period(overrides = {}) {
+	return {
+		day: "2026-08-11",
+		type: "long_sleep",
+		"total_sleep_duration": HOURS(7.5),
+		"time_in_bed": HOURS(8),
+		efficiency: 91,
+		latency: 600,
+		"rem_sleep_duration": HOURS(1.6),
+		"deep_sleep_duration": HOURS(1.2),
+		"lowest_heart_rate": 47,
+		"average_hrv": 62,
+		...overrides,
+	};
+}
+
+describe("shapeNight", () => {
+	it("reads the night off the main sleep period", () => {
+		const night = shapeNight({
+			day: "2026-08-11",
+			periods: [period()],
+			dailySleep: { day: "2026-08-11", score: 84 },
+			readiness: { day: "2026-08-11", score: 79, "temperature_deviation": 0.2 },
+		});
+
+		expect(night.sleepSec).toBe(HOURS(7.5));
+		expect(night.restingHr).toBe(47);
+		expect(night.averageHrv).toBe(62);
+		expect(night.sleepScore).toBe(84);
+		expect(night.readinessScore).toBe(79);
+		expect(night.temperatureDeviationC).toBe(0.2);
+	});
+
+	it("ignores naps", () => {
+		// A nap's lowest heart rate is not your overnight resting rate, and
+		// counting one towards the total says you slept well when in fact you
+		// slept twice.
+		const night = shapeNight({
+			day: "2026-08-11",
+			periods: [period(), period({ type: "late_nap", "total_sleep_duration": HOURS(1), "lowest_heart_rate": 58 })],
+		});
+		expect(night.sleepSec).toBe(HOURS(7.5));
+		expect(night.restingHr).toBe(47);
+	});
+
+	it("sums a night that was recorded in two halves", () => {
+		const night = shapeNight({
+			day: "2026-08-11",
+			periods: [
+				period({ "total_sleep_duration": HOURS(5) }),
+				period({ "total_sleep_duration": HOURS(2), "lowest_heart_rate": 52 }),
+			],
+		});
+		expect(night.sleepSec).toBe(HOURS(7));
+		// The longer half carries the heart-rate figures.
+		expect(night.restingHr).toBe(47);
+	});
+
+	it("has nothing to say about a day with no main sleep", () => {
+		expect(shapeNight({ day: "2026-08-11", periods: [] })).toBeNull();
+		expect(shapeNight({ day: "2026-08-11", periods: [period({ type: "late_nap" })] })).toBeNull();
+		expect(
+			shapeNight({ day: "2026-08-11", periods: [period({ "total_sleep_duration": 0 })] }),
+		).toBeNull();
+	});
+});
+
+describe("shapeRecovery", () => {
+	it("joins the three collections by day, oldest first", () => {
+		const nights = shapeRecovery({
+			sleep: [period({ day: "2026-08-11" }), period({ day: "2026-08-09" })],
+			dailySleep: [{ day: "2026-08-09", score: 70 }],
+			readiness: [{ day: "2026-08-11", score: 88 }],
+		});
+
+		expect(nights.map((n) => n.day)).toEqual(["2026-08-09", "2026-08-11"]);
+		expect(nights[0].sleepScore).toBe(70);
+		expect(nights[0].readinessScore).toBeNull();
+		expect(nights[1].readinessScore).toBe(88);
+	});
+});
+
+describe("windowMean", () => {
+	const nights = [
+		{ day: "2026-08-09", sleepSec: HOURS(6) },
+		{ day: "2026-08-10", sleepSec: HOURS(8) },
+		{ day: "2026-08-11", sleepSec: HOURS(7) },
+	];
+
+	it("averages the window", () => {
+		expect(windowMean(nights, "sleepSec", { to: "2026-08-11", days: 3 }).mean).toBe(HOURS(7));
+	});
+
+	it("skips missing nights rather than counting them as no sleep", () => {
+		// The opposite of how daily training load works, and the difference
+		// matters: a day with no run really is a day of no load, but a night
+		// with no record is a ring left on a bedside table. Averaging it in as
+		// zero would manufacture the exact alarm this is meant to raise.
+		const withGap = [
+			{ day: "2026-08-05", sleepSec: HOURS(8) },
+			{ day: "2026-08-10", sleepSec: HOURS(8) },
+			{ day: "2026-08-11", sleepSec: HOURS(8) },
+		];
+		const out = windowMean(withGap, "sleepSec", { to: "2026-08-11", days: 7 });
+		expect(out.mean).toBe(HOURS(8));
+		expect(out.nights).toBe(3);
+	});
+
+	it("says nothing rather than averaging one or two nights", () => {
+		const sparse = [{ day: "2026-08-11", sleepSec: HOURS(4) }];
+		expect(windowMean(sparse, "sleepSec", { to: "2026-08-11", days: 7 }).mean).toBeNull();
+	});
+
+	it("ignores a field the night doesn't carry", () => {
+		const noHrv = [
+			{ day: "2026-08-09", averageHrv: 60 },
+			{ day: "2026-08-10" },
+			{ day: "2026-08-11", averageHrv: 70 },
+		];
+		const out = windowMean(noHrv, "averageHrv", { to: "2026-08-11", days: 7 });
+		expect(out.nights).toBe(2);
+		expect(out.mean).toBeNull(); // two readings is under the floor
+	});
+});
+
+// A month of identical nights, so a test only has to say how the recent ones
+// differed from the established normal.
+function block(today, { sleepSec = HOURS(8), restingHr = 48, averageHrv = 65, days = 28 } = {}) {
+	return Array.from({ length: days }, (_, i) => ({
+		day: addDays(today, -(days - 1 - i)),
+		sleepSec,
+		restingHr,
+		averageHrv,
+	}));
+}
+
+// Replace the last seven nights, leaving the baseline behind them intact.
+function recent(nights, patch) {
+	return nights.map((n, i) => (i >= nights.length - 7 ? { ...n, ...patch } : n));
+}
+
+describe("recoverySummary", () => {
+	const TODAY = "2026-08-11";
+
+	it("has nothing to say without any nights", () => {
+		expect(recoverySummary([], { today: TODAY })).toBeNull();
+	});
+
+	it("reads level when nothing has changed", () => {
+		const out = recoverySummary(block(TODAY), { today: TODAY });
+		expect(out.sleep.recent).toBe(HOURS(8));
+		expect(out.sleep.baseline).toBe(HOURS(8));
+		expect(out.sleep.delta).toBe(0);
+		expect(out.restingHr.delta).toBe(0);
+	});
+
+	it("measures the last week against the month behind it", () => {
+		const out = recoverySummary(recent(block(TODAY), { sleepSec: HOURS(6) }), { today: TODAY });
+		expect(out.sleep.recent).toBe(HOURS(6));
+		// The baseline is the whole 28 days, recent week included, which is
+		// the same acute-against-chronic shape ACWR uses.
+		expect(out.sleep.baseline).toBeLessThan(HOURS(8));
+		expect(out.sleep.delta).toBeLessThan(0);
+		expect(out.sleep.recent).toBeLessThan(SLEEP_TARGET_SEC);
+	});
+
+	it("catches a resting heart rate that has climbed", () => {
+		const out = recoverySummary(recent(block(TODAY), { restingHr: 56 }), { today: TODAY });
+		expect(out.restingHr.delta).toBeGreaterThanOrEqual(RHR_RISE_BPM);
+	});
+
+	it("catches heart-rate variability falling away", () => {
+		const out = recoverySummary(recent(block(TODAY), { averageHrv: 40 }), { today: TODAY });
+		expect(out.hrv.deltaPct).toBeLessThanOrEqual(-HRV_DROP_PCT);
+	});
+
+	it("ignores anything logged after today", () => {
+		const nights = [...block(TODAY), { day: "2026-08-20", sleepSec: HOURS(1), restingHr: 90 }];
+		const out = recoverySummary(nights, { today: TODAY });
+		expect(out.latest.day).toBe(TODAY);
+		expect(out.series.every((n) => n.day <= TODAY)).toBe(true);
+	});
+
+	it("dates the latest night, which needn't be last night", () => {
+		// Before the ring syncs in the morning, the most recent night on
+		// record is the one before — the panel says which rather than
+		// implying it's current.
+		const nights = block(TODAY).slice(0, -1);
+		const out = recoverySummary(nights, { today: TODAY });
+		expect(out.latest.day).toBe(addDays(TODAY, -1));
+	});
+
+	it("serves a month of nights and no more", () => {
+		const out = recoverySummary(block(TODAY, { days: 90 }), { today: TODAY });
+		expect(out.series).toHaveLength(28);
+		// And nothing beyond what the panel draws.
+		expect(Object.keys(out.series[0]).sort()).toEqual([
+			"averageHrv",
+			"day",
+			"readinessScore",
+			"restingHr",
+			"sleepScore",
+			"sleepSec",
+		]);
+	});
+});

--- a/netlify/functions/_shared/training/recovery.test.js
+++ b/netlify/functions/_shared/training/recovery.test.js
@@ -10,18 +10,18 @@ import {
 } from "./recovery.js";
 import { addDays } from "./dates.js";
 
-const HOURS = (h) => Math.round(h * 3600);
+const hours = (h) => Math.round(h * 3600);
 
 function period(overrides = {}) {
 	return {
 		day: "2026-08-11",
 		type: "long_sleep",
-		"total_sleep_duration": HOURS(7.5),
-		"time_in_bed": HOURS(8),
+		"total_sleep_duration": hours(7.5),
+		"time_in_bed": hours(8),
 		efficiency: 91,
 		latency: 600,
-		"rem_sleep_duration": HOURS(1.6),
-		"deep_sleep_duration": HOURS(1.2),
+		"rem_sleep_duration": hours(1.6),
+		"deep_sleep_duration": hours(1.2),
 		"lowest_heart_rate": 47,
 		"average_hrv": 62,
 		...overrides,
@@ -37,7 +37,7 @@ describe("shapeNight", () => {
 			readiness: { day: "2026-08-11", score: 79, "temperature_deviation": 0.2 },
 		});
 
-		expect(night.sleepSec).toBe(HOURS(7.5));
+		expect(night.sleepSec).toBe(hours(7.5));
 		expect(night.restingHr).toBe(47);
 		expect(night.averageHrv).toBe(62);
 		expect(night.sleepScore).toBe(84);
@@ -51,9 +51,9 @@ describe("shapeNight", () => {
 		// slept twice.
 		const night = shapeNight({
 			day: "2026-08-11",
-			periods: [period(), period({ type: "late_nap", "total_sleep_duration": HOURS(1), "lowest_heart_rate": 58 })],
+			periods: [period(), period({ type: "late_nap", "total_sleep_duration": hours(1), "lowest_heart_rate": 58 })],
 		});
-		expect(night.sleepSec).toBe(HOURS(7.5));
+		expect(night.sleepSec).toBe(hours(7.5));
 		expect(night.restingHr).toBe(47);
 	});
 
@@ -61,11 +61,11 @@ describe("shapeNight", () => {
 		const night = shapeNight({
 			day: "2026-08-11",
 			periods: [
-				period({ "total_sleep_duration": HOURS(5) }),
-				period({ "total_sleep_duration": HOURS(2), "lowest_heart_rate": 52 }),
+				period({ "total_sleep_duration": hours(5) }),
+				period({ "total_sleep_duration": hours(2), "lowest_heart_rate": 52 }),
 			],
 		});
-		expect(night.sleepSec).toBe(HOURS(7));
+		expect(night.sleepSec).toBe(hours(7));
 		// The longer half carries the heart-rate figures.
 		expect(night.restingHr).toBe(47);
 	});
@@ -96,13 +96,13 @@ describe("shapeRecovery", () => {
 
 describe("windowMean", () => {
 	const nights = [
-		{ day: "2026-08-09", sleepSec: HOURS(6) },
-		{ day: "2026-08-10", sleepSec: HOURS(8) },
-		{ day: "2026-08-11", sleepSec: HOURS(7) },
+		{ day: "2026-08-09", sleepSec: hours(6) },
+		{ day: "2026-08-10", sleepSec: hours(8) },
+		{ day: "2026-08-11", sleepSec: hours(7) },
 	];
 
 	it("averages the window", () => {
-		expect(windowMean(nights, "sleepSec", { to: "2026-08-11", days: 3 }).mean).toBe(HOURS(7));
+		expect(windowMean(nights, "sleepSec", { to: "2026-08-11", days: 3 }).mean).toBe(hours(7));
 	});
 
 	it("skips missing nights rather than counting them as no sleep", () => {
@@ -111,17 +111,17 @@ describe("windowMean", () => {
 		// with no record is a ring left on a bedside table. Averaging it in as
 		// zero would manufacture the exact alarm this is meant to raise.
 		const withGap = [
-			{ day: "2026-08-05", sleepSec: HOURS(8) },
-			{ day: "2026-08-10", sleepSec: HOURS(8) },
-			{ day: "2026-08-11", sleepSec: HOURS(8) },
+			{ day: "2026-08-05", sleepSec: hours(8) },
+			{ day: "2026-08-10", sleepSec: hours(8) },
+			{ day: "2026-08-11", sleepSec: hours(8) },
 		];
 		const out = windowMean(withGap, "sleepSec", { to: "2026-08-11", days: 7 });
-		expect(out.mean).toBe(HOURS(8));
+		expect(out.mean).toBe(hours(8));
 		expect(out.nights).toBe(3);
 	});
 
 	it("says nothing rather than averaging one or two nights", () => {
-		const sparse = [{ day: "2026-08-11", sleepSec: HOURS(4) }];
+		const sparse = [{ day: "2026-08-11", sleepSec: hours(4) }];
 		expect(windowMean(sparse, "sleepSec", { to: "2026-08-11", days: 7 }).mean).toBeNull();
 	});
 
@@ -139,7 +139,7 @@ describe("windowMean", () => {
 
 // A month of identical nights, so a test only has to say how the recent ones
 // differed from the established normal.
-function block(today, { sleepSec = HOURS(8), restingHr = 48, averageHrv = 65, days = 28 } = {}) {
+function block(today, { sleepSec = hours(8), restingHr = 48, averageHrv = 65, days = 28 } = {}) {
 	return Array.from({ length: days }, (_, i) => ({
 		day: addDays(today, -(days - 1 - i)),
 		sleepSec,
@@ -162,18 +162,18 @@ describe("recoverySummary", () => {
 
 	it("reads level when nothing has changed", () => {
 		const out = recoverySummary(block(TODAY), { today: TODAY });
-		expect(out.sleep.recent).toBe(HOURS(8));
-		expect(out.sleep.baseline).toBe(HOURS(8));
+		expect(out.sleep.recent).toBe(hours(8));
+		expect(out.sleep.baseline).toBe(hours(8));
 		expect(out.sleep.delta).toBe(0);
 		expect(out.restingHr.delta).toBe(0);
 	});
 
 	it("measures the last week against the month behind it", () => {
-		const out = recoverySummary(recent(block(TODAY), { sleepSec: HOURS(6) }), { today: TODAY });
-		expect(out.sleep.recent).toBe(HOURS(6));
+		const out = recoverySummary(recent(block(TODAY), { sleepSec: hours(6) }), { today: TODAY });
+		expect(out.sleep.recent).toBe(hours(6));
 		// The baseline is the whole 28 days, recent week included, which is
 		// the same acute-against-chronic shape ACWR uses.
-		expect(out.sleep.baseline).toBeLessThan(HOURS(8));
+		expect(out.sleep.baseline).toBeLessThan(hours(8));
 		expect(out.sleep.delta).toBeLessThan(0);
 		expect(out.sleep.recent).toBeLessThan(SLEEP_TARGET_SEC);
 	});
@@ -189,7 +189,7 @@ describe("recoverySummary", () => {
 	});
 
 	it("ignores anything logged after today", () => {
-		const nights = [...block(TODAY), { day: "2026-08-20", sleepSec: HOURS(1), restingHr: 90 }];
+		const nights = [...block(TODAY), { day: "2026-08-20", sleepSec: hours(1), restingHr: 90 }];
 		const out = recoverySummary(nights, { today: TODAY });
 		expect(out.latest.day).toBe(TODAY);
 		expect(out.series.every((n) => n.day <= TODAY)).toBe(true);

--- a/netlify/functions/_shared/training/store.js
+++ b/netlify/functions/_shared/training/store.js
@@ -6,6 +6,12 @@
 //   index.json  — every shaped run in the block
 //   athlete.json — the athlete's configured HR zones
 //   cursor.json — sync bookkeeping (last activity seen, last run time)
+//   recovery.json — a night's sleep and overnight heart rate, per day
+//   oura.json  — Oura's rotating OAuth tokens
+//
+// oura.json is the one key here that isn't a cache. Oura invalidates a refresh
+// token the moment it's used, so the successor is the only way back in and
+// losing it means re-authorising by hand — see _shared/oura.js.
 
 import { getStore } from "@netlify/blobs";
 
@@ -13,6 +19,8 @@ export const STORE_NAME = "training";
 export const INDEX_KEY = "index.json";
 export const ATHLETE_KEY = "athlete.json";
 export const CURSOR_KEY = "cursor.json";
+export const RECOVERY_KEY = "recovery.json";
+export const OURA_KEY = "oura.json";
 
 export function getTrainingStore() {
 	return getStore({ name: STORE_NAME, consistency: "strong" });

--- a/netlify/functions/trainingData.js
+++ b/netlify/functions/trainingData.js
@@ -15,7 +15,13 @@ import { createJsonResponder, cacheControl } from "./_shared/http.js";
 import { createMemo } from "./_shared/memo.js";
 import { buildDashboard } from "./_shared/training/metrics.js";
 import { loadPlan } from "./_shared/training/planFile.js";
-import { CURSOR_KEY, INDEX_KEY, getTrainingStore, readJson } from "./_shared/training/store.js";
+import {
+	CURSOR_KEY,
+	INDEX_KEY,
+	RECOVERY_KEY,
+	getTrainingStore,
+	readJson,
+} from "./_shared/training/store.js";
 import { toDayKey } from "./_shared/training/dates.js";
 
 // The underlying data only changes when the hourly sync runs, so a 10-minute
@@ -48,15 +54,17 @@ function syncState(cursor) {
 
 async function build(today) {
 	const store = getTrainingStore();
-	const [activities, cursor] = await Promise.all([
+	const [activities, cursor, recovery] = await Promise.all([
 		readJson(store, INDEX_KEY, []),
 		readJson(store, CURSOR_KEY, null),
+		readJson(store, RECOVERY_KEY, []),
 	]);
 	return {
 		...buildDashboard({
 			activities: Array.isArray(activities) ? activities : [],
 			plan: loadPlan(),
 			today,
+			recovery: Array.isArray(recovery) ? recovery : [],
 		}),
 		sync: syncState(cursor),
 	};

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -24,17 +24,21 @@
 
 import { createJsonResponder, cacheControl } from "./_shared/http.js";
 import { STRAVA_API_BASE, callsRemaining, getAccessToken, readQuota } from "./_shared/strava.js";
+import { getOuraAccessToken, ouraCollection } from "./_shared/oura.js";
 import {
 	SHAPE_VERSION,
 	isTrackableActivity,
 	isTrackableRide,
 	shapeActivity,
 } from "./_shared/training/shape.js";
+import { shapeRecovery } from "./_shared/training/recovery.js";
 import { loadPlan } from "./_shared/training/planFile.js";
+import { addDays, toDayKey } from "./_shared/training/dates.js";
 import {
 	ATHLETE_KEY,
 	CURSOR_KEY,
 	INDEX_KEY,
+	RECOVERY_KEY,
 	getTrainingStore,
 	mergeActivities,
 	readJson,
@@ -82,6 +86,12 @@ function historyStartEpoch(plan) {
 	return Math.floor((anchor.getTime() - HISTORY_LEAD_DAYS * 86_400_000) / 1000);
 }
 
+// The athlete's today, matching trainingData. A night is filed under the day
+// you woke up in, which is a local idea rather than a UTC one.
+function todayKey() {
+	return toDayKey(new Date().toLocaleDateString("en-CA", { timeZone: "America/Toronto" }));
+}
+
 // Run an async mapper over a list a few at a time. Sequential fetches would
 // spend the whole timeout waiting on round trips; unbounded parallelism would
 // burst the rate limit on a cold-start backfill.
@@ -102,6 +112,55 @@ async function mapWithConcurrency(items, limit, mapper) {
 // absent — see _shared/training/shape.js for why the payload carries no
 // coordinates, and gap.js for why GAP doesn't need them.
 const STREAM_KEYS = "time,distance,heartrate,velocity_smooth,altitude,grade_smooth";
+
+// How much sleep history to hold. Baselines are 28-day averages and the panel
+// draws a month, so this is comfortably more than either needs. The whole
+// window is refetched and rewritten every sync rather than merged: Oura's
+// limit is 5000 requests per 5 minutes against the three this spends, and
+// Oura revises a night's figures for a while after it, so the newer answer
+// should win outright rather than being merged around.
+const RECOVERY_DAYS = 45;
+
+/**
+ * Pull the recent nights from Oura into Blobs.
+ *
+ * Isolated from the Strava sync in both directions. Oura being unconfigured is
+ * the normal state of a fresh checkout and mustn't read as a failure; Oura
+ * being broken mustn't stop the runs syncing, which are what the page is
+ * actually for. Nothing here shares a rate limit, a token or a store key with
+ * the code above, so it runs alongside it rather than after it.
+ *
+ * @param {object} store
+ * @param {string} today day key.
+ * @returns {Promise<object>} a status for the response body, never a throw.
+ */
+async function syncRecovery(store, today) {
+	let token;
+	try {
+		token = await getOuraAccessToken(store);
+	} catch (err) {
+		if (err.code === "not_configured") return { configured: false };
+		console.error("Oura auth failed", err);
+		return { configured: true, ok: false, reason: "auth" };
+	}
+
+	const start = addDays(today, -(RECOVERY_DAYS - 1));
+	try {
+		const [sleep, dailySleep, readiness] = await Promise.all([
+			ouraCollection("/v2/usercollection/sleep", token, { start, end: today }),
+			ouraCollection("/v2/usercollection/daily_sleep", token, { start, end: today }),
+			ouraCollection("/v2/usercollection/daily_readiness", token, { start, end: today }),
+		]);
+		const nights = shapeRecovery({ sleep, dailySleep, readiness });
+		await writeJson(store, RECOVERY_KEY, nights);
+		return { configured: true, ok: true, nights: nights.length };
+	} catch (err) {
+		// 403 is the membership having lapsed rather than anything being
+		// wrong here, and it's worth being able to tell them apart in a log.
+		console.error("Oura sync failed", err);
+		return { configured: true, ok: false, reason: err.status === 403 ? "membership" : "fetch" };
+	}
+}
 
 // Last quota Strava reported, updated on every response (including errors —
 // a 429 carries the headers that say how long we've overshot by).
@@ -190,6 +249,11 @@ export default async function handler(req) {
 
 	const plan = loadPlan();
 	const blockStart = historyStartEpoch(plan);
+
+	// Started rather than awaited. It shares no state, token or rate limit
+	// with the Strava work below, which is allowed to spend twenty seconds,
+	// and there's no reason three quick requests should queue behind it.
+	const recoveryWork = syncRecovery(store, todayKey());
 
 	// Re-list the whole block whenever anything might need rebuilding, so
 	// stale records are actually visible to the pass below. ?full=1 forces it;
@@ -326,6 +390,7 @@ export default async function handler(req) {
 		rateLimited,
 		quotaPaused,
 		timedOut,
+		recovery: await recoveryWork,
 	});
 }
 

--- a/scripts/get_oura_refresh_token.js
+++ b/scripts/get_oura_refresh_token.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * One-shot helper to obtain an Oura refresh token for the /training recovery
+ * panel.
+ *
+ * Setup:
+ *   1. Create an application at https://cloud.ouraring.com/oauth/applications
+ *   2. Set its Redirect URI to exactly: http://localhost:8889/callback
+ *      (Oura matches this string exactly. If it insists on a different form,
+ *      register that instead and pass it as OURA_REDIRECT_URI below.)
+ *   3. Run with your client credentials:
+ *
+ *      OURA_CLIENT_ID=xxx OURA_CLIENT_SECRET=yyy node scripts/get_oura_refresh_token.js
+ *
+ *   4. Open the printed URL, log in to Oura, approve.
+ *   5. The refresh token will print in your terminal.
+ *   6. Add to Netlify env vars (Functions scope):
+ *        OURA_CLIENT_ID
+ *        OURA_CLIENT_SECRET
+ *        OURA_REFRESH_TOKEN
+ *
+ * Note what OURA_REFRESH_TOKEN is for, because it isn't the same job as
+ * STRAVA_REFRESH_TOKEN. Oura invalidates a refresh token the moment it's spent
+ * and returns a successor, so the live credential can't live in an environment
+ * variable — it's kept in Blobs and rewritten on every rotation (see
+ * netlify/functions/_shared/oura.js). This variable seeds the very first
+ * refresh, and is retried automatically if the stored chain ever breaks. That's
+ * the recovery path: re-run this script, paste the new value into Netlify, and
+ * the next sync heals itself without a deploy.
+ *
+ * Re-run this whenever SCOPES below changes — a refresh token only ever carries
+ * the scopes it was originally granted, so widening the list here has no effect
+ * on production until the new token replaces OURA_REFRESH_TOKEN.
+ *
+ * Requires an active Oura membership: Gen 3 and Ring 4 data is gated behind it,
+ * and without one the API returns 403 for the collections below.
+ */
+
+import http from "node:http";
+import { randomBytes } from "node:crypto";
+
+const CLIENT_ID = process.env.OURA_CLIENT_ID;
+const CLIENT_SECRET = process.env.OURA_CLIENT_SECRET;
+const REDIRECT_URI = process.env.OURA_REDIRECT_URI || "http://localhost:8889/callback";
+
+// daily — daily_sleep, daily_readiness and the detailed sleep periods, which is
+//   everything the recovery panel reads.
+//
+// Deliberately nothing else. `personal` (age, height, weight) and `heartrate`
+// (continuous time-series) would both be granted happily and neither is used,
+// and this is a public page: the narrowest token that does the job is the one
+// worth holding. If Oura ever answers 401 naming a scope, it says which in the
+// error detail — add it here and re-run.
+const SCOPES = "daily";
+
+if (!CLIENT_ID || !CLIENT_SECRET) {
+	console.error("Set OURA_CLIENT_ID and OURA_CLIENT_SECRET in the env before running.");
+	process.exit(1);
+}
+
+const callback = new URL(REDIRECT_URI);
+const PORT = Number(callback.port) || 8889;
+
+// Guards against a stray request to the callback port being taken for the real
+// one. Cheap here, and the reason the parameter exists.
+const STATE = randomBytes(16).toString("hex");
+
+const authUrl =
+	`https://cloud.ouraring.com/oauth/authorize` +
+	`?client_id=${CLIENT_ID}` +
+	`&response_type=code` +
+	`&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+	`&state=${STATE}` +
+	`&scope=${encodeURIComponent(SCOPES)}`;
+
+const server = http.createServer(async (req, res) => {
+	const url = new URL(req.url, REDIRECT_URI);
+	if (url.pathname !== callback.pathname) {
+		res.writeHead(404);
+		res.end();
+		return;
+	}
+	if (url.searchParams.get("state") !== STATE) {
+		res.writeHead(400);
+		res.end("State mismatch");
+		return;
+	}
+	const code = url.searchParams.get("code");
+	if (!code) {
+		// Oura reports a refusal here rather than as a failed exchange.
+		const denied = url.searchParams.get("error");
+		console.error(denied ? `Oura returned an error: ${denied}` : "No code received");
+		res.writeHead(400);
+		res.end("No code received");
+		return;
+	}
+	try {
+		const tokenRes = await fetch("https://api.ouraring.com/oauth/token", {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				client_id: CLIENT_ID,
+				client_secret: CLIENT_SECRET,
+				grant_type: "authorization_code",
+				redirect_uri: REDIRECT_URI,
+				code,
+			}),
+		});
+		const data = await tokenRes.json();
+		if (data.refresh_token) {
+			console.log("\n✅ Refresh token:\n");
+			console.log("   " + data.refresh_token + "\n");
+			console.log("Set this as OURA_REFRESH_TOKEN in Netlify env vars (Functions scope).");
+			console.log("It seeds the first refresh; after that the live token lives in Blobs.\n");
+			res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+			res.end("<h1>Got it.</h1><p>Refresh token printed in your terminal. You can close this tab.</p>");
+			setTimeout(() => process.exit(0), 500);
+		} else {
+			console.error("Oura did not return a refresh token:", data);
+			res.writeHead(500, { "Content-Type": "application/json" });
+			res.end(JSON.stringify(data));
+			process.exit(1);
+		}
+	} catch (err) {
+		console.error(err);
+		res.writeHead(500);
+		res.end("Token exchange failed");
+		process.exit(1);
+	}
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+	console.log("\n1. Open this URL in your browser to authorize:\n");
+	console.log("   " + authUrl + "\n");
+	console.log("2. After approving, watch this terminal for the refresh token.\n");
+});

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -33,6 +33,7 @@
     import IntensityMix from "./sections/IntensityMix.svelte";
     import RacePrediction from "./sections/RacePrediction.svelte";
     import WeekPlan from "./sections/WeekPlan.svelte";
+    import Recovery from "./sections/Recovery.svelte";
     import RunLog from "./sections/RunLog.svelte";
 
     const ENDPOINT = "/.netlify/functions/trainingData";
@@ -55,15 +56,17 @@
     // own.
     const DEFAULT_ORDER = [
         "lastRun", "volume", "fitness", "efficiency", "prediction",
-        "recommendations", "week", "load", "intensity",
+        "recommendations", "week", "load", "recovery", "intensity",
         "runs",
     ];
     const WIDE_SLOTS = 5;
-    const NARROW_SLOTS = 4;
+    const NARROW_SLOTS = 5;
     // Versioned: a layout saved against the old order would keep the imbalance
     // this fixes, and the arrangement is a convenience rather than anything
     // worth carrying forward at the cost of the fix.
-    const LAYOUT_KEY = "training-layout-2";
+    // 3: recovery joins the narrow column. A saved layout of ten panels can't
+    //    place an eleventh, so the stored order would silently drop it.
+    const LAYOUT_KEY = "training-layout-3";
 
     let data = $state(null);
     let error = $state("");
@@ -173,6 +176,8 @@
         <IntensityMix intensity={data.summary?.intensity} />
     {:else if id === "week"}
         <WeekPlan {currentWeek} week={data.week} upcoming={data.upcoming} />
+    {:else if id === "recovery"}
+        <Recovery recovery={data.recovery} />
     {:else if id === "runs"}
         <RunLog runs={data.runs} total={data.summary?.totals?.runs} />
     {/if}

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -130,6 +130,20 @@ export const GLOSSARY = {
 		],
 	},
 
+	recovery: {
+		title: "Recovery",
+		body: [
+			"Sleep and overnight heart rate from an Oura ring, read the same way as the load panel: the last 7 days against the last 28, so every number here is recent measured against your own established normal rather than against anybody else's.",
+			"None of this feeds fitness, fatigue or form. Those are a closed system fed by training load alone, and that's what makes them readable — mixing a second source into part of it is how form ends up permanently negative. Recovery sits alongside instead, and shows up in the recommendations where the combination says more than either half: a 12% jump in volume means something different on eight hours a night than on six.",
+			"Nights with no record are skipped rather than counted as zero. A missing night is a ring left on the bedside table, not a night without sleep, and averaging it in would manufacture exactly the alarm this is meant to raise honestly.",
+		],
+		terms: [
+			{ term: "Resting HR", definition: "Your lowest heart rate overnight. Measured asleep, so it's a truer resting rate than any daytime reading, and a rise of about 5 bpm over baseline is a long-standing marker of illness or work you haven't absorbed." },
+			{ term: "HRV", definition: "Heart-rate variability, the beat-to-beat variation while you sleep. Higher generally means better recovered, but it's noisy night to night, which is why it's read as a week against a month." },
+			{ term: "Baseline", definition: "Your own 28-day average for the same measure. Everything here is a deviation from it rather than an absolute judgement." },
+		],
+	},
+
 	runs: {
 		title: "Recent activity",
 		body: [

--- a/src/components/Training/sections/Recovery.svelte
+++ b/src/components/Training/sections/Recovery.svelte
@@ -1,0 +1,240 @@
+<!--
+    Sleep and overnight heart rate, from the Oura ring.
+
+    The one panel here fed by something other than training load, and it stays
+    beside the fitness model rather than inside it — nothing on this page moves
+    because of these numbers (see _shared/training/recovery.js for why that
+    separation is load-bearing). What it adds is the thing load genuinely can't
+    see: the same week of running is a different proposition on eight hours a
+    night than on six, and the recommendations read both together.
+
+    Every measure is a week against a month, the same acute-versus-chronic
+    shape the load panel uses, so "recent against established" means one thing
+    across the page.
+-->
+<script>
+    import Card from "../../../lib/ui/Card.svelte";
+    import { bars } from "../lib/chart.js";
+    import { formatDuration, shortDate } from "../lib/format.js";
+    import { GLOSSARY } from "../lib/glossary.js";
+
+    let { recovery = null } = $props();
+
+    // Matching the server's thresholds (recovery.js). Duplicated rather than
+    // shipped in the payload because they're constants of the model, not of
+    // the data — if they diverge, the panel and the advice would disagree
+    // about the same night, which is worse than either being wrong.
+    const SLEEP_TARGET_SEC = 7 * 3600;
+    const RHR_RISE_BPM = 5;
+
+    const CHART_W = 300;
+    const CHART_H = 56;
+    const NIGHTS = 14;
+
+    const sleep = $derived(recovery?.sleep || {});
+    const restingHr = $derived(recovery?.restingHr || {});
+    const hrv = $derived(recovery?.hrv || {});
+    const latest = $derived(recovery?.latest || null);
+
+    const shortSleep = $derived(Number.isFinite(sleep.recent) && sleep.recent < SLEEP_TARGET_SEC);
+    const hrUp = $derived(Number.isFinite(restingHr.delta) && restingHr.delta >= RHR_RISE_BPM);
+
+    const status = $derived.by(() => {
+        if (!Number.isFinite(sleep.recent)) return { label: "Not enough nights yet", tone: "neutral" };
+        if (shortSleep && hrUp) return { label: "Not keeping up with the training", tone: "bad" };
+        if (shortSleep) return { label: "Sleeping short", tone: "warn" };
+        if (hrUp) return { label: "Heart rate up on baseline", tone: "warn" };
+        return { label: "Recovering well", tone: "good" };
+    });
+
+    // The last fortnight, which is enough to see a pattern without the bars
+    // becoming hairlines. Drawn against a ceiling of nine hours rather than
+    // the best night on record, so the target line sits in the same place
+    // from week to week and a good run of sleep doesn't flatten the chart.
+    const nights = $derived((recovery?.series || []).slice(-NIGHTS));
+    const columns = $derived(
+        bars(nights.map((n) => n.sleepSec || 0), {
+            width: CHART_W,
+            height: CHART_H,
+            max: 9 * 3600,
+            gap: 0.3,
+        }),
+    );
+    const targetY = $derived(CHART_H - (SLEEP_TARGET_SEC / (9 * 3600)) * CHART_H);
+
+    // Signed, in the units of whatever it's describing.
+    const delta = (value, unit) => {
+        if (!Number.isFinite(value)) return "—";
+        const rounded = Math.round(value);
+        if (rounded === 0) return `level`;
+        return `${rounded > 0 ? "+" : ""}${rounded} ${unit}`;
+    };
+</script>
+
+<Card title="Recovery" info={GLOSSARY.recovery}>
+    {#if !recovery}
+        <p class="card-empty">Nothing from the ring yet.</p>
+    {:else}
+        <div class="headline">
+            <div class="value tone-{status.tone}">
+                <strong>{Number.isFinite(sleep.recent) ? formatDuration(sleep.recent) : "—"}</strong>
+                <span>average night, last 7</span>
+            </div>
+            <p class="status tone-{status.tone}">{status.label}</p>
+        </div>
+
+        {#if columns.length}
+            <svg
+                viewBox="0 0 {CHART_W} {CHART_H}"
+                class="chart"
+                role="img"
+                aria-label="Sleep each night over the last fortnight"
+            >
+                <!-- The seven-hour floor, so a short night is visible as
+                     falling under a line rather than as a slightly shorter
+                     bar than the one beside it. -->
+                <line class="target" x1="0" x2={CHART_W} y1={targetY} y2={targetY} />
+                {#each columns as bar, i (nights[i].day)}
+                    <rect
+                        class="bar"
+                        class:under={bar.value > 0 && bar.value < SLEEP_TARGET_SEC}
+                        x={bar.x}
+                        y={bar.y}
+                        width={bar.width}
+                        height={bar.height}
+                        rx="2"
+                    />
+                {/each}
+            </svg>
+            <p class="chart-unit">nightly sleep · line at {formatDuration(SLEEP_TARGET_SEC)}</p>
+        {/if}
+
+        <dl class="detail">
+            <div>
+                <dt>Resting HR</dt>
+                <dd class:over={hrUp}>
+                    {Number.isFinite(restingHr.recent) ? `${Math.round(restingHr.recent)} bpm` : "—"}
+                </dd>
+                <small>{delta(restingHr.delta, "on baseline")}</small>
+            </div>
+            <div>
+                <dt>HRV</dt>
+                <dd>{Number.isFinite(hrv.recent) ? `${Math.round(hrv.recent)} ms` : "—"}</dd>
+                <small>{delta(hrv.delta, "on baseline")}</small>
+            </div>
+            <div>
+                <dt>Sleep vs baseline</dt>
+                <dd class:over={Number.isFinite(sleep.delta) && sleep.delta < 0}>
+                    {delta(Number.isFinite(sleep.delta) ? sleep.delta / 60 : null, "min")}
+                </dd>
+                <small>{Number.isFinite(sleep.baseline) ? `${formatDuration(sleep.baseline)} normal` : "—"}</small>
+            </div>
+            <div>
+                <dt>Last night</dt>
+                <dd>{latest?.sleepSec ? formatDuration(latest.sleepSec) : "—"}</dd>
+                <!-- Dated, because on a morning before the ring has synced
+                     the most recent night on record is the one before. -->
+                <small>{latest?.day ? shortDate(latest.day) : "—"}</small>
+            </div>
+        </dl>
+    {/if}
+</Card>
+
+<style>
+    .headline {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+    }
+    .value {
+        display: flex;
+        flex-direction: column;
+        line-height: 1.1;
+    }
+    .value strong {
+        font-family: var(--font-serif);
+        font-size: var(--font-2xl);
+        font-weight: 700;
+        letter-spacing: -0.03em;
+        color: var(--header-colour);
+    }
+    .value span {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+    }
+    .tone-good strong { color: var(--tone-good); }
+    .tone-bad strong { color: var(--tone-bad); }
+    .tone-warn strong { color: var(--tone-warn); }
+
+    .status {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-size: var(--font-sm);
+        font-weight: 600;
+        margin: 0;
+        padding: var(--space-1) var(--space-3);
+        border-radius: var(--radius-pill);
+        color: var(--paragraph-colour);
+        background: var(--item-background);
+    }
+    .status::before {
+        content: "";
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: currentColor;
+    }
+    .status.tone-good { color: var(--tone-good); background: var(--tone-good-bg); }
+    .status.tone-bad { color: var(--tone-bad); background: var(--tone-bad-bg); }
+    .status.tone-warn { color: var(--tone-warn); background: var(--tone-warn-bg); }
+
+    .chart {
+        width: 100%;
+        height: 56px;
+        display: block;
+        margin-top: var(--space-4);
+        overflow: visible;
+    }
+    .bar { fill: var(--main-green); opacity: 0.75; }
+    /* A night under the floor is the thing the chart is for. */
+    .bar.under { fill: var(--tone-warn); opacity: 0.9; }
+    .target {
+        stroke: var(--paragraph-colour);
+        stroke-width: 1;
+        stroke-dasharray: 3 3;
+        opacity: 0.45;
+    }
+
+    .detail {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+        gap: var(--space-3);
+        margin: var(--space-4) 0 0 0;
+    }
+    .detail div { display: flex; flex-direction: column; gap: 2px; }
+    dt {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--main-green);
+    }
+    dd {
+        margin: 0;
+        font-family: var(--font-serif);
+        font-size: var(--font-md);
+        font-weight: 600;
+        color: var(--header-colour);
+    }
+    dd.over { color: var(--tone-warn); }
+    small {
+        font-size: var(--font-2xs);
+        color: var(--paragraph-colour);
+        opacity: 0.65;
+    }
+</style>


### PR DESCRIPTION
Adds a Recovery panel to `/training`, fed by the Oura ring, plus the recommendation rules that read it alongside training load.


## Why

Training load is blind to the thing that decides whether a week of running is absorbed or merely survived. It knows how much you ran and has no idea whether you slept five hours or nine afterwards. Chronic short sleep is one of the better-evidenced injury risk factors in athletes, and overnight resting heart rate is a long-standing marker of illness and overreaching — both read while asleep, which is why a ring sees them and a watch never did.

## Beside the fitness model, not inside it

This is the rides lesson applied before the fact rather than after. CTL and ATL are averages of the same daily load, and that shared source is what makes them converge and form readable; a second input reaching part of that system breaks the equilibrium. So `metrics.test.js` asserts every training number — series, form, ACWR, totals, weeks — is **identical** with a ring reporting four hours a night and with no ring at all.

What recovery earns instead is a place in the recommendations, where the combination says what neither half can. `sleep-and-ramp` is one critical item rather than two unrelated warnings, because a 12% jump in volume means something different on six hours than on eight.

Windows are 7 days against 28, matching ACWR exactly — the page already explains acute against chronic in those terms.

## The one modelling decision worth arguing about

Missing nights are skipped rather than counted as zero, which is the opposite of how daily load works. A day with no run is genuinely a day of no load; a night with no record is a ring on a bedside table, and averaging it in as no sleep would manufacture the exact alarm this exists to raise honestly.

## Tokens

The awkward part. Personal access tokens were withdrawn at the end of 2025, so this is OAuth2 only, and Oura invalidates a refresh token the moment it's spent. Every other integration here reads a static one from the environment and never thinks about it again; do that with Oura and the second refresh fails.

Token state therefore lives in Blobs and is written **before** the access token is handed out — a token used but never stored leaves the successor lost. `OURA_REFRESH_TOKEN` becomes a bootstrap that's retried if the chain ever breaks, making recovery "re-run the script, paste into Netlify" rather than a deploy. `oura.test.js` covers this more carefully than anything else here, including the write-ordering, because it's the one failure mode a human has to fix.

Scope is `daily` alone. The portal will happily grant continuous heart rate and personal details; the page is public, so the narrowest token that does the job is the one worth holding.

## Cost

Three requests per sync against a limit of 5000 per five minutes, run alongside the Strava work rather than after it, and unable to fail in either direction — an unconfigured ring is the normal state of a fresh checkout and mustn't read as a broken sync.

## Also here

A stale e2e selector fix: the extra-run pill was renamed `extra-tag` → `extra` when card conventions moved into `Card.svelte`, and the assertion kept the old name. It's been failing silently since, because the suite needs a browser installed and nothing in CI runs it.

## Test plan

- [x] 593 unit tests pass
- [x] 21 e2e tests pass (including a new one rendering a real ride row and the recovery panel)
- [x] Production build clean
- [ ] **Not verified against the real Oura API.** Field mapping comes from their published schema but has never seen a live response. First exercise has to happen in production — spending the bootstrap token locally would strand it.
- [ ] After merge: check the sync log for `recovery: { configured: true, ok: true, nights: N }`
- [ ] If it renders with every number an em-dash, that's a field name rather than a modelling bug

Made with [Cursor](https://cursor.com)
