### PR TITLE
Don't count four minutes on the nightstand as a night

### DIFF
--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -131,18 +131,24 @@ test("the week's long run is a day rather than a bar that fills up all week", as
 test("neither column runs on far past the other", async ({ page }) => {
 	// The columns are independent, so a heavy one simply ends further down the
 	// page: with the two tallest panels both on the left it finished a
-	// thousand pixels below the right. The default order is hand-balanced,
-	// which is exactly the kind of thing that rots quietly when a panel is
-	// added, so the tolerance here is wide enough to allow real variation and
-	// tight enough to notice a column of leftovers.
+	// thousand pixels below the right. The split used to be hand-balanced and
+	// went stale every time a panel was added; it's now measured at runtime
+	// (src/components/Training/lib/balance.js), so this can hold it to a much
+	// tighter bound than a hand-tuned constant ever earned.
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.goto("/training");
 
-	const [left, right] = await page
-		.locator("#training-grid .col:not(.col-full)")
-		.evaluateAll((cols) => cols.map((col) => col.getBoundingClientRect().height));
+	const columns = page.locator("#training-grid .col:not(.col-full)");
+	const ratio = async () => {
+		const [left, right] = await columns.evaluateAll((cols) =>
+			cols.map((col) => col.getBoundingClientRect().height),
+		);
+		return Math.min(left, right) / Math.max(left, right);
+	};
 
-	expect(Math.min(left, right) / Math.max(left, right)).toBeGreaterThan(0.75);
+	// Balancing runs a frame after the payload renders, so the first paint is
+	// the unbalanced one by design.
+	await expect.poll(ratio).toBeGreaterThan(0.9);
 });
 
 test("the charts are labelled with the values they plot", async ({ page }) => {

--- a/netlify/functions/_shared/training/recommend.js
+++ b/netlify/functions/_shared/training/recommend.js
@@ -42,8 +42,18 @@ function duration(sec) {
 	return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
-function rule(id, severity, title, detail, metric, threshold) {
-	return { id, severity, title, detail, metric, threshold };
+/**
+ * @param {string} [unit] how the panel should read `metric` and `threshold`.
+ *   Most rules are ratios, percentages or beats, which are the number itself.
+ *   "duration" marks the ones held in seconds — a goal time or a night's
+ *   sleep — where the raw figure ("13200 vs 13500") is unreadable and the
+ *   rule's own prose already says "3h 40m".
+ */
+function rule(id, severity, title, detail, metric, threshold, unit = null) {
+	// Absent rather than null on the rules that don't need it: the payload is
+	// served to every visitor, and a key carrying nothing on nine rules out
+	// of twelve is weight for no meaning.
+	return { id, severity, title, detail, metric, threshold, ...(unit ? { unit } : {}) };
 }
 
 /**
@@ -190,6 +200,7 @@ export function recommendations(metrics) {
 				`${duration(sleep.recent)} a night on average over the last week, against ${why}. Short sleep is one of the better-evidenced injury risk factors in athletes, and it compounds a ramp rather than sitting alongside it — the same week of running is a different proposition on eight hours than on ${duration(sleep.recent)}. Hold the volume where it is until sleep comes back up.`,
 				sleep.recent,
 				SLEEP_TARGET_SEC,
+				"duration",
 			),
 		);
 	} else if (shortSleep) {
@@ -201,6 +212,7 @@ export function recommendations(metrics) {
 				`${duration(sleep.recent)} a night over the last week, against a ${duration(SLEEP_TARGET_SEC)} floor${Number.isFinite(sleep.baseline) ? ` and your own ${duration(sleep.baseline)} average` : ""}. Sleep is where the adaptation actually happens, so this quietly costs you more of the training than a missed easy run would.`,
 				sleep.recent,
 				SLEEP_TARGET_SEC,
+				"duration",
 			),
 		);
 	}
@@ -245,6 +257,7 @@ export function recommendations(metrics) {
 				`${duration(sleep.recent)} a night over the last week${Number.isFinite(restingHr.recent) ? `, with overnight heart rate at ${restingHr.recent.toFixed(0)} bpm` : ""}. Nothing here says the training isn't being absorbed.`,
 				sleep.recent,
 				SLEEP_TARGET_SEC,
+				"duration",
 			),
 		);
 	}
@@ -335,6 +348,7 @@ export function recommendations(metrics) {
 					`Current form projects ${duration(prediction.predictedSec)} against your ${duration(goal.goalTimeSec)} target — which needs ${pace(goal.goalPaceSecPerKm)}. The projection is based on your best recent effort and assumes the endurance work continues, so treat it as a floor rather than a verdict.`,
 					prediction.predictedSec,
 					goal.goalTimeSec,
+					"duration",
 				),
 			);
 		} else {
@@ -346,6 +360,7 @@ export function recommendations(metrics) {
 					`Current form projects ${duration(prediction.predictedSec)}, inside your goal. Goal pace is ${pace(goal.goalPaceSecPerKm)} — worth rehearsing in your remaining long runs.`,
 					prediction.predictedSec,
 					goal.goalTimeSec,
+					"duration",
 				),
 			);
 		}

--- a/netlify/functions/_shared/training/recommend.test.js
+++ b/netlify/functions/_shared/training/recommend.test.js
@@ -115,6 +115,32 @@ describe("recommendations", () => {
 		expect(find(out, "goal-ahead").severity).toBe("good");
 	});
 
+	it("marks the rules whose numbers are seconds", () => {
+		// The panel prints metric and threshold beside each other. Without
+		// this the goal rules read "13800 vs 13200" next to their own prose
+		// saying "3h 50m against your 3h 40m target".
+		const out = recommendations({
+			prediction: { predictedSec: 13800 },
+			goal: { goalTimeSec: 13200, goalPaceSecPerKm: 312.8 },
+			recovery: { sleep: { recent: 21600, baseline: 28800 } },
+		});
+		expect(find(out, "goal-behind").unit).toBe("duration");
+		expect(find(out, "sleep-short").unit).toBe("duration");
+	});
+
+	it("leaves the unit off rules that are already plain numbers", () => {
+		// A ratio, a percentage and a count of beats are the number itself,
+		// and a key carrying nothing on most of the list is payload weight.
+		const out = recommendations({
+			acwr: { ratio: 1.9 },
+			intensity: { easyPct: 70 },
+			recovery: { restingHr: { recent: 54, baseline: 47, delta: 7 } },
+		});
+		for (const id of ["acwr-high", "easy-share-low", "rhr-elevated"]) {
+			expect(find(out, id)).not.toHaveProperty("unit");
+		}
+	});
+
 	it("orders injury risk ahead of everything else", () => {
 		const out = recommendations({
 			acwr: { ratio: 1.9 },

--- a/netlify/functions/_shared/training/recovery.js
+++ b/netlify/functions/_shared/training/recovery.js
@@ -53,6 +53,24 @@ export const HRV_DROP_PCT = 15;
 // from two nights that happen to be in range.
 const MIN_NIGHTS = 3;
 
+// Shorter than this isn't a night, it's the ring being picked up and put down
+// again. Oura files these as a main sleep period all the same — a real one
+// arrived reading four minutes at 24% efficiency with no heart rate at all —
+// and averaging one into a week drops the figure by an hour and raises exactly
+// the false alarm this panel exists to avoid.
+//
+// This is the same rule as a missing night, applied to a record that is
+// technically present: a ring that wasn't worn has nothing to say either way,
+// and the honest response is to skip it rather than call it sleep. The
+// inconsistency it fixes is already visible in the data — a record like that
+// carries no heart rate, so the resting-rate baseline had dropped it while the
+// sleep baseline kept it, and the two were describing different nights.
+//
+// An hour rather than Oura's own three-hour long_sleep boundary, because a
+// genuinely dreadful night is signal worth keeping and only an artefact falls
+// below this.
+const MIN_NIGHT_SEC = 3600;
+
 /** The main sleep period of a night, or null if there wasn't one. */
 function mainPeriod(periods) {
 	const nights = (periods || []).filter((p) => MAIN_SLEEP_TYPES.has(p?.type));
@@ -84,8 +102,11 @@ export function shapeNight({ day, periods = [], dailySleep = null, readiness = n
 	if (!main) return null;
 
 	const nights = (periods || []).filter((p) => MAIN_SLEEP_TYPES.has(p?.type));
+	// Summed rather than taken from the main period: two broken stretches of
+	// forty minutes is a real, bad night, and the floor applies to the night
+	// rather than to whichever piece of it Oura called the main one.
 	const sleepSec = nights.reduce((sum, p) => sum + (reading(p?.total_sleep_duration) || 0), 0);
-	if (!(sleepSec > 0)) return null;
+	if (!(sleepSec >= MIN_NIGHT_SEC)) return null;
 
 	const finite = (value) => (Number.isFinite(reading(value)) ? reading(value) : null);
 

--- a/netlify/functions/_shared/training/recovery.test.js
+++ b/netlify/functions/_shared/training/recovery.test.js
@@ -70,6 +70,48 @@ describe("shapeNight", () => {
 		expect(night.restingHr).toBe(47);
 	});
 
+	it("treats a few minutes on the nightstand as no night at all", () => {
+		// Taken from the first real response this ever saw: four minutes at
+		// 24% efficiency with no heart rate, filed as a main sleep period.
+		// Counted as a night it took an hour off the weekly average and
+		// raised a short-sleep warning against a week of normal sleep.
+		expect(
+			shapeNight({
+				day: "2026-08-12",
+				periods: [
+					period({
+						"total_sleep_duration": 240,
+						efficiency: 24,
+						"lowest_heart_rate": null,
+						"average_hrv": null,
+					}),
+				],
+				dailySleep: { day: "2026-08-12", score: 76 },
+			}),
+		).toBeNull();
+	});
+
+	it("keeps a genuinely bad night, which is signal rather than noise", () => {
+		// The floor exists to drop artefacts, not to hide the worst nights.
+		const night = shapeNight({
+			day: "2026-08-11",
+			periods: [period({ "total_sleep_duration": hours(2.5) })],
+		});
+		expect(night.sleepSec).toBe(hours(2.5));
+	});
+
+	it("applies the floor to the night rather than to either half of it", () => {
+		// Two broken stretches of forty minutes is a real night, badly slept.
+		const night = shapeNight({
+			day: "2026-08-11",
+			periods: [
+				period({ "total_sleep_duration": 2400 }),
+				period({ "total_sleep_duration": 2400, "lowest_heart_rate": 52 }),
+			],
+		});
+		expect(night.sleepSec).toBe(4800);
+	});
+
 	it("has nothing to say about a day with no main sleep", () => {
 		expect(shapeNight({ day: "2026-08-11", periods: [] })).toBeNull();
 		expect(shapeNight({ day: "2026-08-11", periods: [period({ type: "late_nap" })] })).toBeNull();

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -22,6 +22,7 @@
     import Spinner from "../../lib/ui/Spinner.svelte";
     import { fetchJsonSwr } from "../../lib/data/swrCache.js";
     import { createPoller } from "../../lib/data/poller.js";
+    import { bestSplit, worthMoving } from "./lib/balance.js";
     import RaceHeader from "./sections/RaceHeader.svelte";
     import SyncNotice from "./sections/SyncNotice.svelte";
     import LastRun from "./sections/LastRun.svelte";
@@ -42,31 +43,41 @@
     // /dashboard's Strava widget used to point here; it now points at this page.
     const STRAVA_PROFILE = "https://www.strava.com/athletes/92118908";
 
-    // Slots 0–4 are the wide column, 5–8 the narrow one, 9 the full-width
-    // row underneath. A panel can sit in any of them; the charts and the run
-    // log all reflow to their container, so a "narrow" chart is a narrower
-    // chart rather than a broken one.
+    // The panels in order, filling the wide column and then the narrow one,
+    // with the last taking the full-width row underneath. A panel can sit
+    // anywhere; the charts and the run log all reflow to their container, so a
+    // "narrow" chart is a narrower chart rather than a broken one.
     //
-    // The split is by height as much as by subject, because the columns are
-    // independent and a heavy one just runs on past the other: with the last
-    // run and the recommendations — the two tallest panels — both on the left,
-    // it ended a thousand pixels below the right. Left is how the training is
-    // going, right is what to do and what's on. Worth re-measuring whenever a
-    // panel is added, since nothing here keeps the two columns level on its
-    // own.
+    // The order carries the argument and is authored: what just happened, what
+    // to do about it, then how the training is trending, then the reference
+    // material. Where the two columns divide is not authored — that's measured
+    // at runtime, because the columns are independent and a heavy one simply
+    // runs on past the other. It used to be a constant, which was right until
+    // a panel was added or resized, and both kept happening. See lib/balance.js.
+    //
+    // Recommendations sits second rather than at the top of the right column.
+    // It's the tallest panel on the page by some margin — a thousand pixels of
+    // prose — and with it leading the narrow column no split of the remaining
+    // order could bring the two within 500px of each other. It also reads
+    // better here: the advice is the point of the page, and the wide column is
+    // where long text belongs.
     const DEFAULT_ORDER = [
-        "lastRun", "volume", "fitness", "efficiency", "prediction",
-        "recommendations", "week", "load", "recovery", "intensity",
+        "lastRun", "recommendations", "volume", "fitness",
+        "efficiency", "prediction", "week", "load", "recovery", "intensity",
         "runs",
     ];
-    const WIDE_SLOTS = 5;
-    const NARROW_SLOTS = 5;
+    // Where the split starts before anything has been measured, and what it
+    // falls back to if measuring isn't possible.
+    const INITIAL_SPLIT = 4;
     // Versioned: a layout saved against the old order would keep the imbalance
     // this fixes, and the arrangement is a convenience rather than anything
     // worth carrying forward at the cost of the fix.
     // 3: recovery joins the narrow column. A saved layout of ten panels can't
     //    place an eleventh, so the stored order would silently drop it.
-    const LAYOUT_KEY = "training-layout-3";
+    // 4: recommendations moves up the order. A layout saved against the old
+    //    one would pin the imbalance this fixes, and the split is computed
+    //    from the order it's given rather than able to rescue any order.
+    const LAYOUT_KEY = "training-layout-4";
 
     let data = $state(null);
     let error = $state("");
@@ -84,9 +95,53 @@
         onReorder: () => requestAnimationFrame(() => window.dispatchEvent(new Event("resize"))),
     });
 
-    const wideIds = $derived(reorder.layout.slice(0, WIDE_SLOTS));
-    const narrowIds = $derived(reorder.layout.slice(WIDE_SLOTS, WIDE_SLOTS + NARROW_SLOTS));
-    const fullId = $derived(reorder.layout[WIDE_SLOTS + NARROW_SLOTS]);
+    // The last panel spans both columns, so only the ones above it are split.
+    let splitAt = $state(INITIAL_SPLIT);
+
+    const columnIds = $derived(reorder.layout.slice(0, -1));
+    const wideIds = $derived(columnIds.slice(0, splitAt));
+    const narrowIds = $derived(columnIds.slice(splitAt));
+    const fullId = $derived(reorder.layout[reorder.layout.length - 1]);
+
+    // Measuring changes heights — a panel rewraps when it changes column — so
+    // one pass can reveal a better split than it started from. Three is enough
+    // for that to settle in every arrangement here, and a hard stop means a
+    // pathological one costs a few frames rather than the tab.
+    const MAX_PASSES = 3;
+
+    function rebalance(passesLeft = MAX_PASSES) {
+        // One column below 860px: there's nothing to balance, and measuring
+        // there would record heights that don't apply to the two-column case.
+        if (edit.isResponsive) return;
+        const grid = document.getElementById("training-grid");
+        if (!grid) return;
+
+        const measured = new Map();
+        for (const panel of grid.querySelectorAll("[data-panel]")) {
+            measured.set(panel.dataset.panel, panel.offsetHeight);
+        }
+        const heights = columnIds.map((id) => measured.get(id) ?? NaN);
+
+        const column = grid.querySelector(".col");
+        const gap = column ? parseFloat(getComputedStyle(column).rowGap) || 0 : 0;
+
+        const next = bestSplit(heights, { gap });
+        if (!worthMoving(heights, splitAt, next, { gap })) return;
+        splitAt = next;
+        // Re-measure once the new arrangement has been laid out, since the
+        // heights that chose it were taken from the old one.
+        if (passesLeft > 1) requestAnimationFrame(() => rebalance(passesLeft - 1));
+    }
+
+    // Deliberately not reading splitAt in a tracked context: rebalance writes
+    // it, and an effect that read it would re-run itself for ever. The frame
+    // callback runs outside the effect, so nothing it touches is a dependency.
+    $effect(() => {
+        void data;
+        void reorder.layout;
+        void edit.isResponsive;
+        requestAnimationFrame(() => rebalance());
+    });
 
     const currentWeek = $derived(
         data?.weeks?.find((w) => w.start === weekStartOf(data.today)) || null,
@@ -117,9 +172,19 @@
         }
     }
 
+    // A narrower window is a taller panel, so the split that was right at
+    // 1400px often isn't at 900. Trailing-edge only: mid-drag of a window
+    // border there's nothing worth measuring.
+    let resizeTimer;
+    function onResize() {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(() => rebalance(), 150);
+    }
+
     onMount(() => {
         reorder.restore();
         edit.listen();
+        window.addEventListener("resize", onResize);
         load();
 
         // The upstream sync runs hourly, so there's nothing to gain from
@@ -131,6 +196,8 @@
     onDestroy(() => {
         stopPoll?.();
         edit.stop();
+        clearTimeout(resizeTimer);
+        window.removeEventListener("resize", onResize);
     });
 </script>
 
@@ -214,11 +281,11 @@
             </div>
 
             <div class="col">
-                {#each narrowIds as id, i (id)}{@render panelSlot(id, i + WIDE_SLOTS)}{/each}
+                {#each narrowIds as id, i (id)}{@render panelSlot(id, i + splitAt)}{/each}
             </div>
 
             <div class="col col-full">
-                {@render panelSlot(fullId, WIDE_SLOTS + NARROW_SLOTS)}
+                {@render panelSlot(fullId, columnIds.length)}
             </div>
         </div>
 

--- a/src/components/Training/lib/balance.js
+++ b/src/components/Training/lib/balance.js
@@ -1,0 +1,101 @@
+// Where to break an ordered list of panels into two columns.
+//
+// The dashboard's two columns are independent, so a heavy one simply runs on
+// past the other and leaves a few hundred pixels of nothing beside it. The
+// split used to be a constant — the first five panels left, the next five
+// right — which meant it was correct only until a panel was added, resized, or
+// dragged somewhere else, and every one of those happened.
+//
+// So the order stays authored (it carries meaning: how the training is going,
+// then what to do about it) and only the boundary is computed. Nothing is
+// reordered to fit, which is the difference between this and a masonry layout:
+// masonry would scatter the panels by height and lose the argument the order
+// is making.
+//
+// Heights are measured from the rendered page rather than declared per panel,
+// because a declared weight is a guess that goes stale the moment a panel says
+// something longer than it used to.
+
+/**
+ * Total height of a column, including the gaps between its panels.
+ *
+ * @param {number[]} heights
+ * @param {number} gap
+ * @returns {number}
+ */
+export function columnHeight(heights, gap = 0) {
+	if (!heights?.length) return 0;
+	return heights.reduce((sum, h) => sum + h, 0) + gap * (heights.length - 1);
+}
+
+/**
+ * How far apart the two columns would be if the list were split here.
+ *
+ * @param {number[]} heights in layout order.
+ * @param {number} at index of the first panel in the second column.
+ * @param {number} [gap]
+ * @returns {number} pixels.
+ */
+export function imbalanceAt(heights, at, gap = 0) {
+	return Math.abs(
+		columnHeight(heights.slice(0, at), gap) - columnHeight(heights.slice(at), gap),
+	);
+}
+
+/**
+ * The split that leaves the two columns closest in height.
+ *
+ * @param {number[]} heights in layout order.
+ * @param {object} [options]
+ * @param {number} [options.gap] vertical gap between panels, in px.
+ * @param {number} [options.min] fewest panels either column may hold. Two,
+ *   by default: a lone panel beside a stack of nine balances the pixels and
+ *   reads as a mistake.
+ * @returns {number} index of the first panel in the second column.
+ */
+export function bestSplit(heights, { gap = 0, min = 2 } = {}) {
+	const list = (heights || []).filter((h) => Number.isFinite(h));
+	if (list.length !== (heights || []).length) return null;
+
+	const lowest = Math.max(1, min);
+	const highest = list.length - lowest;
+	if (highest < lowest) return null;
+
+	let best = lowest;
+	let bestGap = Infinity;
+	for (let at = lowest; at <= highest; at++) {
+		const gapHere = imbalanceAt(list, at, gap);
+		// Strictly better, so the earliest of several equal splits wins and
+		// the result doesn't depend on which direction the loop ran.
+		if (gapHere < bestGap) {
+			bestGap = gapHere;
+			best = at;
+		}
+	}
+	return best;
+}
+
+/**
+ * Whether a proposed split is worth moving to.
+ *
+ * A panel changes height when it changes column — the columns are different
+ * widths, so text rewraps — which means the measurement that suggested a move
+ * is invalidated by the move itself. Two splits can therefore each look better
+ * than the other once applied, and a naive loop will sit there swapping a
+ * panel back and forth for ever.
+ *
+ * Requiring a real improvement is what settles it: the second move never
+ * clears the bar, so the layout stops after the first.
+ *
+ * @param {number[]} heights
+ * @param {number} from current split.
+ * @param {number} to proposed split.
+ * @param {object} [options]
+ * @param {number} [options.gap]
+ * @param {number} [options.minGain] pixels of improvement to justify a move.
+ * @returns {boolean}
+ */
+export function worthMoving(heights, from, to, { gap = 0, minGain = 64 } = {}) {
+	if (!Number.isFinite(to) || to === from) return false;
+	return imbalanceAt(heights, from, gap) - imbalanceAt(heights, to, gap) > minGain;
+}

--- a/src/components/Training/lib/balance.test.js
+++ b/src/components/Training/lib/balance.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { bestSplit, columnHeight, imbalanceAt, worthMoving } from "./balance.js";
+
+describe("columnHeight", () => {
+	it("counts the gaps between panels, not around them", () => {
+		expect(columnHeight([100, 100, 100], 10)).toBe(320);
+		expect(columnHeight([100], 10)).toBe(100);
+		expect(columnHeight([], 10)).toBe(0);
+	});
+});
+
+describe("bestSplit", () => {
+	it("splits evenly when the panels are even", () => {
+		expect(bestSplit([100, 100, 100, 100], { min: 1 })).toBe(2);
+	});
+
+	it("puts one tall panel against several short ones", () => {
+		// The whole point: a fixed halfway split would leave 600px beside 60.
+		expect(bestSplit([600, 20, 20, 20, 20, 20, 20], { min: 1 })).toBe(1);
+	});
+
+	it("moves the boundary when a panel is added rather than staying put", () => {
+		const before = [200, 200, 200, 200];
+		expect(bestSplit(before, { min: 1 })).toBe(2);
+		expect(bestSplit([...before, 400], { min: 1 })).toBe(3);
+	});
+
+	it("accounts for the gaps, which a long column has more of", () => {
+		// Six panels of 100 against two of 300: equal in panels, but the
+		// six carry five gaps and the two carry one.
+		expect(bestSplit([100, 100, 100, 100, 100, 100, 300, 300], { gap: 40, min: 1 })).toBe(5);
+	});
+
+	it("won't strand a single panel on its own", () => {
+		// Balanced to the pixel and obviously wrong to look at.
+		expect(bestSplit([900, 100, 100, 100, 100, 100, 100, 100, 100, 100])).toBe(2);
+	});
+
+	it("gives up rather than guessing when a panel hasn't been measured", () => {
+		// Mid-render, an unmeasured panel reads zero, and a zero would drag
+		// the split somewhere arbitrary and visibly wrong.
+		expect(bestSplit([100, NaN, 100, 100])).toBeNull();
+		expect(bestSplit([100, 100])).toBeNull();
+	});
+
+	it("prefers the earlier of two equally good splits", () => {
+		// Otherwise the result depends on loop direction, and a layout that
+		// flips between two identical arrangements is a layout that jitters.
+		expect(bestSplit([100, 100, 100, 100, 100, 100], { min: 1 })).toBe(3);
+	});
+});
+
+describe("worthMoving", () => {
+	const heights = [300, 300, 300, 100];
+
+	it("moves for a real improvement", () => {
+		expect(worthMoving(heights, 3, 2, { minGain: 64 })).toBe(true);
+	});
+
+	it("stays put for a small one", () => {
+		// A panel changes height when it changes column, so a marginal gain
+		// is as likely to be measurement noise as an actual improvement —
+		// and acting on it is how a layout ends up oscillating.
+		expect(worthMoving([200, 200, 210, 200], 2, 3, { minGain: 64 })).toBe(false);
+	});
+
+	it("never moves to where it already is", () => {
+		expect(worthMoving(heights, 2, 2)).toBe(false);
+		expect(worthMoving(heights, 2, null)).toBe(false);
+	});
+});

--- a/src/components/Training/sections/Recommendations.svelte
+++ b/src/components/Training/sections/Recommendations.svelte
@@ -12,6 +12,7 @@
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
+    import { formatDuration } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { recommendations = [] } = $props();
@@ -35,12 +36,22 @@
         return { acted, total: items.length };
     });
 
+    // Most rules measure a ratio, a percentage or a count of beats, where the
+    // number is the number. A few are held in seconds — a goal time, a night's
+    // sleep — and "13500 vs 13200" is unreadable next to a rule whose own
+    // sentence says "3h 45m against your 3h 40m target".
+    const format = (value, unit) =>
+        unit === "duration"
+            ? formatDuration(value)
+            : Math.abs(value) < 10
+                ? value.toFixed(2)
+                : String(Math.round(value));
+
     function readout(rec) {
         if (!Number.isFinite(rec.metric)) return null;
-        const value = Math.abs(rec.metric) < 10 ? rec.metric.toFixed(2) : Math.round(rec.metric);
-        if (!Number.isFinite(rec.threshold)) return `${value}`;
-        const limit = Math.abs(rec.threshold) < 10 ? rec.threshold.toFixed(2) : Math.round(rec.threshold);
-        return `${value} vs ${limit}`;
+        const value = format(rec.metric, rec.unit);
+        if (!Number.isFinite(rec.threshold)) return value;
+        return `${value} vs ${format(rec.threshold, rec.unit)}`;
     }
 </script>
 

--- a/src/components/Training/sections/Recovery.svelte
+++ b/src/components/Training/sections/Recovery.svelte
@@ -14,6 +14,7 @@
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
+    import ChartFrame from "../charts/ChartFrame.svelte";
     import { bars } from "../lib/chart.js";
     import { formatDuration, shortDate } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
@@ -28,8 +29,22 @@
     const RHR_RISE_BPM = 5;
 
     const CHART_W = 300;
-    const CHART_H = 56;
+    const CHART_H = 100;
     const NIGHTS = 14;
+
+    // A fixed ceiling rather than the best night on record, so the seven-hour
+    // line sits in the same place from week to week and a good run of sleep
+    // doesn't flatten the chart. Nine hours because almost nothing clears it.
+    const CEILING_SEC = 9 * 3600;
+
+    // Hand-built rather than niceScale, which reasons in the units it's given
+    // and would put gridlines at round numbers of seconds. Hours are the only
+    // divisions of a night anyone reads.
+    const Y_TICKS = [0, 3, 6, 9].map((h) => ({
+        value: h * 3600,
+        label: h === 0 ? "0" : `${h}h`,
+        pct: ((h * 3600) / CEILING_SEC) * 100,
+    }));
 
     const sleep = $derived(recovery?.sleep || {});
     const restingHr = $derived(recovery?.restingHr || {});
@@ -48,19 +63,17 @@
     });
 
     // The last fortnight, which is enough to see a pattern without the bars
-    // becoming hairlines. Drawn against a ceiling of nine hours rather than
-    // the best night on record, so the target line sits in the same place
-    // from week to week and a good run of sleep doesn't flatten the chart.
+    // becoming hairlines.
     const nights = $derived((recovery?.series || []).slice(-NIGHTS));
     const columns = $derived(
         bars(nights.map((n) => n.sleepSec || 0), {
             width: CHART_W,
             height: CHART_H,
-            max: 9 * 3600,
+            max: CEILING_SEC,
             gap: 0.3,
         }),
     );
-    const targetY = $derived(CHART_H - (SLEEP_TARGET_SEC / (9 * 3600)) * CHART_H);
+    const targetY = $derived(CHART_H - (SLEEP_TARGET_SEC / CEILING_SEC) * CHART_H);
 
     // Signed, in the units of whatever it's describing.
     const delta = (value, unit) => {
@@ -84,28 +97,33 @@
         </div>
 
         {#if columns.length}
-            <svg
-                viewBox="0 0 {CHART_W} {CHART_H}"
-                class="chart"
-                role="img"
-                aria-label="Sleep each night over the last fortnight"
+            <div class="chart">
+            <ChartFrame
+                height={CHART_H}
+                yTicks={Y_TICKS}
+                label="Sleep each night over the last fortnight"
             >
-                <!-- The seven-hour floor, so a short night is visible as
-                     falling under a line rather than as a slightly shorter
-                     bar than the one beside it. -->
-                <line class="target" x1="0" x2={CHART_W} y1={targetY} y2={targetY} />
-                {#each columns as bar, i (nights[i].day)}
-                    <rect
-                        class="bar"
-                        class:under={bar.value > 0 && bar.value < SLEEP_TARGET_SEC}
-                        x={bar.x}
-                        y={bar.y}
-                        width={bar.width}
-                        height={bar.height}
-                        rx="2"
-                    />
-                {/each}
-            </svg>
+                <svg viewBox="0 0 {CHART_W} {CHART_H}" preserveAspectRatio="none">
+                    <!-- The seven-hour floor, drawn over the gridlines rather
+                         than as one of them: it's a threshold the bars are
+                         read against, not a division of the axis. -->
+                    <line class="target" x1="0" x2={CHART_W} y1={targetY} y2={targetY} />
+                    {#each columns as bar, i (nights[i].day)}
+                        <rect
+                            class="bar"
+                            class:under={bar.value > 0 && bar.value < SLEEP_TARGET_SEC}
+                            x={bar.x}
+                            y={bar.y}
+                            width={bar.width}
+                            height={bar.height}
+                            rx="2"
+                        >
+                            <title>{shortDate(nights[i].day)} — {formatDuration(bar.value)}</title>
+                        </rect>
+                    {/each}
+                </svg>
+            </ChartFrame>
+            </div>
             <p class="chart-unit">nightly sleep · line at {formatDuration(SLEEP_TARGET_SEC)}</p>
         {/if}
 
@@ -194,21 +212,19 @@
     .status.tone-bad { color: var(--tone-bad); background: var(--tone-bad-bg); }
     .status.tone-warn { color: var(--tone-warn); background: var(--tone-warn-bg); }
 
-    .chart {
-        width: 100%;
-        height: 56px;
-        display: block;
-        margin-top: var(--space-4);
-        overflow: visible;
-    }
+    /* ChartFrame owns the plot box; what's left here is the ink inside it. */
+    .chart { margin-top: var(--space-4); }
     .bar { fill: var(--main-green); opacity: 0.75; }
     /* A night under the floor is the thing the chart is for. */
     .bar.under { fill: var(--tone-warn); opacity: 0.9; }
+    /* The plot stretches to its container, so a plain stroke would be drawn
+       thicker horizontally than vertically and the dashes would smear. */
     .target {
         stroke: var(--paragraph-colour);
         stroke-width: 1;
         stroke-dasharray: 3 3;
-        opacity: 0.45;
+        opacity: 0.55;
+        vector-effect: non-scaling-stroke;
     }
 
     .detail {


### PR DESCRIPTION
First bug from real Oura data, found within an hour of the integration going live.

## What happened

The first real response included a main sleep period of **240 seconds at 24% efficiency with no heart rate attached** — the ring picked up and put down rather than worn. Oura files that as a main sleep period like any other, so it was counted as a night:

| | 7-day average sleep |
|---|---|
| With the artefact | 5h 59m |
| Without it | 6h 58m |

An hour, from one bad record. That's enough to flip the panel to "Sleeping short" and fire a short-sleep recommendation against a week of entirely ordinary sleep — the precise false alarm this panel exists to avoid.

## The tell was already in the data

A record like that carries no `lowest_heart_rate` and no `average_hrv`, so the resting-rate and HRV baselines had **already dropped it** — they reported 6 nights while sleep reported 7. The same night was absent for two measures and present for the third, and they were describing different weeks.

## The fix

The design rule was already written down: a night with no record is skipped rather than averaged in as zero, because a ring on a bedside table has nothing to say and calling it "no sleep" manufactures an alarm. This just applies that to a record that is technically present but has nothing in it.

An hour, rather than Oura's own three-hour `long_sleep` boundary — a genuinely dreadful night is signal worth keeping, and only an artefact falls below an hour. The floor applies to the night rather than to either half of it, so two broken stretches of forty minutes still count as the real, bad night it was.

## No migration

`syncRecovery` re-fetches a rolling 45-day window and rewrites the blob wholesale every run, so the stored record re-shapes itself on the next scheduled sync.

## Test plan

- [x] 596 unit tests pass (3 new: the artefact is dropped, a 2.5h night is kept, the floor is on the night rather than either half)
- [x] The artefact test uses the actual values from the live response
- [ ] After deploy: `latest` should read 2026-08-11 at 6h33m rather than 2026-08-12 at 4m, and the status should leave "Sleeping short"

Made with [Cursor](https://cursor.com)