### PR TITLE
Scrub the charts, fold the advice, and say what the numbers are

### DIFF
--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -151,6 +151,101 @@ test("neither column runs on far past the other", async ({ page }) => {
 	await expect.poll(ratio).toBeGreaterThan(0.9);
 });
 
+test("a recommendation leads with its evidence and folds the reasoning away", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "What to do about it" }).first();
+	const rule = card.locator(".rec").filter({ has: page.locator("details") }).first();
+
+	// The measurement is on screen; the reasoning behind it is a click away.
+	// Twelve of these unfolded was a panel people scrolled past.
+	const detail = rule.locator("details");
+	await expect(detail).not.toHaveAttribute("open", /.*/);
+	await expect(rule.locator("p.rest")).toBeHidden();
+
+	await detail.locator("summary").click();
+	await expect(rule.locator("p.rest")).toBeVisible();
+});
+
+test("a measured recommendation says what kind of number it is", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "What to do about it" }).first();
+	const readouts = await card.locator(".rec-metric").allTextContents();
+	expect(readouts.length).toBeGreaterThan(0);
+
+	// Percentages, ratios, heart rates and times all landed here as bare
+	// numbers, which left "1.17 vs 1.50" sitting above "72 vs 80".
+	for (const text of readouts) {
+		expect(text).toMatch(/%|×|bpm|days|h \d+m/);
+	}
+});
+
+test("scrubbing a chart reads out the values under the cursor", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "Fitness and fatigue" }).first();
+	const plot = card.locator(".plot");
+
+	await expect(card.locator(".tip")).toHaveCount(0);
+
+	await plot.scrollIntoViewIfNeeded();
+	const box = await plot.boundingBox();
+	await page.mouse.move(box.x + box.width * 0.6, box.y + box.height / 2);
+
+	// All three series at one instant, which is the point: form is the gap
+	// between the other two and can't be read from any of them alone.
+	const tip = card.locator(".tip");
+	await expect(tip).toBeVisible();
+	for (const label of ["Fitness", "Fatigue", "Form"]) {
+		await expect(tip.getByText(label, { exact: true })).toBeVisible();
+	}
+
+	// And it lets go rather than following the pointer off the chart.
+	await page.mouse.move(box.x + box.width / 2, box.y - 60);
+	await expect(card.locator(".tip")).toHaveCount(0);
+});
+
+test("the chart cursor can be driven from the keyboard", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();
+	const plot = card.locator(".plot");
+
+	await plot.focus();
+	// Focus lands on the most recent week: every chart here runs into today.
+	const tip = card.locator(".tip");
+	await expect(tip).toBeVisible();
+	const last = await tip.locator(".tip-label").textContent();
+
+	await page.keyboard.press("ArrowLeft");
+	await expect(tip.locator(".tip-label")).not.toHaveText(last);
+
+	await page.keyboard.press("Home");
+	const first = await tip.locator(".tip-label").textContent();
+	// Home is the far end of the series, not one step further left.
+	await page.keyboard.press("ArrowLeft");
+	await expect(tip.locator(".tip-label")).toHaveText(first);
+
+	await page.keyboard.press("Escape");
+	await expect(card.locator(".tip")).toHaveCount(0);
+});
+
+test("a chart readout at the edge of a phone doesn't widen the page", async ({ page }) => {
+	// The readout is absolutely positioned over the plot, so at the last week
+	// of a chart on a 360px screen it is exactly the sort of thing that hangs
+	// off the right-hand side and takes the viewport with it.
+	await page.setViewportSize(NARROW_PHONE);
+	await page.goto("/training");
+
+	const plot = page.locator("section.card").filter({ hasText: "Weekly volume" }).first().locator(".plot");
+	await plot.scrollIntoViewIfNeeded();
+	const box = await plot.boundingBox();
+	await page.mouse.move(box.x + box.width - 2, box.y + box.height / 2);
+	await expect(page.locator(".tip").first()).toBeVisible();
+
+	const overflow = await page.evaluate(
+		() => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+	);
+	expect(overflow).toBeLessThanOrEqual(0);
+});
+
 test("the charts are labelled with the values they plot", async ({ page }) => {
 	await page.goto("/training");
 	const volume = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();

--- a/netlify/functions/_shared/training/fitness.js
+++ b/netlify/functions/_shared/training/fitness.js
@@ -109,6 +109,35 @@ export function acwr(loadsByDay, date) {
 }
 
 /**
+ * Change in fitness across a trailing window.
+ *
+ * CTL on its own is a number on an arbitrary scale: 62 is neither good nor
+ * bad, and nobody has an instinct for it the way they do for a weekly mileage.
+ * What it's for is direction — whether the block is still building — and that
+ * only exists as a difference between two days.
+ *
+ * Four weeks because CTL has a 42-day time constant: a week's change is mostly
+ * the smoothing catching up with itself, and a whole block is too coarse to
+ * tell you anything about the training you're doing now.
+ *
+ * @param {{date: string, ctl: number}[]} series ascending by date.
+ * @param {string} to day key to measure back from.
+ * @param {number} [days]
+ * @returns {number|null} null when the series doesn't reach back far enough,
+ *   rather than a gain measured from a start that was never trained.
+ */
+export function fitnessGain(series, to, days = CHRONIC_DAYS) {
+	const from = addDays(toDayKey(to), -days);
+	if (!from) return null;
+
+	const byDay = new Map((series || []).map((point) => [point.date, point]));
+	const now = byDay.get(toDayKey(to));
+	const then = byDay.get(from);
+	if (!Number.isFinite(now?.ctl) || !Number.isFinite(then?.ctl)) return null;
+	return now.ctl - then.ctl;
+}
+
+/**
  * Group activities into Monday-anchored training weeks.
  *
  * @param {object[]} activities shaped activities.

--- a/netlify/functions/_shared/training/fitness.test.js
+++ b/netlify/functions/_shared/training/fitness.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
 	ACWR_CEILING,
 	ACWR_FLOOR,
+	fitnessGain,
 	fitnessSeries,
 	rollingMean,
 	acwr,
@@ -67,6 +68,30 @@ describe("fitnessSeries", () => {
 
 	it("returns nothing for an inverted range", () => {
 		expect(fitnessSeries(new Map(), { from: "2026-08-12", to: "2026-08-10" })).toEqual([]);
+	});
+});
+
+describe("fitnessGain", () => {
+	const series = eachDay("2026-06-01", "2026-08-12").map((date, i) => ({ date, ctl: 20 + i }));
+
+	it("measures the climb across the window, not the whole series", () => {
+		// One a day for 28 days, from a series that starts 72 days earlier.
+		expect(fitnessGain(series, "2026-08-12")).toBe(28);
+	});
+
+	it("reports a decline as a decline", () => {
+		const falling = series.map((point, i) => ({ ...point, ctl: 100 - i }));
+		expect(fitnessGain(falling, "2026-08-12")).toBe(-28);
+	});
+
+	it("says nothing rather than measuring from a day that wasn't trained", () => {
+		// A block whose history starts inside the window has no earlier CTL to
+		// subtract, and treating the missing day as zero would report the
+		// whole of someone's fitness as four weeks' worth of gain.
+		const short = eachDay("2026-08-01", "2026-08-12").map((date) => ({ date, ctl: 50 }));
+		expect(fitnessGain(short, "2026-08-12")).toBeNull();
+		expect(fitnessGain([], "2026-08-12")).toBeNull();
+		expect(fitnessGain(series, null)).toBeNull();
 	});
 });
 

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -5,7 +5,7 @@
 // without Strava, Blobs, or a clock.
 
 import { dailyLoads } from "./load.js";
-import { acwr, fitnessSeries, longRunShare, rampRate, weeklySummaries } from "./fitness.js";
+import { acwr, fitnessGain, fitnessSeries, longRunShare, rampRate, weeklySummaries } from "./fitness.js";
 import { hrZoneFloors, intensitySplit } from "./zones.js";
 import { efficiencyTrend } from "./efficiency.js";
 import { collectBestEfforts, publicRun } from "./shape.js";
@@ -202,7 +202,14 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		weeksToRace: weeksToRace(plan, day),
 		totals,
 		latest: latest
-			? { date: latest.date, ctl: latest.ctl, atl: latest.atl, tsb: latest.tsb }
+			? {
+					date: latest.date,
+					ctl: latest.ctl,
+					atl: latest.atl,
+					tsb: latest.tsb,
+					// What the fitness number is actually for. See fitnessGain.
+					ctlGain: fitnessGain(series, day),
+				}
 			: null,
 		acwr: ratio,
 		intensity,

--- a/netlify/functions/_shared/training/recommend.js
+++ b/netlify/functions/_shared/training/recommend.js
@@ -44,15 +44,23 @@ function duration(sec) {
 
 /**
  * @param {string} [unit] how the panel should read `metric` and `threshold`.
- *   Most rules are ratios, percentages or beats, which are the number itself.
- *   "duration" marks the ones held in seconds — a goal time or a night's
- *   sleep — where the raw figure ("13200 vs 13500") is unreadable and the
- *   rule's own prose already says "3h 40m".
+ *   The pair is printed beside the rule as "12% vs 10%", and a bare number
+ *   there is ambiguous in a list where the one above it is a ratio and the
+ *   one below is a count of beats. Every rule that isn't a plain quantity
+ *   says which it is:
+ *
+ *   - "duration" for the ones held in seconds — a goal time, a night's sleep
+ *   - "percent" for shares, ramps and drifts
+ *   - "ratio"   for acute:chronic, which reads as a multiple
+ *   - "bpm"     for heart rate
+ *   - "days"    for the countdown to the race
+ *
+ *   Only form is left bare, because training-stress balance genuinely has no
+ *   unit: it's the difference between two loads on an arbitrary scale, and
+ *   inventing "points" for it would imply a precision it doesn't have.
  */
 function rule(id, severity, title, detail, metric, threshold, unit = null) {
-	// Absent rather than null on the rules that don't need it: the payload is
-	// served to every visitor, and a key carrying nothing on nine rules out
-	// of twelve is weight for no meaning.
+	// Absent rather than null on the one rule that doesn't need it.
 	return { id, severity, title, detail, metric, threshold, ...(unit ? { unit } : {}) };
 }
 
@@ -89,6 +97,7 @@ export function recommendations(metrics) {
 					`Your last 7 days carry ${acwr.ratio.toFixed(2)}× the load of your 28-day average. Above ${ACWR_CEILING} is where injury rates climb sharply. Hold the next few days easy and let the chronic average catch up rather than pushing on.`,
 					acwr.ratio,
 					ACWR_CEILING,
+					"ratio",
 				),
 			);
 		} else if (acwr.ratio < ACWR_FLOOR) {
@@ -100,6 +109,7 @@ export function recommendations(metrics) {
 					`Your last 7 days are only ${acwr.ratio.toFixed(2)}× your 28-day average. Below ${ACWR_FLOOR} you start losing fitness. If this wasn't a planned down week, add volume back gradually — not all at once.`,
 					acwr.ratio,
 					ACWR_FLOOR,
+					"ratio",
 				),
 			);
 		} else {
@@ -111,6 +121,7 @@ export function recommendations(metrics) {
 					`Acute-to-chronic ratio is ${acwr.ratio.toFixed(2)}, inside the ${ACWR_FLOOR}–${ACWR_CEILING} corridor.`,
 					acwr.ratio,
 					null,
+					"ratio",
 				),
 			);
 		}
@@ -150,6 +161,7 @@ export function recommendations(metrics) {
 				`You were up ${ramp.toFixed(0)}% ${thisOrLast} on ${priorWeek} (${from.toFixed(0)} to ${to.toFixed(0)} km). The conventional ceiling is ${SAFE_RAMP_PCT}%. Hold the coming week near ${(to * 1.1).toFixed(0)} km rather than stacking another jump on top.`,
 				ramp,
 				SAFE_RAMP_PCT,
+				"percent",
 			),
 		);
 	}
@@ -164,6 +176,7 @@ export function recommendations(metrics) {
 				`The long run was ${share.toFixed(0)}% of ${thisOrLast}'s distance, above the ${LONG_RUN_SHARE_CEILING}% guideline. Add an easy midweek run rather than shortening the long one — the aerobic work is worth keeping.`,
 				share,
 				LONG_RUN_SHARE_CEILING,
+				"percent",
 			),
 		);
 	}
@@ -226,6 +239,7 @@ export function recommendations(metrics) {
 				`Averaging ${restingHr.recent.toFixed(0)} bpm over the last week against a ${restingHr.baseline.toFixed(0)} bpm baseline, up ${restingHr.delta.toFixed(0)}. A rise of ${RHR_RISE_BPM} or more usually means something the training log can't see: illness coming on, or work you haven't absorbed yet. Worth an easy few days before a key session rather than after one.`,
 				restingHr.delta,
 				RHR_RISE_BPM,
+				"bpm",
 			),
 		);
 	}
@@ -239,6 +253,7 @@ export function recommendations(metrics) {
 				`${hrv.recent.toFixed(0)} ms over the last week against a ${hrv.baseline.toFixed(0)} ms baseline, down ${Math.abs(hrv.deltaPct).toFixed(0)}%. HRV is noisy night to night and this is a week against a month, so it's worth noting rather than acting on alone — but read it alongside the resting heart rate above.`,
 				hrv.deltaPct,
 				-HRV_DROP_PCT,
+				"percent",
 			),
 		);
 	}
@@ -274,6 +289,7 @@ export function recommendations(metrics) {
 					`Only ${intensity.easyPct.toFixed(0)}% of your running is in zones 1-2, against a target near ${EASY_SHARE_TARGET}%. Running easy days moderately hard is the most common way to arrive at a marathon tired rather than fit. Slow the easy days down.`,
 					intensity.easyPct,
 					EASY_SHARE_TARGET,
+					"percent",
 				),
 			);
 		} else {
@@ -285,6 +301,7 @@ export function recommendations(metrics) {
 					`${intensity.easyPct.toFixed(0)}% of your running is easy, close to the ${EASY_SHARE_TARGET}% target.`,
 					intensity.easyPct,
 					EASY_SHARE_TARGET,
+					"percent",
 				),
 			);
 		}
@@ -299,6 +316,7 @@ export function recommendations(metrics) {
 				`Aerobic decoupling was ${longRunDecouplingPct.toFixed(1)}%, above the ${DECOUPLING_CEILING}% marker. Your pace faded relative to heart rate in the second half, which usually means the aerobic base still needs work. Keep long runs easy rather than pushing the finish.`,
 				longRunDecouplingPct,
 				DECOUPLING_CEILING,
+				"percent",
 			),
 		);
 	}
@@ -315,6 +333,7 @@ export function recommendations(metrics) {
 					`${currentWeek.actualKm.toFixed(0)} km against a target of ${currentWeek.targetKm} km (${currentWeek.volumePct.toFixed(0)}%). One week matters little; two in a row is worth adjusting the plan for rather than trying to make up.`,
 					currentWeek.volumePct,
 					VOLUME_SHORTFALL_PCT,
+					"percent",
 				),
 			);
 		}
@@ -331,6 +350,7 @@ export function recommendations(metrics) {
 				"Fitness is already banked; the work now is arriving fresh. Keep some intensity to stay sharp but cut volume substantially, and resist the urge to test yourself.",
 				daysToRace,
 				21,
+				"days",
 			),
 		);
 	}

--- a/netlify/functions/_shared/training/recommend.test.js
+++ b/netlify/functions/_shared/training/recommend.test.js
@@ -128,17 +128,35 @@ describe("recommendations", () => {
 		expect(find(out, "sleep-short").unit).toBe("duration");
 	});
 
-	it("leaves the unit off rules that are already plain numbers", () => {
-		// A ratio, a percentage and a count of beats are the number itself,
-		// and a key carrying nothing on most of the list is payload weight.
+	it("says which kind of number every measured rule reports", () => {
+		// The panel prints metric and threshold side by side. A bare "1.9 vs
+		// 1.5" sitting above a bare "70 vs 80" leaves the reader to work out
+		// from the prose that one is a multiple and the other a percentage.
 		const out = recommendations({
 			acwr: { ratio: 1.9 },
 			intensity: { easyPct: 70 },
+			longRunDecouplingPct: 6.2,
+			daysToRace: 12,
 			recovery: { restingHr: { recent: 54, baseline: 47, delta: 7 } },
 		});
-		for (const id of ["acwr-high", "easy-share-low", "rhr-elevated"]) {
-			expect(find(out, id)).not.toHaveProperty("unit");
+		const units = {
+			"acwr-high": "ratio",
+			"easy-share-low": "percent",
+			"decoupling-high": "percent",
+			"rhr-elevated": "bpm",
+			taper: "days",
+		};
+		for (const [id, unit] of Object.entries(units)) {
+			expect(find(out, id).unit).toBe(unit);
 		}
+	});
+
+	it("leaves form unitless, because it hasn't got one", () => {
+		// Training-stress balance is the difference between two loads on an
+		// arbitrary scale. Calling it "points" would imply a precision it
+		// doesn't have, so it's the one rule that reports a bare number.
+		const out = recommendations({ latest: { tsb: -40 } });
+		expect(find(out, "tsb-fatigued")).not.toHaveProperty("unit");
 	});
 
 	it("orders injury risk ahead of everything else", () => {

--- a/src/components/Training/charts/ChartFrame.svelte
+++ b/src/components/Training/charts/ChartFrame.svelte
@@ -1,5 +1,5 @@
 <!--
-    Axes and gridlines around a plot.
+    Axes, gridlines and a scrub cursor around a plot.
 
     The charts here draw into a fixed viewBox and stretch to their container,
     which is what keeps them free of resize observers — but it also means
@@ -7,12 +7,19 @@
     live there without being stretched. Both axes are therefore HTML, placed by
     percentage: the y labels against the plot's height, the x labels against
     its width, with the gridlines drawn in their own SVG layer at the same
-    fractions so the numbers and the lines can't disagree.
+    fractions so the numbers and the lines can't disagree. The cursor and its
+    readout are HTML for the same reason.
 
     The x labels are absolutely positioned inside a clipped track rather than
     laid out in flow. In flow they can't shrink below their own text, and a row
     of nowrap dates will happily make a card wider than a phone — which is
     exactly what it did (see e2e/training.e2e.js).
+
+    Scrubbing is optional and lives here rather than in each chart, so that a
+    line chart, a bar chart and a scatter all answer a hover the same way. A
+    chart passes what its points mean — a label and some readouts, positioned
+    as percentages — and gets the cursor, the dots, the tooltip and the
+    keyboard handling for it.
 -->
 <script>
 	let {
@@ -22,26 +29,181 @@
 		yTicks = [],
 		/** [{ key, label, pct, anchor: "start" | "middle" | "end" }] */
 		xTicks = [],
+		/**
+		 * Scrubbable points, ascending by pct:
+		 * [{ key, pct, label, readouts: [{ label, value, colour, yPct }] }]
+		 *
+		 * pct is measured from the left of the plot and yPct from its bottom,
+		 * so a chart converts once from its own viewBox and this stays free of
+		 * any chart's geometry.
+		 */
+		scrub = [],
 		/** Describes the plot for screen readers. */
 		label = "",
 		children,
 	} = $props();
+
+	let plot = $state(null);
+	let active = $state(-1);
+
+	// One point is a dot, not a series: there's nothing to move between.
+	const scrubbable = $derived(scrub.length > 1);
+	const current = $derived(scrubbable && active >= 0 ? scrub[active] || null : null);
+
+	// Nearest by position rather than by slot width, because bars sit at slot
+	// centres and line points sit at the edges — measuring the gap works for
+	// both without either chart having to say which it is.
+	function nearest(clientX) {
+		const box = plot?.getBoundingClientRect();
+		if (!box?.width) return -1;
+		const pct = ((clientX - box.left) / box.width) * 100;
+		let best = 0;
+		let smallest = Infinity;
+		for (const [i, point] of scrub.entries()) {
+			const gap = Math.abs(point.pct - pct);
+			if (gap < smallest) {
+				smallest = gap;
+				best = i;
+			}
+		}
+		return best;
+	}
+
+	function track(event) {
+		if (scrubbable) active = nearest(event.clientX);
+	}
+
+	function clear() {
+		active = -1;
+	}
+
+	// Focus lands on the most recent point rather than the oldest: every chart
+	// here runs left to right into today, and the right-hand end is the one
+	// worth reading first.
+	function focus() {
+		if (scrubbable && active < 0) active = scrub.length - 1;
+	}
+
+	const STEPS = {
+		ArrowRight: 1,
+		ArrowUp: 1,
+		ArrowLeft: -1,
+		ArrowDown: -1,
+	};
+
+	function key(event) {
+		if (!scrubbable) return;
+
+		if (event.key === "Escape") {
+			event.preventDefault();
+			active = -1;
+			return;
+		}
+
+		const last = scrub.length - 1;
+		const from = active < 0 ? last : active;
+
+		let next;
+		if (event.key in STEPS) next = from + STEPS[event.key];
+		else if (event.key === "Home") next = 0;
+		else if (event.key === "End") next = last;
+		else return;
+
+		// Only once it's certainly ours: arrow keys still have to scroll the
+		// page when the cursor isn't what they're aimed at.
+		event.preventDefault();
+		// Clamped, not wrapped or dismissed: stepping past the first point
+		// used to clear the cursor, which reads as the chart having lost you.
+		active = Math.min(last, Math.max(0, next));
+	}
+
+	// Beside the cursor, on whichever side has more room — never centred over
+	// it. Centred, the readout covers the very dots it's describing, and it
+	// also hangs off the edge at the ends of the series, which on a phone is
+	// enough to make the whole page scroll sideways.
+	const tipStyle = $derived.by(() => {
+		if (!current) return "";
+		return current.pct < 50
+			? `left: calc(${current.pct}% + 10px)`
+			: `right: calc(${100 - current.pct}% + 10px)`;
+	});
+
+	// What a screen reader hears as the cursor moves, since it can't see the
+	// dots: the same sentence the tooltip shows, read out.
+	const spoken = $derived(
+		current
+			? `${current.label}. ${current.readouts.map((r) => `${r.label} ${r.value}`).join(", ")}`
+			: "",
+	);
 </script>
 
-<figure class="frame" style="--plot-height: {height}px" role="img" aria-label={label}>
+<figure
+	class="frame"
+	style="--plot-height: {height}px"
+	role={scrubbable ? undefined : "img"}
+	aria-label={scrubbable ? undefined : label}
+>
 	<div class="y-axis" aria-hidden="true">
 		{#each yTicks as tick (tick.value)}
 			<span style="bottom: {tick.pct}%">{tick.label}</span>
 		{/each}
 	</div>
 
-	<div class="plot">
+	<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+	<div
+		class="plot"
+		class:scrubbable
+		bind:this={plot}
+		role={scrubbable ? "slider" : undefined}
+		aria-label={scrubbable ? label : undefined}
+		aria-valuemin={scrubbable ? 0 : undefined}
+		aria-valuemax={scrubbable ? scrub.length - 1 : undefined}
+		aria-valuenow={scrubbable ? Math.max(0, active) : undefined}
+		aria-valuetext={scrubbable ? spoken || label : undefined}
+		tabindex={scrubbable ? 0 : undefined}
+		onpointermove={track}
+		onpointerleave={clear}
+		onpointercancel={clear}
+		onfocus={focus}
+		onblur={clear}
+		onkeydown={key}
+	>
 		<svg class="grid" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true">
 			{#each yTicks as tick (tick.value)}
 				<line class:base={tick.value === 0} x1="0" x2="100" y1={100 - tick.pct} y2={100 - tick.pct} />
 			{/each}
 		</svg>
 		{@render children()}
+
+		{#if current}
+			<div class="cursor" style="left: {current.pct}%" aria-hidden="true"></div>
+			{#each current.readouts as readout (readout.label)}
+				{#if Number.isFinite(readout.yPct)}
+					<span
+						class="dot"
+						style="left: {current.pct}%; bottom: {readout.yPct}%; --dot: {readout.colour ||
+							'var(--main-green)'}"
+						aria-hidden="true"
+					></span>
+				{/if}
+			{/each}
+			<div class="tip" style={tipStyle} aria-hidden="true">
+				<p class="tip-label">{current.label}</p>
+				<dl>
+					{#each current.readouts as readout (readout.label)}
+						<div>
+							<dt>
+								{#if readout.colour}
+									<span class="swatch" style="--dot: {readout.colour}"></span>
+								{/if}
+								{readout.label}
+							</dt>
+							<dd>{readout.value}</dd>
+						</div>
+					{/each}
+				</dl>
+			</div>
+		{/if}
 	</div>
 
 	{#if xTicks.length}
@@ -95,6 +257,17 @@
 		height: var(--plot-height);
 		min-width: 0;
 	}
+	.plot.scrubbable {
+		/* The cursor is the affordance — there's nothing to click. */
+		cursor: crosshair;
+		touch-action: pan-y;
+	}
+	.plot:focus { outline: none; }
+	.plot:focus-visible {
+		outline: 2px solid var(--main-green);
+		outline-offset: 4px;
+		border-radius: var(--radius-sm);
+	}
 	.plot :global(svg) {
 		position: absolute;
 		inset: 0;
@@ -111,6 +284,85 @@
 	}
 	/* Zero is a reference, not a gridline — it wants to read as the floor. */
 	.grid line.base { opacity: 0.28; }
+
+	.cursor {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 1px;
+		background: var(--paragraph-colour);
+		opacity: 0.45;
+		pointer-events: none;
+	}
+	.dot {
+		position: absolute;
+		width: 9px;
+		height: 9px;
+		margin: 0 0 -4.5px -4.5px;
+		border-radius: 50%;
+		background: var(--dot);
+		/* Ringed in the card's own background so a dot stays legible where it
+		   sits on top of the line it belongs to. */
+		box-shadow: 0 0 0 2px var(--card-background, var(--inner-background));
+		pointer-events: none;
+	}
+
+	.tip {
+		position: absolute;
+		top: 0;
+		z-index: 2;
+		min-width: max-content;
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius-sm);
+		background: var(--inner-background);
+		border: 1px solid var(--main-green-translucent);
+		box-shadow: var(--box-shadow, 0 4px 16px rgb(0 0 0 / 18%));
+		pointer-events: none;
+	}
+	.tip-label {
+		margin: 0 0 var(--space-1) 0;
+		font-size: var(--font-2xs);
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--main-green);
+		white-space: nowrap;
+	}
+	.tip dl {
+		display: grid;
+		gap: 2px;
+		margin: 0;
+	}
+	.tip dl div {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+	.tip dt {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		font-size: var(--font-2xs);
+		color: var(--paragraph-colour);
+		opacity: 0.75;
+		white-space: nowrap;
+	}
+	.tip dd {
+		margin: 0;
+		font-size: var(--font-xs);
+		font-variant-numeric: tabular-nums;
+		font-weight: 600;
+		color: var(--header-colour);
+		white-space: nowrap;
+	}
+	.swatch {
+		width: 8px;
+		height: 8px;
+		border-radius: 2px;
+		background: var(--dot);
+		flex: none;
+	}
 
 	.x-axis {
 		grid-column: 2;

--- a/src/components/Training/lib/chart.js
+++ b/src/components/Training/lib/chart.js
@@ -126,6 +126,34 @@ export function seriesPoints(values, { width, height, domain }) {
 	return list.map((value, i) => ({ x: i * step, y: y(value), value }));
 }
 
+// ChartFrame places its cursor, dots and axis labels in percentages of the
+// plot box, because they're HTML sitting over an SVG that stretches. These
+// convert once from a chart's own viewBox so that arithmetic doesn't get
+// repeated, slightly differently, in every chart that wants a cursor.
+
+/**
+ * Horizontal position as a percentage from the left of the plot.
+ *
+ * @param {number} x in viewBox units.
+ * @param {number} width of the viewBox.
+ * @returns {number}
+ */
+export function xPct(x, width) {
+	return width > 0 ? (x / width) * 100 : 0;
+}
+
+/**
+ * Vertical position as a percentage from the *bottom* of the plot, which is
+ * where CSS wants it and the opposite of where SVG counts from.
+ *
+ * @param {number} y in viewBox units, measured from the top.
+ * @param {number} height of the viewBox.
+ * @returns {number}
+ */
+export function yPct(y, height) {
+	return height > 0 ? (1 - y / height) * 100 : 0;
+}
+
 /**
  * Position for a marker on a horizontal gauge, clamped to the track.
  *

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -3,7 +3,11 @@
 // Distances and durations reuse the shared Strava helpers; what's added here is
 // the pace/time vocabulary specific to marathon training.
 
-export { formatDistance, formatDuration } from "../../../lib/strava.js";
+// Imported rather than re-exported straight through, because the unit
+// formatting below needs formatDuration as a local binding.
+import { formatDistance, formatDuration } from "../../../lib/strava.js";
+
+export { formatDistance, formatDuration };
 
 const pad = (n) => String(n).padStart(2, "0");
 
@@ -207,6 +211,78 @@ export function signed(value, digits = 1) {
 		return `+${magnitude}`;
 	}
 	return rounded < 0 ? `-${magnitude}` : magnitude;
+}
+
+// A measured number to one decimal, with the decimal dropped when it's a
+// whole number anyway. Rounding harder than this makes a rule contradict
+// itself: a long run at 35.4% of the week, flagged for exceeding a 35%
+// guideline, prints as "35% vs 35%" and reads as a rule that fired over
+// nothing. The thresholds are all whole numbers, so only the measurement ever
+// carries the decimal and the pair stays easy to compare.
+function quantity(value) {
+	return String(Number(value.toFixed(1)));
+}
+
+// How each unit is said. Symbols bind to their number, so both halves of a
+// comparison carry them; words are said once at the end, because "7 bpm vs
+// 3 bpm" is how a form prints and not how anyone speaks.
+const UNITS = {
+	duration: { each: (v) => formatDuration(v) },
+	percent: { each: (v) => `${quantity(v)}%` },
+	ratio: { each: (v) => `${v.toFixed(2)}×` },
+	bpm: { each: quantity, trailing: " bpm" },
+	days: { each: (v) => String(Math.round(v)), trailing: " days" },
+	// Form is the one genuinely unitless measure on the page: a difference
+	// between two loads on an arbitrary scale.
+	none: { each: quantity },
+};
+
+/**
+ * A measured value against the threshold it crossed, as the recommendation
+ * panel prints it: "5.4% vs 5%", "3h 50m vs 3h 40m", "7 vs 3 bpm".
+ *
+ * Without the unit these read as bare numbers in a list where the row above
+ * is a ratio and the row below is a count of heartbeats — the reader is left
+ * to infer which from the prose, which is exactly the work the readout is
+ * supposed to save them.
+ *
+ * @param {number} metric
+ * @param {number} [threshold] omitted for rules that report a value rather
+ *   than a crossing.
+ * @param {string} [unit] one of duration, percent, ratio, bpm, days.
+ * @returns {string|null} null when there's no number to show.
+ */
+export function readout(metric, threshold, unit) {
+	if (!Number.isFinite(metric)) return null;
+	const { each, trailing = "" } = UNITS[unit] || UNITS.none;
+	const value = each(metric);
+	return Number.isFinite(threshold)
+		? `${value} vs ${each(threshold)}${trailing}`
+		: `${value}${trailing}`;
+}
+
+// A sentence ends at punctuation followed by a space and the start of the
+// next one. Deliberately not a lookbehind: Safari only learned those in 16.4,
+// and an unsupported one is a parse error that takes the whole bundle with it
+// rather than a formatting bug on one panel.
+const SENTENCE_BREAK = /[.!?]\s+[A-Z0-9]/;
+
+/**
+ * Split prose into its opening sentence and everything after it.
+ *
+ * The recommendations lead with the measurement and follow with why it
+ * matters and what to do — so the first sentence is the part that earns its
+ * place on screen, and the rest is what a reader asks for.
+ *
+ * @param {string} text
+ * @returns {{lead: string, rest: string}} rest is "" for a single sentence,
+ *   which is the signal not to offer an expander at all.
+ */
+export function splitLead(text) {
+	const trimmed = String(text ?? "").trim();
+	const at = trimmed.search(SENTENCE_BREAK);
+	if (at < 0) return { lead: trimmed, rest: "" };
+	return { lead: trimmed.slice(0, at + 1), rest: trimmed.slice(at + 1).trim() };
 }
 
 /**

--- a/src/components/Training/lib/format.test.js
+++ b/src/components/Training/lib/format.test.js
@@ -1,5 +1,78 @@
 import { describe, it, expect } from "vitest";
-import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed, speed } from "./format.js";
+import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed, speed, readout, splitLead } from "./format.js";
+
+describe("readout", () => {
+	it("binds symbols to both numbers and says words once", () => {
+		expect(readout(12, 10, "percent")).toBe("12% vs 10%");
+		expect(readout(1.62, 1.5, "ratio")).toBe("1.62× vs 1.50×");
+		expect(readout(7, 3, "bpm")).toBe("7 vs 3 bpm");
+		expect(readout(12, 21, "days")).toBe("12 vs 21 days");
+		expect(readout(13800, 13200, "duration")).toBe("3h 50m vs 3h 40m");
+	});
+
+	it("keeps the decimal that shows a threshold was crossed", () => {
+		// Rounded to whole numbers these print "5% vs 5%" and "35% vs 35%",
+		// which read as rules that fired without anything having happened.
+		expect(readout(5.4, 5, "percent")).toBe("5.4% vs 5%");
+		expect(readout(35.42, 35, "percent")).toBe("35.4% vs 35%");
+	});
+
+	it("drops the decimal when there isn't one", () => {
+		expect(readout(72, 80, "percent")).toBe("72% vs 80%");
+	});
+
+	it("reads a value on its own when nothing was crossed", () => {
+		expect(readout(1.24, null, "ratio")).toBe("1.24×");
+		expect(readout(48, null, "bpm")).toBe("48 bpm");
+	});
+
+	it("leaves form unitless, because it has no unit", () => {
+		expect(readout(-27, -25)).toBe("-27 vs -25");
+	});
+
+	it("has nothing to show without a number", () => {
+		expect(readout(null, 10, "percent")).toBeNull();
+		expect(readout(undefined, undefined, "percent")).toBeNull();
+	});
+});
+
+describe("splitLead", () => {
+	it("keeps the opening sentence and folds the rest away", () => {
+		const { lead, rest } = splitLead(
+			"Form is -27, below -25. That's normal in a heavy block. Take two easy days.",
+		);
+		expect(lead).toBe("Form is -27, below -25.");
+		expect(rest).toBe("That's normal in a heavy block. Take two easy days.");
+	});
+
+	it("offers nothing to expand for a single sentence", () => {
+		expect(splitLead("Acute-to-chronic ratio is 1.24, inside the corridor.")).toEqual({
+			lead: "Acute-to-chronic ratio is 1.24, inside the corridor.",
+			rest: "",
+		});
+	});
+
+	it("doesn't break a sentence at a decimal point", () => {
+		// "1.42×" and "1.5" are the numbers these rules are built on, and a
+		// naive split on "." cuts every one of them in half.
+		const { lead, rest } = splitLead(
+			"Your last 7 days carry 1.42× the load of your 28-day average. Above 1.5 is where injury rates climb.",
+		);
+		expect(lead).toBe("Your last 7 days carry 1.42× the load of your 28-day average.");
+		expect(rest).toBe("Above 1.5 is where injury rates climb.");
+	});
+
+	it("splits before a sentence that opens with a figure", () => {
+		const { lead, rest } = splitLead("You came in under plan. 42 km against 50 km.");
+		expect(lead).toBe("You came in under plan.");
+		expect(rest).toBe("42 km against 50 km.");
+	});
+
+	it("survives prose it can't split", () => {
+		expect(splitLead("")).toEqual({ lead: "", rest: "" });
+		expect(splitLead(null)).toEqual({ lead: "", rest: "" });
+	});
+});
 
 describe("speed", () => {
 	it("reads a ride in km/h", () => {

--- a/src/components/Training/sections/AerobicEfficiency.svelte
+++ b/src/components/Training/sections/AerobicEfficiency.svelte
@@ -13,8 +13,8 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { axisTicks, CHART_WEEKS, linePath, niceScale, seriesPoints, withinWindow } from "../lib/chart.js";
-    import { axisDate } from "../lib/format.js";
+    import { axisTicks, CHART_WEEKS, linePath, niceScale, seriesPoints, withinWindow, xPct, yPct } from "../lib/chart.js";
+    import { axisDate, shortDate } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { efficiency = null, summary = null, today = null } = $props();
@@ -57,6 +57,32 @@
     });
 
     const change = $derived(Number.isFinite(stats?.changePct) ? stats.changePct : null);
+
+    // Every dot is one run, and the trend is a rolling mean of the same list,
+    // so the two share an index and a cursor can honestly show both: what that
+    // run measured, and where the block stood by then. Three decimals because
+    // EF moves in the third one — 1.32 to 1.34 is a block's worth of progress.
+    const scrub = $derived(
+        points.map((point, i) => ({
+            key: `${point.date}-${i}`,
+            pct: xPct(dots[i].x, WIDTH),
+            label: shortDate(point.date),
+            readouts: [
+                {
+                    label: "This run",
+                    value: point.ef.toFixed(3),
+                    colour: "var(--paragraph-colour)",
+                    yPct: yPct(dots[i].y, HEIGHT),
+                },
+                {
+                    label: "Trend",
+                    value: trend[i].ef.toFixed(3),
+                    colour: "var(--main-green)",
+                    yPct: yPct(line[i].y, HEIGHT),
+                },
+            ],
+        })),
+    );
 </script>
 
 <Card title="Aerobic efficiency" info={GLOSSARY.efficiency}>
@@ -71,7 +97,7 @@
     {#if points.length < 2}
         <p class="card-empty">Not enough aerobic runs with heart rate in the last {CHART_WEEKS} weeks to plot yet.</p>
     {:else}
-        <ChartFrame height={160} {yTicks} {xTicks} label="Efficiency factor per aerobic run over the last {CHART_WEEKS} weeks">
+        <ChartFrame height={160} {yTicks} {xTicks} {scrub} label="Efficiency factor per aerobic run over the last {CHART_WEEKS} weeks">
             <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
                 {#each dots as dot}
                     <circle class="dot" cx={dot.x} cy={dot.y} r="3" />

--- a/src/components/Training/sections/FitnessChart.svelte
+++ b/src/components/Training/sections/FitnessChart.svelte
@@ -13,8 +13,8 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { areaPath, axisTicks, CHART_WEEKS, linePath, niceScale, seriesPoints, withinWindow } from "../lib/chart.js";
-    import { axisDate } from "../lib/format.js";
+    import { areaPath, axisTicks, CHART_WEEKS, linePath, niceScale, seriesPoints, withinWindow, xPct, yPct } from "../lib/chart.js";
+    import { axisDate, shortDate, signed } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { series = [], today = null } = $props();
@@ -64,6 +64,37 @@
     });
 
     const latest = $derived(series.at(-1) || null);
+
+    // Form is the gap between the other two, so all three want reading at the
+    // same instant — which is the whole reason this chart is worth scrubbing
+    // rather than just labelling its ends.
+    const scrub = $derived(
+        sampled.map((day, i) => ({
+            key: day.date,
+            pct: xPct(ctlPoints[i].x, WIDTH),
+            label: shortDate(day.date),
+            readouts: [
+                {
+                    label: "Fitness",
+                    value: String(Math.round(day.ctl)),
+                    colour: "var(--main-green)",
+                    yPct: yPct(ctlPoints[i].y, HEIGHT),
+                },
+                {
+                    label: "Fatigue",
+                    value: String(Math.round(day.atl)),
+                    colour: "var(--tone-bad)",
+                    yPct: yPct(atlPoints[i].y, HEIGHT),
+                },
+                {
+                    label: "Form",
+                    value: signed(day.tsb, 0),
+                    colour: "var(--paragraph-colour)",
+                    yPct: yPct(tsbPoints[i].y, HEIGHT),
+                },
+            ],
+        })),
+    );
 </script>
 
 <Card title="Fitness and fatigue" info={GLOSSARY.fitness}>
@@ -80,7 +111,7 @@
     {#if sampled.length < 2}
         <p class="card-empty">Not enough history to plot yet.</p>
     {:else}
-        <ChartFrame height={210} {yTicks} {xTicks} label="Fitness, fatigue and form over the last {CHART_WEEKS} weeks">
+        <ChartFrame height={210} {yTicks} {xTicks} {scrub} label="Fitness, fatigue and form over the last {CHART_WEEKS} weeks">
             <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
                 <path class="area" d={areaPath(ctlPoints, zeroY)} />
                 <path class="line form" d={linePath(tsbPoints)} />

--- a/src/components/Training/sections/RaceHeader.svelte
+++ b/src/components/Training/sections/RaceHeader.svelte
@@ -3,7 +3,7 @@
     training is in, and whether current fitness projects to the goal.
 -->
 <script>
-    import { clock, km, pace, signedClock } from "../lib/format.js";
+    import { clock, km, pace, signed, signedClock } from "../lib/format.js";
 
     let { summary } = $props();
 
@@ -17,6 +17,23 @@
         if (days < 0) return { value: "Done", label: "race day has passed" };
         if (days === 0) return { value: "Today", label: "race day" };
         return { value: String(days), label: days === 1 ? "day to go" : "days to go" };
+    });
+
+    // Fitness was the one headline number with nothing beside it, and it's the
+    // one that needs the context most: 62 is a figure on an arbitrary scale,
+    // and whether the block is still building is the part worth reading. A
+    // gain of under a point over four weeks is flat — CTL moves in decimals
+    // day to day, and "+0" dressed up as a rise would be noise.
+    const trend = $derived.by(() => {
+        const gain = latest?.ctlGain;
+        if (!Number.isFinite(gain)) return null;
+        if (Math.abs(gain) < 1) {
+            return { value: "level", tone: "flat", note: "holding over 4 weeks" };
+        }
+        const rounded = Math.round(Math.abs(gain));
+        return gain > 0
+            ? { value: `+${rounded}`, tone: "up", note: `up ${rounded} in 4 weeks` }
+            : { value: `−${rounded}`, tone: "down", note: `down ${rounded} in 4 weeks` };
     });
 
     const raceDate = $derived.by(() => {
@@ -62,9 +79,18 @@
 
     <div class="stat">
         <span class="stat-label">Fitness</span>
-        <strong class="stat-value">{latest ? Math.round(latest.ctl) : "—"}</strong>
+        <strong class="stat-value">
+            {latest ? Math.round(latest.ctl) : "—"}
+            {#if trend}
+                <span class="trend {trend.tone}">{trend.value}</span>
+            {/if}
+        </strong>
         <span class="stat-note">
-            {latest ? `form ${latest.tsb > 0 ? "+" : ""}${Math.round(latest.tsb)}` : "no data yet"}
+            {#if latest}
+                form {signed(latest.tsb, 0)}{trend ? ` · ${trend.note}` : ""}
+            {:else}
+                no data yet
+            {/if}
         </span>
     </div>
 
@@ -178,6 +204,20 @@
     }
     .stat-value.ahead { color: var(--tone-good); }
     .stat-value.behind { color: var(--tone-bad); }
+
+    /* Sized and set apart from the figure it qualifies, so the eye still
+       lands on the fitness number first. */
+    .trend {
+        font-family: var(--font-sans);
+        font-size: var(--font-xs);
+        font-weight: 600;
+        letter-spacing: 0;
+        vertical-align: 0.35em;
+        margin-left: 2px;
+    }
+    .trend.up { color: var(--tone-good); }
+    .trend.down { color: var(--tone-bad); }
+    .trend.flat { color: var(--paragraph-colour); opacity: 0.6; }
     .stat-note {
         font-size: var(--font-xs);
         color: var(--paragraph-colour);

--- a/src/components/Training/sections/Recommendations.svelte
+++ b/src/components/Training/sections/Recommendations.svelte
@@ -9,10 +9,16 @@
     a 3px rule — which is what this was — is not a signal; "act now" and "on
     track" have to differ in hue, in weight and in the words themselves, and the
     icon carries it for anyone who doesn't see the hue at all.
+
+    Each card leads with its opening sentence and folds the rest away. The rules
+    are written to put the measurement first and the reasoning after it, so the
+    visible line is always the evidence — and a dozen cards of full reasoning
+    was a panel you scrolled past rather than read. The short ones, which are a
+    single sentence, get no expander at all.
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
-    import { formatDuration } from "../lib/format.js";
+    import { readout, splitLead } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { recommendations = [] } = $props();
@@ -28,6 +34,8 @@
         (recommendations || []).map((rec) => ({
             ...rec,
             meta: SEVERITY[rec.severity] || { label: rec.severity, tone: "info", icon: "i" },
+            ...splitLead(rec.detail),
+            readout: readout(rec.metric, rec.threshold, rec.unit),
         })),
     );
 
@@ -36,23 +44,6 @@
         return { acted, total: items.length };
     });
 
-    // Most rules measure a ratio, a percentage or a count of beats, where the
-    // number is the number. A few are held in seconds — a goal time, a night's
-    // sleep — and "13500 vs 13200" is unreadable next to a rule whose own
-    // sentence says "3h 45m against your 3h 40m target".
-    const format = (value, unit) =>
-        unit === "duration"
-            ? formatDuration(value)
-            : Math.abs(value) < 10
-                ? value.toFixed(2)
-                : String(Math.round(value));
-
-    function readout(rec) {
-        if (!Number.isFinite(rec.metric)) return null;
-        const value = format(rec.metric, rec.unit);
-        if (!Number.isFinite(rec.threshold)) return value;
-        return `${value} vs ${format(rec.threshold, rec.unit)}`;
-    }
 </script>
 
 <!--
@@ -108,12 +99,18 @@
                             {@render glyph(rec.meta.icon)}
                             {rec.meta.label}
                         </span>
-                        {#if readout(rec)}
-                            <span class="rec-metric" title="Measured value against its threshold">{readout(rec)}</span>
+                        {#if rec.readout}
+                            <span class="rec-metric" title="Measured value against its threshold">{rec.readout}</span>
                         {/if}
                     </div>
                     <h3>{rec.title}</h3>
-                    <p>{rec.detail}</p>
+                    <p>{rec.lead}</p>
+                    {#if rec.rest}
+                        <details>
+                            <summary>Why this matters</summary>
+                            <p class="rest">{rec.rest}</p>
+                        </details>
+                    {/if}
                 </li>
             {/each}
         </ul>
@@ -189,6 +186,55 @@
     .rec-icon .dot {
         fill: currentColor;
         stroke: none;
+    }
+
+    /* A native disclosure rather than a state flag and a click handler: it
+       comes with the button semantics, the keyboard behaviour and the
+       expanded/collapsed announcement already correct, and find-in-page can
+       still reach the text inside it. Only the marker is replaced, because
+       the default triangle is a different shape in every browser. */
+    details {
+        margin-top: var(--space-3);
+    }
+    summary {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        width: fit-content;
+        cursor: pointer;
+        font-size: var(--font-2xs);
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--tone);
+        opacity: 0.8;
+        list-style: none;
+        border-radius: var(--radius-sm);
+    }
+    summary::-webkit-details-marker { display: none; }
+    summary:hover { opacity: 1; }
+    summary:focus-visible {
+        outline: 2px solid var(--tone);
+        outline-offset: 3px;
+    }
+    /* Half a square rotated into a chevron, so it points from the same box
+       whichever way it's turned — a glyph would shift on its baseline. */
+    summary::after {
+        content: "";
+        width: 0.4em;
+        height: 0.4em;
+        border-right: 1.5px solid currentColor;
+        border-bottom: 1.5px solid currentColor;
+        transform: translateY(-0.12em) rotate(45deg);
+        transition: transform 0.15s ease;
+    }
+    details[open] summary::after {
+        transform: translateY(0.08em) rotate(-135deg);
+    }
+    .rest { margin-top: var(--space-2); }
+
+    @media (prefers-reduced-motion: reduce) {
+        summary::after { transition: none; }
     }
 
     .rec-metric {

--- a/src/components/Training/sections/Recovery.svelte
+++ b/src/components/Training/sections/Recovery.svelte
@@ -15,7 +15,7 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { bars } from "../lib/chart.js";
+    import { bars, xPct, yPct } from "../lib/chart.js";
     import { formatDuration, shortDate } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
@@ -75,6 +75,32 @@
     );
     const targetY = $derived(CHART_H - (SLEEP_TARGET_SEC / CEILING_SEC) * CHART_H);
 
+    // The panel's three measures are summarised as a week against a month, so
+    // the cursor is where a single night's numbers are readable at all — and
+    // the night you slept badly and the night your heart rate sat high are
+    // usually the same one, which the averages can't show you.
+    const scrub = $derived(
+        nights.map((night, i) => ({
+            key: night.day,
+            pct: xPct(columns[i].x + columns[i].width / 2, CHART_W),
+            label: shortDate(night.day),
+            readouts: [
+                {
+                    label: "Sleep",
+                    value: formatDuration(night.sleepSec || 0),
+                    colour: night.sleepSec < SLEEP_TARGET_SEC ? "var(--tone-warn)" : "var(--main-green)",
+                    yPct: yPct(columns[i].y, CHART_H),
+                },
+                ...(Number.isFinite(night.restingHr)
+                    ? [{ label: "Resting HR", value: `${Math.round(night.restingHr)} bpm` }]
+                    : []),
+                ...(Number.isFinite(night.averageHrv)
+                    ? [{ label: "HRV", value: `${Math.round(night.averageHrv)} ms` }]
+                    : []),
+            ],
+        })),
+    );
+
     // Signed, in the units of whatever it's describing.
     const delta = (value, unit) => {
         if (!Number.isFinite(value)) return "—";
@@ -101,6 +127,7 @@
             <ChartFrame
                 height={CHART_H}
                 yTicks={Y_TICKS}
+                {scrub}
                 label="Sleep each night over the last fortnight"
             >
                 <svg viewBox="0 0 {CHART_W} {CHART_H}" preserveAspectRatio="none">
@@ -117,9 +144,7 @@
                             width={bar.width}
                             height={bar.height}
                             rx="2"
-                        >
-                            <title>{shortDate(nights[i].day)} — {formatDuration(bar.value)}</title>
-                        </rect>
+                        ></rect>
                     {/each}
                 </svg>
             </ChartFrame>

--- a/src/components/Training/sections/VolumeChart.svelte
+++ b/src/components/Training/sections/VolumeChart.svelte
@@ -3,7 +3,9 @@
 
     Bars are what was actually run; the tick above each is the planned target,
     where one has been entered. Weeks with no plan entry simply have no tick,
-    rather than reading as a target of zero.
+    rather than reading as a target of zero. Both numbers are in the cursor's
+    readout, which replaces the per-bar <title> — a native tooltip and a drawn
+    one appearing over each other is worse than either alone.
 
     The window stops at the current week rather than running on to race day.
     Charting the weeks still to come stretched the axis across four months and
@@ -14,7 +16,7 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { axisTicks, bars, CHART_WEEKS, niceScale } from "../lib/chart.js";
+    import { axisTicks, bars, CHART_WEEKS, niceScale, xPct, yPct } from "../lib/chart.js";
     import { axisDate, weekRange } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
@@ -46,6 +48,35 @@
             if (!slot || !(week.targetKm > 0)) return null;
             return { ...slot, y: HEIGHT - (week.targetKm / scale.max) * HEIGHT };
         }),
+    );
+
+    // Run against planned, week by week. The bar and its tick are the two
+    // numbers the chart is a comparison of, so both belong in the readout —
+    // and a taper week says so, since a short bar there is the plan working.
+    const scrub = $derived(
+        shown.map((week, i) => ({
+            key: week.start,
+            pct: xPct(layout[i].x + layout[i].width / 2, WIDTH),
+            label: weekRange(week.start),
+            readouts: [
+                {
+                    label: week.isTaper ? "Run (taper)" : "Run",
+                    value: `${(week.actualKm || 0).toFixed(1)} km`,
+                    colour: week.isTaper ? "var(--background-accent)" : "var(--main-green)",
+                    yPct: yPct(layout[i].y, HEIGHT),
+                },
+                ...(week.targetKm > 0
+                    ? [
+                            {
+                                label: "Planned",
+                                value: `${week.targetKm} km`,
+                                colour: "var(--paragraph-colour)",
+                                yPct: yPct(targets[i].y, HEIGHT),
+                            },
+                        ]
+                    : []),
+            ],
+        })),
     );
 
     // A date under every bar doesn't fit on a phone, so label every third week
@@ -80,7 +111,7 @@
     {#if shown.length === 0}
         <p class="card-empty">No weeks recorded yet.</p>
     {:else}
-        <ChartFrame height={190} {yTicks} {xTicks} label="Weekly running volume in kilometres against plan">
+        <ChartFrame height={190} {yTicks} {xTicks} {scrub} label="Weekly running volume in kilometres against plan">
             <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
                 {#each layout as bar, i}
                     {@const week = shown[i]}
@@ -92,9 +123,7 @@
                         width={bar.width}
                         height={bar.height}
                         rx="2"
-                    >
-                        <title>{weekRange(week.start)} — {bar.value.toFixed(1)} km{week.targetKm ? ` of ${week.targetKm} km planned` : ""}</title>
-                    </rect>
+                    ></rect>
                     {#if targets[i]}
                         <line
                             class="target"


### PR DESCRIPTION
Four notes from using the page, which all come down to the same thing: it shows its working, and showing your working only helps if it can be read.

## Recommendations fold their reasoning away

Each card leads with its opening sentence and puts the rest behind a native `<details>`. The rules were already written measurement-first and reasoning-after, so the visible line is always the evidence. Single-sentence rules — the "on track" ones — get no expander at all.

## Measured rules say what kind of number they are

Symbols bind to their figure, words are said once: `35.4% vs 35%`, `1.17×`, `7 vs 3 bpm`, `3h 50m vs 3h 40m`, `12 vs 21 days`. Form stays bare on purpose — it's a difference between two loads on an arbitrary scale, and calling it "points" would imply a precision it hasn't got.

This turned up a bug rather than just tidying one. Rounding to whole numbers printed a long run at 35.4% of the week, *flagged for exceeding a 35% guideline*, as `35% vs 35%` — a rule contradicting itself on screen. The thresholds are all whole numbers, so one decimal on the measurement fixes it without making the pair harder to compare.

## The charts can be scrubbed

Implemented once in `ChartFrame` rather than four times, so a line chart, a bar chart and a scatter all answer a hover identically. A chart passes what its points mean and where they sit as percentages; it gets the cursor, the dots, the readout and the keyboard handling back.

- **Fitness** — all three series at one instant, which is the point: form is the gap between the other two and can't be read off any of them alone
- **Volume** — run against planned, with taper weeks named so a short bar reads as the plan working
- **Efficiency** — the run and the smoothed trend, which share an index
- **Recovery** — sleep, resting HR and HRV for a single night, where the panel otherwise only summarises a week against a month

Two details worth calling out. The readout sits *beside* the cursor, never over it: centred, it covers the very dots it describes, and at the ends of a series it hangs off the edge — which on a phone takes the whole viewport sideways. And the per-bar `<title>` elements are gone from the bar charts, because a native tooltip and a drawn one appearing over each other is worse than either alone.

## Fitness has something to say

It was the one headline stat with nothing beside it, and the one needing context most — `62` is a figure on an arbitrary scale nobody has an instinct for. It now carries its four-week change (`37 +7`, "up 7 in 4 weeks"). Four weeks because CTL has a 42-day time constant: a week's change is mostly the smoothing catching up with itself, and a whole block is too coarse to say anything about the training you're doing now.

## Test plan

- [x] 627 unit tests pass — new coverage for `readout`, `splitLead` and `fitnessGain`, including the rounding collision above and the sentence split not breaking on `1.42×`
- [x] 26 e2e pass, 5 new: the disclosure, the units, pointer scrubbing, keyboard scrubbing, and a readout at the right-hand edge of a 360px screen not widening the page
- [x] The keyboard test caught a real bug — arrow-left at the first point dismissed the cursor instead of holding it
- [x] Checked in a real browser at 1280px and 390px, light theme
- [ ] ESLint not run locally (not installed in this environment); Codacy covers it

Made with [Cursor](https://cursor.com)