### PR TITLE
Ask Oura for a day past today, because the end is exclusive

### DIFF
--- a/netlify/functions/_tests/trainingSync.test.js
+++ b/netlify/functions/_tests/trainingSync.test.js
@@ -19,6 +19,7 @@ const store = {
 vi.mock("@netlify/blobs", () => ({ getStore: () => store }));
 
 import { SHAPE_VERSION } from "../_shared/training/shape.js";
+import { addDays } from "../_shared/training/dates.js";
 
 // A day per activity walking back from the most recent, so "newest first" is
 // unambiguous in the assertions below.
@@ -260,5 +261,104 @@ describe("trainingSync", () => {
 		expect(res.status).toBe(502);
 		expect(body.error).toBe("strava_failed");
 		expect(index()).toEqual(before);
+	});
+
+	describe("the Oura window", () => {
+		// Oura's date range excludes its end. Asking through today therefore
+		// returns every night except last night, and the failure is quiet:
+		// the panel fills in, the chart draws, and the most recent night on
+		// record is silently the one before. This is the boundary that got it
+		// wrong in production, so it's asserted rather than commented.
+		// The sync anchors its days to the athlete's timezone, not UTC, and
+		// for a few hours each evening those are different dates — which is
+		// exactly the window this bug lived in, so the test has to agree with
+		// the code about what "today" is rather than assume UTC.
+		const today = () =>
+			new Date().toLocaleDateString("en-CA", { timeZone: "America/Toronto" });
+		const tomorrow = () => addDays(today(), 1);
+
+		function mockOura({ nights = [] } = {}) {
+			const asked = [];
+			globalThis.fetch = vi.fn(async (url, init) => {
+				const target = String(url);
+				if (target.includes("cloud.ouraring.com") || target.includes("/oauth/token")) {
+					// Oura's token endpoint posts a form; Strava's doesn't.
+					if (init?.body instanceof URLSearchParams) {
+						return new Response(
+							JSON.stringify({
+								access_token: "oura",
+								refresh_token: "next",
+								expires_in: 86400,
+							}),
+							{ status: 200 },
+						);
+					}
+					return new Response(
+						JSON.stringify({ access_token: "tok", expires_at: Math.floor(Date.now() / 1000) + 3600 }),
+						{ status: 200 },
+					);
+				}
+				if (target.includes("/v2/usercollection/")) {
+					asked.push(new URL(target));
+					const data = target.includes("/sleep") && !target.includes("daily_sleep")
+						? nights
+						: [];
+					return new Response(JSON.stringify({ data, next_token: null }), { status: 200 });
+				}
+				if (target.includes("/athlete/activities")) {
+					return new Response(JSON.stringify([]), { status: 200 });
+				}
+				if (target.includes("/athlete/zones")) {
+					return new Response(JSON.stringify({ heart_rate: { zones: [] } }), { status: 200 });
+				}
+				throw new Error(`unexpected fetch ${target}`);
+			});
+			return asked;
+		}
+
+		beforeEach(() => {
+			process.env.OURA_CLIENT_ID = "id";
+			process.env.OURA_CLIENT_SECRET = "secret";
+			process.env.OURA_REFRESH_TOKEN = "refresh";
+		});
+
+		it("asks for a day past today, because the end is exclusive", async () => {
+			const asked = mockOura();
+			await sync();
+
+			expect(asked.length).toBeGreaterThan(0);
+			for (const url of asked) {
+				expect(url.searchParams.get("end_date")).toBe(tomorrow());
+			}
+		});
+
+		it("stores last night rather than dropping it at the boundary", async () => {
+			const asked = mockOura({
+				nights: [
+					{
+						day: today(),
+						type: "long_sleep",
+						"total_sleep_duration": 20880,
+						"lowest_heart_rate": 46,
+						"average_hrv": 82,
+					},
+				],
+			});
+			await sync();
+
+			expect(asked.length).toBeGreaterThan(0);
+			expect(blobs.get("recovery.json")).toEqual([
+				expect.objectContaining({ day: today(), sleepSec: 20880 }),
+			]);
+		});
+
+		it("reports the ring being unconfigured as normal rather than broken", async () => {
+			delete process.env.OURA_CLIENT_ID;
+			mockOura();
+			const { res, body } = await sync();
+
+			expect(res.status).toBe(200);
+			expect(body.recovery).toEqual({ configured: false });
+		});
 	});
 });

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -145,11 +145,23 @@ async function syncRecovery(store, today) {
 	}
 
 	const start = addDays(today, -(RECOVERY_DAYS - 1));
+	// Tomorrow, not today. Oura's date range excludes its end: asking for
+	// start=end=a single day returns nothing at all, and asking through today
+	// returns every night except the one people actually want to see. The
+	// symptom is subtle enough to look like a working integration — the panel
+	// fills in, the chart draws, and "last night" is quietly the night before.
+	//
+	// A plain date rather than today at 23:59:59, which also works: the
+	// parameters are documented as dates, and a day past the end costs one
+	// request's worth of nothing. Anything dated after today is dropped by
+	// recoverySummary anyway, so a nap recorded after midnight can't turn up
+	// as last night's sleep.
+	const end = addDays(today, 1);
 	try {
 		const [sleep, dailySleep, readiness] = await Promise.all([
-			ouraCollection("/v2/usercollection/sleep", token, { start, end: today }),
-			ouraCollection("/v2/usercollection/daily_sleep", token, { start, end: today }),
-			ouraCollection("/v2/usercollection/daily_readiness", token, { start, end: today }),
+			ouraCollection("/v2/usercollection/sleep", token, { start, end }),
+			ouraCollection("/v2/usercollection/daily_sleep", token, { start, end }),
+			ouraCollection("/v2/usercollection/daily_readiness", token, { start, end }),
 		]);
 		const nights = shapeRecovery({ sleep, dailySleep, readiness });
 		await writeJson(store, RECOVERY_KEY, nights);


### PR DESCRIPTION
"Last night" on the recovery panel was always the night before. Reported from the app: Oura showed 5h 48m for the night it calls 12 Aug, while the panel showed 11 Aug at 6h 33m.

## Cause

Oura's date range **excludes its end**. `start_date=X&end_date=X` returns zero records; you need `end_date=X+1` to get day `X`. The sync asked for `end_date = today`, so it received every night except the most recent one.

Two independent write-ups of the same quirk, both matching what production returned:

- [intervals.icu forum](https://forum.intervals.icu/t/oura-sync-imports-sleep-score-readiness-but-never-hrv-or-resting-hr-likely-the-end-date-exclusive-quirk-on-ouras-detailed-sleep-endpoint/130825) — a single-day query returns 0 records, `end_date+1` returns the night
- [open-wearables#1162](https://github.com/the-momentum/open-wearables/pull/1162) — a date-only `end_date` reads as midnight, dropping the current day across all eight range endpoints

## Why it survived review and a deploy

This is the part worth noting. The failure is indistinguishable from working software: the panel filled in, the chart drew, the baselines and deltas were all correct, and the only symptom was the newest night being a day stale. The panel already tolerates exactly that — a ring that hasn't synced yet — and dates the record specifically so it can say so:

> The most recent night on record, which on a morning before the ring has synced is the night before last. Dated so the page can say so rather than implying it's last night.

A design accommodation for a legitimate case turned out to be camouflage for a bug. Worth remembering the next time an integration looks fine.

The [previous fix](https://github.com/maxeisen/MaxEisen.me/pull/72) is unaffected and still correct — the four-minute record it drops was real, and was all Oura returned for that day precisely because the real night was outside the window.

## The fix

`end = addDays(today, 1)`. A plain date rather than `today` at `23:59:59`, which also works: the parameters are documented as dates, and a day past the end costs one request's worth of nothing.

Nothing dated after today can reach the page, because `recoverySummary` already filters `r.day <= today`. A nap recorded after midnight can't surface as last night's sleep.

No migration — the sync rewrites the whole window every run.

## Test plan

- [x] 612 unit tests pass, 3 new: the request asks for tomorrow, a night dated today survives the boundary, and an unconfigured ring still reads as normal rather than broken
- [x] The boundary is asserted rather than commented, since this is where it went wrong
- [x] The test had to be taught that the sync anchors days to the athlete's timezone rather than UTC — for a few hours each evening those differ, which is exactly the window the bug lived in
- [ ] After deploy: `latest.day` should be today's date, and the value should match the Oura app

Made with [Cursor](https://cursor.com)