### PR TITLE
Curve the trend lines, scrub the last run, and fix the form disagreement

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ Polling cadences:
 - **Dashboard widgets** poll on a fixed `setInterval` (5 min for GitHub/Strava/
   HN, 10 s for Spotify) and read through the SWR cache. The Gallery widget loads
   the photo list once and only re-picks a random image on its timer.
+- **`/training`** is a chain of four cadences that only works if they line up,
+  since the slowest one is the delay: `trainingSync` reads Strava every 5 min,
+  `trainingData` is held at the edge for 60 s (and revalidated by the browser
+  every time, so a reload after an upload can't answer itself from a stale
+  copy), the page polls every 5 min, and `fetchJsonSwr`'s window is 60 s. A run
+  is on the page within roughly 5 minutes of uploading. Change one and check
+  the rest — a poll slower than the sync makes an open tab lag a reopened one,
+  and an SWR window above the poll interval quietly skips ticks.
 - **Bach** (`src/components/Bach/Bach.svelte`) uses a single self-scheduling
   loop: each `poll()` queues the next tick at a phase-appropriate interval
   (`src/components/Bach/lib/poll.js`) — fast during active phases, backed off in

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -203,6 +203,25 @@ test("scrubbing a chart reads out the values under the cursor", async ({ page })
 	await expect(card.locator(".tip")).toHaveCount(0);
 });
 
+test("the last run scrubs a kilometre at a time", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "Last run" }).first();
+	const plot = card.locator(".plot");
+
+	await plot.scrollIntoViewIfNeeded();
+	const box = await plot.boundingBox();
+	await page.mouse.move(box.x + box.width * 0.5, box.y + box.height / 2);
+
+	const tip = card.locator(".tip");
+	await expect(tip).toBeVisible();
+	// The split, not the run: a kilometre's own pace and what the heart was
+	// doing for it, which is the question the whole panel is a preamble to.
+	await expect(tip.locator(".tip-label")).toHaveText(/Kilometre \d+/);
+	await expect(tip.getByText("Pace", { exact: true })).toBeVisible();
+	await expect(tip).toContainText(/\d+:\d\d\/km/);
+	await expect(tip).toContainText(/\d+ bpm/);
+});
+
 test("the chart cursor can be driven from the keyboard", async ({ page }) => {
 	await page.goto("/training");
 	const card = page.locator("section.card").filter({ hasText: "Weekly volume" }).first();

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -203,6 +203,27 @@ test("scrubbing a chart reads out the values under the cursor", async ({ page })
 	await expect(card.locator(".tip")).toHaveCount(0);
 });
 
+test("the footer dates the sync, not the visit", async ({ page }) => {
+	await page.goto("/training");
+	const stamp = page.locator(".foot .stamp");
+
+	// The page-build time ticks forward on a refresh that changed nothing, and
+	// dates a payload the CDN may have been holding for ten minutes, so it
+	// answers a question nobody asked.
+	await expect(stamp).toHaveText(/^Last synced /);
+
+	const shown = await stamp.textContent();
+	const syncedAt = await page.evaluate(async () => {
+		const res = await fetch("/.netlify/functions/trainingData");
+		return (await res.json()).sync.lastRunAt;
+	});
+	const expected = new Date(syncedAt).toLocaleString("en-GB", {
+		dateStyle: "medium",
+		timeStyle: "short",
+	});
+	expect(shown).toBe(`Last synced ${expected}`);
+});
+
 test("the last run scrubs a kilometre at a time", async ({ page }) => {
 	await page.goto("/training");
 	const card = page.locator("section.card").filter({ hasText: "Last run" }).first();

--- a/netlify/functions/_shared/training/fitness.js
+++ b/netlify/functions/_shared/training/fitness.js
@@ -7,11 +7,17 @@
 //
 //   CTL (fitness) — 42-day exponentially weighted average of daily load
 //   ATL (fatigue) —  7-day exponentially weighted average of daily load
-//   TSB (form)    — yesterday's CTL minus yesterday's ATL
+//   TSB (form)    — CTL minus ATL
 //
-// TSB deliberately lags by a day: today's session shouldn't make you look less
-// ready before you've done it, and a morning check-in would otherwise flip
-// negative the moment a run uploads.
+// All three describe the same instant, the end of the day they're filed under,
+// and that consistency is load-bearing rather than tidiness. Form used to lag a
+// day on the reasoning that today's session shouldn't make you look less ready
+// before you'd done it — but the record then mixed two moments, reporting
+// fitness and fatigue after the run and form from before it. Every reader had
+// to know which, and they disagreed: the chart's own header read "Fitness 19,
+// Fatigue 25, Form −1" when 19 − 25 is −6, and the day of the hardest run in a
+// week drew form going *up*. If a "form you woke up with" is ever wanted, it's
+// yesterday's record, and asking for it that way is honest about what it is.
 //
 // Separately, ACWR (acute:chronic workload ratio) compares the last 7 days of
 // load against the last 28. It's the standard early warning for ramping too
@@ -67,12 +73,12 @@ export function fitnessSeries(loadsByDay, { from, to }) {
 	let ctl = 0;
 	let atl = 0;
 	return days.map((date) => {
-		// Form reflects the state you woke up with, before today's session.
-		const tsb = ctl - atl;
 		const load = Number(lookup.get(date)) || 0;
 		ctl += (load - ctl) * ctlAlpha;
 		atl += (load - atl) * atlAlpha;
-		return { date, load, ctl, atl, tsb };
+		// Read off the same two numbers the record reports, so that nothing
+		// downstream can disagree with it by doing the subtraction itself.
+		return { date, load, ctl, atl, tsb: ctl - atl };
 	});
 }
 

--- a/netlify/functions/_shared/training/fitness.test.js
+++ b/netlify/functions/_shared/training/fitness.test.js
@@ -56,13 +56,29 @@ describe("fitnessSeries", () => {
 		expect(raceDay.tsb).toBeGreaterThan(0);
 	});
 
-	it("reports form from before the day's own session", () => {
-		// A single big day shouldn't drag its own form reading negative.
-		const series = fitnessSeries(new Map([["2026-08-11", 200]]), {
+	it("reports fitness, fatigue and form as of the same moment", () => {
+		// The one that got away: ctl and atl were reported after the day's
+		// load and tsb from before it, so a record contradicted itself and
+		// every reader that did the subtraction disagreed with every reader
+		// that trusted the field. On the page that looked like the last run
+		// costing 4.7 of form while the chart drew form rising by 3.
+		const loads = steady("2026-06-01", "2026-08-12", 60);
+		loads.set("2026-08-12", 200);
+		const series = fitnessSeries(loads, { from: "2026-06-01", to: "2026-08-12" });
+
+		for (const day of series) {
+			expect(day.tsb).toBeCloseTo(day.ctl - day.atl, 10);
+		}
+	});
+
+	it("counts the day's own session against its form", () => {
+		const series = fitnessSeries(new Map([["2026-08-12", 200]]), {
 			from: "2026-08-11",
 			to: "2026-08-12",
 		});
 		expect(series[0].tsb).toBe(0);
+		// A hard run leaves you less fresh on the day you do it, which is the
+		// reading the "what it did" panel has always given.
 		expect(series[1].tsb).toBeLessThan(0);
 	});
 

--- a/netlify/functions/_shared/training/lastRun.js
+++ b/netlify/functions/_shared/training/lastRun.js
@@ -42,19 +42,12 @@ function median(values) {
 	return sorted.length % 2 ? upper : (lower + upper) / 2;
 }
 
-/** Fitness minus fatigue, as of the end of a day in the series. */
-function formOf(day) {
-	return day.ctl - day.atl;
-}
-
 /**
  * What the day's running did to fitness, fatigue and form.
  *
- * fitnessSeries reports a day's ctl/atl *after* that day's load, but its tsb as
- * the form you woke up with, before it (see fitness.js). Taking ctl and atl
- * from the day before and the day itself therefore brackets the run cleanly,
- * and form is recomputed from those rather than read off, so all three deltas
- * describe the same moment.
+ * Each record in the series is the state at the end of its day, so the day
+ * before and the day itself bracket the run and all three deltas describe the
+ * same pair of moments.
  *
  * @param {object[]} series from fitnessSeries().
  * @param {string} date day key of the run.
@@ -76,8 +69,8 @@ function formImpact(series, date) {
 		ctlDelta: after.ctl - before.ctl,
 		atl: after.atl,
 		atlDelta: after.atl - before.atl,
-		tsb: formOf(after),
-		tsbDelta: formOf(after) - formOf(before),
+		tsb: after.tsb,
+		tsbDelta: after.tsb - before.tsb,
 	};
 }
 

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -282,6 +282,10 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 	});
 
 	return {
+		// When this payload was computed, which is not when Strava was last
+		// read — that's sync.lastRunAt, and it's the one worth showing anyone.
+		// This one exists to tell a stale CDN copy from a fresh one, and it
+		// ticks forward on a rebuild that changed nothing.
 		generatedAt: new Date().toISOString(),
 		today: day,
 		summary,

--- a/netlify/functions/_tests/trainingData.test.js
+++ b/netlify/functions/_tests/trainingData.test.js
@@ -151,13 +151,21 @@ describe("trainingData privacy", () => {
 });
 
 describe("trainingData behaviour", () => {
-	it("is publicly cacheable, since there is nothing to gate", async () => {
+	it("is cached at the edge, and revalidated by the browser", async () => {
 		seed(shapeActivities([rawRun()], { thresholds: PLAN_THRESHOLDS }));
 		const { res } = await payload();
+
+		// The edge absorbs a burst, so a public page costs one invocation a
+		// minute rather than one a visitor.
+		expect(res.headers.get("netlify-cdn-cache-control")).toContain("public");
+		expect(res.headers.get("netlify-cdn-cache-control")).toContain("max-age=60");
+
+		// But the browser asks every time. A shared max-age would let a reload
+		// answer itself from a copy older than the sync that has since run,
+		// which is the one case this page is refreshed for.
 		const cache = res.headers.get("cache-control");
-		expect(cache).toContain("public");
-		expect(cache).toContain("max-age=600");
-		expect(cache).toContain("stale-while-revalidate=1800");
+		expect(cache).toContain("must-revalidate");
+		expect(cache).not.toContain("stale-while-revalidate");
 	});
 
 	it("serves an empty dashboard before the first sync has run", async () => {

--- a/netlify/functions/trainingData.js
+++ b/netlify/functions/trainingData.js
@@ -8,8 +8,8 @@
 //
 // This reads Blobs and runs pure functions; it never calls Strava. That's what
 // makes it cheap enough to leave open — combined with the CDN cache below, a
-// burst of traffic costs one function invocation per ten minutes rather than
-// one per visitor, and can't affect the Strava rate limit at all.
+// burst of traffic costs one function invocation per minute rather than one
+// per visitor, and can't affect the Strava rate limit at all.
 
 import { createJsonResponder, cacheControl } from "./_shared/http.js";
 import { createMemo } from "./_shared/memo.js";
@@ -24,9 +24,19 @@ import {
 } from "./_shared/training/store.js";
 import { toDayKey } from "./_shared/training/dates.js";
 
-// The underlying data only changes when the hourly sync runs, so a 10-minute
-// CDN cache with a 30-minute stale window costs nothing in freshness.
-const jsonResponse = createJsonResponder(cacheControl.swr(600, 1800));
+// The data changes when the 5-minute sync runs, and the point of that cadence
+// is a run appearing shortly after it uploads — so the cache must not be the
+// thing that eats the gain.
+//
+// The edge holds a copy for a minute and the browser always revalidates
+// against it, rather than a plain public max-age. Two reasons, and the second
+// is the real one. A shared max-age lets a browser serve its own copy without
+// asking, so the reload after an upload can miss data that has already landed;
+// and stale-while-revalidate hands out the previous copy while it refreshes,
+// which is exactly the wrong trade for someone refreshing *because* they
+// expect something new. A burst still costs one origin call a minute, and the
+// memo below makes that cheaper again.
+const jsonResponse = createJsonResponder(cacheControl.edgeBurst(60));
 const errResponse = createJsonResponder(cacheControl.none);
 
 // Absorb bursts that get past a cold edge cache.

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -406,27 +406,30 @@ export default async function handler(req) {
 	});
 }
 
-// Every 10 minutes, which is what a run showing up on the page shortly after
-// it uploads costs.
+// Every 5 minutes, which is what a run showing up on the page shortly after it
+// uploads costs. Paired with a 60s edge cache on trainingData, so the cadence
+// is the whole delay rather than half of it.
 //
 // Once caught up an invocation is two upstream calls: a token refresh and one
 // activity listing. Strava meters those in two buckets and the tighter one is
 // reads — 100 per 15 minutes and 1,000 per day at the standard tier — but only
 // the listing is a read, since the refresh is a POST to /oauth/token. So this
-// cadence spends about 144 reads a day of 1,000, and at most two of the 100 in
-// any quarter hour. The same app credentials serve the /dashboard widgets in a
+// cadence spends about 288 reads a day of 1,000, and three of the 100 in any
+// quarter hour. The same app credentials serve the /dashboard widgets in a
 // visitor's request path, which is the reason for the headroom and for
 // QUOTA_SHARE above.
 //
-// A backfill is the expensive case, at up to DETAIL_BUDGET × 2 reads an
-// invocation, and halving the interval doubles the rate it can burn quota. It
-// converges in two or three invocations, and past that the quota guard reads
-// Strava's own headers and stands down, so the cost is bounded by the guard
-// rather than by this number.
+// Backfill is the expensive case, at up to DETAIL_BUDGET × 2 reads an
+// invocation — more than a quarter hour's whole share in one go. That is fine,
+// and it's why the quota guard exists: it reads Strava's own headers and
+// stands the job down at 60% of either bucket, so a cold start moves at
+// whatever the window allows and defers the rest. Shortening the interval
+// therefore doesn't buy a faster backfill and can't buy a 429 either; both are
+// the guard's business. What it buys is the steady state.
 //
 // A schedule is also the ONLY thing that ever writes this store — a scheduled
 // function can't be invoked over HTTP — so the gap between deploying and the
 // first tick is exactly how long the dashboard has no runs on it at all.
 export const config = {
-	schedule: "*/10 * * * *",
+	schedule: "*/5 * * * *",
 };

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -406,12 +406,27 @@ export default async function handler(req) {
 	});
 }
 
-// Every 20 minutes. Once caught up an invocation is two upstream calls (a
-// token refresh and one activity listing), so the steady-state cost of this
-// cadence is negligible; what it buys is the cold start. A schedule is also
-// the ONLY thing that ever writes this store — a scheduled function can't be
-// invoked over HTTP — so the gap between deploying and the first tick is
-// exactly how long the dashboard has no runs on it at all.
+// Every 10 minutes, which is what a run showing up on the page shortly after
+// it uploads costs.
+//
+// Once caught up an invocation is two upstream calls: a token refresh and one
+// activity listing. Strava meters those in two buckets and the tighter one is
+// reads — 100 per 15 minutes and 1,000 per day at the standard tier — but only
+// the listing is a read, since the refresh is a POST to /oauth/token. So this
+// cadence spends about 144 reads a day of 1,000, and at most two of the 100 in
+// any quarter hour. The same app credentials serve the /dashboard widgets in a
+// visitor's request path, which is the reason for the headroom and for
+// QUOTA_SHARE above.
+//
+// A backfill is the expensive case, at up to DETAIL_BUDGET × 2 reads an
+// invocation, and halving the interval doubles the rate it can burn quota. It
+// converges in two or three invocations, and past that the quota guard reads
+// Strava's own headers and stands down, so the cost is bounded by the guard
+// rather than by this number.
+//
+// A schedule is also the ONLY thing that ever writes this store — a scheduled
+// function can't be invoked over HTTP — so the gap between deploying and the
+// first tick is exactly how long the dashboard has no runs on it at all.
 export const config = {
-	schedule: "*/20 * * * *",
+	schedule: "*/10 * * * *",
 };

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -187,10 +187,12 @@
         window.addEventListener("resize", onResize);
         load();
 
-        // The upstream sync runs hourly, so there's nothing to gain from
-        // polling hard — this is really just to catch a sync landing while
-        // the tab is left open.
-        stopPoll = createPoller(load, 1000 * 60 * 10, { jitterMs: 30_000 });
+        // Matched to the upstream sync, so a tab left open is never more than
+        // one cycle behind a tab reopened. Polling faster than the thing that
+        // produces the data only re-fetches an answer that hasn't changed;
+        // fetchJsonSwr's 60s window and the 60s edge cache both sit under this,
+        // so each tick genuinely revalidates.
+        stopPoll = createPoller(load, 1000 * 60 * 5, { jitterMs: 30_000 });
     });
 
     onDestroy(() => {

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -298,8 +298,12 @@
             <p class="links">
                 <a href={STRAVA_PROFILE} target="_blank" rel="noreferrer">Strava profile ↗</a>
             </p>
-            {#if data.generatedAt}
-                <p class="stamp">Updated {new Date(data.generatedAt).toLocaleString("en-GB", { dateStyle: "medium", timeStyle: "short" })}</p>
+            <!-- When Strava was last read, not when this page was built. The
+                 latter is a fact about the reader's own visit — it ticks
+                 forward on a refresh that changed nothing, and dates a payload
+                 the CDN may have been serving for ten minutes. -->
+            {#if data.sync?.lastRunAt}
+                <p class="stamp">Last synced {new Date(data.sync.lastRunAt).toLocaleString("en-GB", { dateStyle: "medium", timeStyle: "short" })}</p>
             {/if}
         </footer>
     {/if}

--- a/src/components/Training/charts/ChartFrame.svelte
+++ b/src/components/Training/charts/ChartFrame.svelte
@@ -303,7 +303,9 @@
 		background: var(--dot);
 		/* Ringed in the card's own background so a dot stays legible where it
 		   sits on top of the line it belongs to. */
-		box-shadow: 0 0 0 2px var(--card-background, var(--inner-background));
+		/* Ringed in an opaque surface so a dot stays legible where it sits on
+		   top of the line it belongs to. */
+		box-shadow: 0 0 0 2px var(--background-one);
 		pointer-events: none;
 	}
 
@@ -314,7 +316,13 @@
 		min-width: max-content;
 		padding: var(--space-2) var(--space-3);
 		border-radius: var(--radius-sm);
-		background: var(--inner-background);
+		/* The card surface tint composited over an opaque base, rather than
+		   used alone: --inner-background is 28% alpha on the dark theme, which
+		   is fine for a panel sitting on the page background and unreadable
+		   for a label sitting on top of the chart it's describing. */
+		background:
+			linear-gradient(var(--inner-background), var(--inner-background)),
+			var(--background-one);
 		border: 1px solid var(--main-green-translucent);
 		box-shadow: var(--box-shadow, 0 4px 16px rgb(0 0 0 / 18%));
 		pointer-events: none;

--- a/src/components/Training/lib/chart.js
+++ b/src/components/Training/lib/chart.js
@@ -63,6 +63,78 @@ export function linePath(points) {
 		.join(" ");
 }
 
+const coord = (n) => n.toFixed(2);
+
+/**
+ * A smooth path through points, by monotone cubic interpolation.
+ *
+ * The straight segments between daily samples are already an interpolation —
+ * nothing was measured between Tuesday and Wednesday — so a curve is no less
+ * truthful than a polyline, and considerably easier to read on a series that
+ * genuinely sawtooths. Fatigue is a 7-day average of an athlete who runs every
+ * second day, so it swings ~40% around its own mean by construction, and drawn
+ * with hard corners that arithmetic reads as instrument noise.
+ *
+ * Monotone rather than a plain spline, and that distinction is the whole point.
+ * Catmull-Rom or a naive Bézier overshoots at a reversal: it invents a peak
+ * higher than any day recorded, which on a chart of someone's training is a
+ * fitness they never had. Fritsch-Carlson flattens the tangent at every local
+ * extreme, so the curve is guaranteed to stay within the values it connects.
+ *
+ * @param {{x: number, y: number}[]} points already in pixel space, ascending
+ *   in x.
+ * @returns {string}
+ */
+export function smoothPath(points) {
+	const list = points || [];
+	// Two points are a straight line; there's no interior tangent to fit.
+	if (list.length < 3) return linePath(list);
+
+	const n = list.length;
+
+	const secants = [];
+	for (let i = 0; i < n - 1; i++) {
+		const dx = list[i + 1].x - list[i].x;
+		secants.push(dx === 0 ? 0 : (list[i + 1].y - list[i].y) / dx);
+	}
+
+	// Zero at a turning point — where the neighbouring secants disagree in
+	// sign — and the average of them elsewhere.
+	const tangents = new Array(n);
+	tangents[0] = secants[0];
+	tangents[n - 1] = secants[n - 2];
+	for (let i = 1; i < n - 1; i++) {
+		tangents[i] = secants[i - 1] * secants[i] <= 0 ? 0 : (secants[i - 1] + secants[i]) / 2;
+	}
+
+	// Fritsch-Carlson: pull any tangent pair back inside a circle of radius 3,
+	// which is the condition for the segment to stay monotone.
+	for (let i = 0; i < n - 1; i++) {
+		if (secants[i] === 0) {
+			tangents[i] = 0;
+			tangents[i + 1] = 0;
+			continue;
+		}
+		const a = tangents[i] / secants[i];
+		const b = tangents[i + 1] / secants[i];
+		const radius = a * a + b * b;
+		if (radius > 9) {
+			const scale = 3 / Math.sqrt(radius);
+			tangents[i] = scale * a * secants[i];
+			tangents[i + 1] = scale * b * secants[i];
+		}
+	}
+
+	let d = `M${coord(list[0].x)} ${coord(list[0].y)}`;
+	for (let i = 0; i < n - 1; i++) {
+		const third = (list[i + 1].x - list[i].x) / 3;
+		const c1 = { x: list[i].x + third, y: list[i].y + tangents[i] * third };
+		const c2 = { x: list[i + 1].x - third, y: list[i + 1].y - tangents[i + 1] * third };
+		d += ` C${coord(c1.x)} ${coord(c1.y)} ${coord(c2.x)} ${coord(c2.y)} ${coord(list[i + 1].x)} ${coord(list[i + 1].y)}`;
+	}
+	return d;
+}
+
 /**
  * A closed area path from a line down to a baseline.
  *
@@ -70,11 +142,12 @@ export function linePath(points) {
  * @param {number} baselineY
  * @returns {string}
  */
-export function areaPath(points, baselineY) {
+export function areaPath(points, baselineY, { smooth = false } = {}) {
 	if (!points || points.length === 0) return "";
 	const first = points[0];
 	const last = points[points.length - 1];
-	return `${linePath(points)} L${last.x.toFixed(2)} ${baselineY.toFixed(2)} L${first.x.toFixed(2)} ${baselineY.toFixed(2)} Z`;
+	const edge = smooth ? smoothPath(points) : linePath(points);
+	return `${edge} L${coord(last.x)} ${coord(baselineY)} L${coord(first.x)} ${coord(baselineY)} Z`;
 }
 
 /**

--- a/src/components/Training/lib/chart.test.js
+++ b/src/components/Training/lib/chart.test.js
@@ -10,8 +10,67 @@ import {
 	niceScale,
 	axisTicks,
 	withinWindow,
+	smoothPath,
 	CHART_DAYS,
 } from "./chart.js";
+
+describe("smoothPath", () => {
+	// Every "C x1 y1 x2 y2 x y" triple, as numbers.
+	function curves(d) {
+		return [...d.matchAll(/C([-\d.]+) ([-\d.]+) ([-\d.]+) ([-\d.]+) ([-\d.]+) ([-\d.]+)/g)].map(
+			(m) => ({
+				c1: { x: Number(m[1]), y: Number(m[2]) },
+				c2: { x: Number(m[3]), y: Number(m[4]) },
+				end: { x: Number(m[5]), y: Number(m[6]) },
+			}),
+		);
+	}
+
+	it("is a straight line when there's no interior tangent to fit", () => {
+		expect(smoothPath([{ x: 0, y: 0 }, { x: 10, y: 5 }])).toBe(linePath([{ x: 0, y: 0 }, { x: 10, y: 5 }]));
+		expect(smoothPath([])).toBe("");
+	});
+
+	it("passes through every measured point", () => {
+		// A curve that misses its own data would be a drawing of numbers
+		// nobody recorded.
+		const points = [
+			{ x: 0, y: 10 }, { x: 10, y: 40 }, { x: 20, y: 15 }, { x: 30, y: 35 }, { x: 40, y: 20 },
+		];
+		const path = smoothPath(points);
+		expect(path.startsWith("M0.00 10.00")).toBe(true);
+		const ends = curves(path).map((c) => c.end);
+		expect(ends).toEqual(points.slice(1).map((p) => ({ x: p.x, y: p.y })));
+	});
+
+	it("never overshoots the values it connects", () => {
+		// The reason for monotone interpolation rather than a plain spline:
+		// on a sawtooth, a naive curve bulges past every peak and draws a
+		// fitness that was never trained for.
+		const zigzag = Array.from({ length: 24 }, (_, i) => ({
+			x: i * 10,
+			y: i % 2 === 0 ? 20 : 60,
+		}));
+		const path = smoothPath(zigzag);
+
+		for (const [i, curve] of curves(path).entries()) {
+			const low = Math.min(zigzag[i].y, zigzag[i + 1].y);
+			const high = Math.max(zigzag[i].y, zigzag[i + 1].y);
+			for (const control of [curve.c1, curve.c2]) {
+				expect(control.y).toBeGreaterThanOrEqual(low);
+				expect(control.y).toBeLessThanOrEqual(high);
+			}
+		}
+	});
+
+	it("keeps a monotone run monotone", () => {
+		const climbing = Array.from({ length: 10 }, (_, i) => ({ x: i * 10, y: i * i }));
+		for (const [i, curve] of curves(smoothPath(climbing)).entries()) {
+			expect(curve.c1.y).toBeGreaterThanOrEqual(climbing[i].y);
+			expect(curve.c2.y).toBeLessThanOrEqual(climbing[i + 1].y);
+		}
+	});
+});
 
 describe("scaleLinear", () => {
 	it("maps the domain onto the range", () => {

--- a/src/components/Training/sections/AerobicEfficiency.svelte
+++ b/src/components/Training/sections/AerobicEfficiency.svelte
@@ -13,7 +13,7 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { axisTicks, CHART_WEEKS, linePath, niceScale, seriesPoints, withinWindow, xPct, yPct } from "../lib/chart.js";
+    import { axisTicks, CHART_WEEKS, niceScale, seriesPoints, smoothPath, withinWindow, xPct, yPct } from "../lib/chart.js";
     import { axisDate, shortDate } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
@@ -102,7 +102,7 @@
                 {#each dots as dot}
                     <circle class="dot" cx={dot.x} cy={dot.y} r="3" />
                 {/each}
-                <path class="line" d={linePath(line)} />
+                <path class="line" d={smoothPath(line)} />
             </svg>
         </ChartFrame>
         <p class="chart-unit">speed per heartbeat · {points.length} aerobic runs in the last {CHART_WEEKS} weeks</p>

--- a/src/components/Training/sections/FitnessChart.svelte
+++ b/src/components/Training/sections/FitnessChart.svelte
@@ -13,7 +13,7 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { areaPath, axisTicks, CHART_WEEKS, linePath, niceScale, seriesPoints, withinWindow, xPct, yPct } from "../lib/chart.js";
+    import { areaPath, axisTicks, CHART_WEEKS, niceScale, seriesPoints, smoothPath, withinWindow, xPct, yPct } from "../lib/chart.js";
     import { axisDate, shortDate, signed } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
@@ -113,10 +113,11 @@
     {:else}
         <ChartFrame height={210} {yTicks} {xTicks} {scrub} label="Fitness, fatigue and form over the last {CHART_WEEKS} weeks">
             <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
-                <path class="area" d={areaPath(ctlPoints, zeroY)} />
-                <path class="line form" d={linePath(tsbPoints)} />
-                <path class="line fatigue" d={linePath(atlPoints)} />
-                <path class="line fitness" d={linePath(ctlPoints)} />
+                <path class="fatigue-fill" d={areaPath(atlPoints, zeroY, { smooth: true })} />
+                <path class="fitness-fill" d={areaPath(ctlPoints, zeroY, { smooth: true })} />
+                <path class="line form" d={smoothPath(tsbPoints)} />
+                <path class="line fatigue" d={smoothPath(atlPoints)} />
+                <path class="line fitness" d={smoothPath(ctlPoints)} />
             </svg>
         </ChartFrame>
         <p class="chart-unit">training load · last {CHART_WEEKS} weeks</p>
@@ -137,9 +138,20 @@
     .key.fitness { color: var(--main-green); opacity: 1; }
     .key.fatigue { color: var(--tone-bad); }
 
-    .area {
+    .fitness-fill {
         fill: var(--main-green);
         opacity: 0.12;
+    }
+    /* Fatigue filled rather than left as a bare line. A 7-day average of an
+       athlete who runs every second day genuinely sawtooths, and there is no
+       honest way to remove that; what can be removed is its loudness. Given a
+       body, the same wobble reads as a range of hills instead of a bright red
+       zigzag, and the sentence this chart exists to show — fatigue standing
+       above fitness means you're in the work — becomes a thing you can see
+       rather than a comparison you have to make. */
+    .fatigue-fill {
+        fill: var(--tone-bad);
+        opacity: 0.14;
     }
     .line {
         fill: none;
@@ -148,11 +160,23 @@
         stroke-linecap: round;
         vector-effect: non-scaling-stroke;
     }
-    .line.fitness { stroke: var(--main-green); }
-    .line.fatigue { stroke: var(--tone-bad); opacity: 0.9; }
+    /* A hierarchy rather than three equal lines. Fitness is the one the chart
+       is about and the only one that moves slowly enough to have a shape, so
+       it's drawn heaviest; fatigue and form both oscillate with every session
+       and, at matching weight, the eye reads the noise instead of the trend. */
+    .line.fitness {
+        stroke: var(--main-green);
+        stroke-width: 2.25;
+    }
+    .line.fatigue {
+        stroke: var(--tone-bad);
+        stroke-width: 1.25;
+        opacity: 0.55;
+    }
     .line.form {
         stroke: var(--paragraph-colour);
-        opacity: 0.45;
+        stroke-width: 1.25;
+        opacity: 0.35;
         stroke-dasharray: 3 3;
     }
 

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -13,7 +13,8 @@
 
     The pace chart is drawn with a flipped y-axis so faster is higher, which is
     the only orientation people read without translating; the axis is labelled
-    in pace so there's nothing to translate anyway. Grade-adjusted pace goes
+    in pace so there's nothing to translate anyway. It scrubs like the rest of
+    the page's charts, which is where a single kilometre is legible at all. Grade-adjusted pace goes
     over it as a second line whenever the two actually diverge — on a hilly run
     that gap is the explanation for a slow kilometre, and on a flat one drawing
     it twice would just be noise.
@@ -21,7 +22,7 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { linePath, niceScale, scaleLinear } from "../lib/chart.js";
+    import { linePath, niceScale, scaleLinear, xPct, yPct } from "../lib/chart.js";
     import { daysAgo, formatDistance, formatDuration, pace, pct, signed } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
     import { stravaTag as tagFor } from "../lib/runTags.js";
@@ -95,6 +96,39 @@
                 pct: (i / Math.max(1, splits.length - 1)) * 100,
                 anchor: i === 0 ? "start" : i === splits.length - 1 ? "end" : "middle",
             })),
+    );
+
+    // A kilometre at a time. The dots carried a title attribute, which put the
+    // pace behind a hover delay and a browser tooltip; this is the same three
+    // numbers you'd actually compare across a run — what it cost in pace, what
+    // the hills made of it, and what your heart was doing for it.
+    const scrub = $derived(
+        splits.map((split, i) => ({
+            key: split.km,
+            pct: xPct(pacePoints[i].x, WIDTH),
+            label: `Kilometre ${split.km}`,
+            readouts: [
+                {
+                    label: "Pace",
+                    value: pace(split.paceSecPerKm),
+                    colour: "var(--main-green)",
+                    yPct: yPct(pacePoints[i].y, HEIGHT),
+                },
+                ...(showGap && split.gapPaceSecPerKm > 0
+                    ? [
+                            {
+                                label: "Grade adjusted",
+                                value: pace(split.gapPaceSecPerKm),
+                                colour: "var(--paragraph-colour)",
+                                yPct: yPct(gapPoints[i].y, HEIGHT),
+                            },
+                        ]
+                    : []),
+                ...(split.averageHr > 0
+                    ? [{ label: "Heart rate", value: `${Math.round(split.averageHr)} bpm` }]
+                    : []),
+            ],
+        })),
     );
 
     const form = $derived(run?.impact?.form || null);
@@ -256,7 +290,7 @@
 
         {#if splits.length > 1}
             <div class="chart">
-                <ChartFrame height={HEIGHT} {yTicks} {xTicks} label="Pace for each kilometre of the run">
+                <ChartFrame height={HEIGHT} {yTicks} {xTicks} {scrub} label="Pace for each kilometre of the run">
                     <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
                         {#if averageY !== null}
                             <line class="average" x1="0" x2={WIDTH} y1={averageY} y2={averageY} />
@@ -265,10 +299,8 @@
                             <path class="gap" d={linePath(gapPoints)} />
                         {/if}
                         <path class="line" d={linePath(pacePoints)} />
-                        {#each pacePoints as point, i}
-                            <circle class="dot" cx={point.x} cy={point.y} r="4">
-                                <title>km {splits[i].km} — {pace(splits[i].paceSecPerKm)}{splits[i].averageHr ? ` at ${Math.round(splits[i].averageHr)} bpm` : ""}</title>
-                            </circle>
+                        {#each pacePoints as point (point.x)}
+                            <circle class="dot" cx={point.x} cy={point.y} r="4" />
                         {/each}
                     </svg>
                 </ChartFrame>

--- a/src/components/Training/sections/SyncNotice.svelte
+++ b/src/components/Training/sections/SyncNotice.svelte
@@ -17,7 +17,7 @@
             return {
                 title: "Waiting for the first sync",
                 detail:
-                    "Strava history is imported on a schedule rather than on page load, so nothing has landed here yet. This page fills in within about 20 minutes of going live.",
+                    "Strava history is imported on a schedule rather than on page load, so nothing has landed here yet. This page fills in within about 10 minutes of going live.",
             };
         }
         if (sync.backfilling) {

--- a/src/components/Training/sections/SyncNotice.svelte
+++ b/src/components/Training/sections/SyncNotice.svelte
@@ -17,7 +17,7 @@
             return {
                 title: "Waiting for the first sync",
                 detail:
-                    "Strava history is imported on a schedule rather than on page load, so nothing has landed here yet. This page fills in within about 10 minutes of going live.",
+                    "Strava history is imported on a schedule rather than on page load, so nothing has landed here yet. This page fills in within about 5 minutes of going live.",
             };
         }
         if (sync.backfilling) {


### PR DESCRIPTION
## Summary

Three notes from the live page.

**The last run now scrubs, a kilometre at a time.** Its per-kilometre detail was behind a `<title>` attribute, which meant a hover delay and a browser tooltip nobody would find. It uses the same cursor as every other chart now, reporting that kilometre's pace, its grade adjustment where the hills moved it, and the heart rate it was run at.

**The scrub readout is opaque.** It was drawn on `--inner-background`, which is `rgba(114,114,114,0.281)` on the dark theme — fine for a panel sitting on the page background, unreadable for a label sitting on top of the chart it's describing. It now composites that same tint over an opaque base, so it keeps the card's colour and stops the chart showing through it.

**Fitness and fatigue is calmer.** Half of the jaggedness is unfixable and should be: a 7-day average of an athlete who runs every second day swings ~40% around its own mean, and smoothing the numbers would be drawing training that didn't happen. What's fixable is how loud it is.

- The straight segments between daily samples were already an interpolation — nothing was measured between Tuesday and Wednesday — so they're now curves instead. Monotone cubic (Fritsch-Carlson) rather than a plain spline, and that distinction is the whole point: Catmull-Rom overshoots at a reversal and invents a peak higher than any day recorded, which on this chart is a fitness that was never trained for. Flattening the tangent at every turning point makes overshoot impossible by construction, and there's a test asserting exactly that against a synthetic sawtooth.
- Fatigue is filled rather than stroked. The sawtooth is still there, but as terrain under the fitness line instead of a bright red zigzag competing with it — and the sentence the panel exists to make, that fatigue standing above fitness means you're in the work, becomes something you can see rather than a comparison you have to perform.
- Fitness is the heaviest line on the chart now, which it wasn't. The mid-block dip from the injury is legible for the first time.

The efficiency trend picked up the same curve, since it's a rolling mean and was the other line with visible corners.


**Fitness, fatigue and form now describe the same moment.** The chart drew form rising by 3 on the day of the hardest run in a week, while the panel below it said that run cost 4.7 of form. Both read the same series and both were right, because each record contradicted itself: `ctl` and `atl` were stored after the day's load and `tsb` from before it, so the chart header read "Fitness 19, Fatigue 25, Form −1" when 19 − 25 is −6.

The lag was deliberate — today'''s session shouldn'''t make you look less ready before you'''ve done it — but it applied to one field of three, so a record described two instants and every reader had to know which. `lastRun.js` had already worked around it by recomputing form instead of reading the field, which is precisely how the two panels came to disagree. Form is now `ctl − atl` of the same day; the workaround goes, and a test asserts the invariant across a whole series. On your current data both panels now read −6.2, and the fatigue recommendation is unaffected (its threshold is −25).


**The footer dates the sync rather than the visit.** The stamp read `generatedAt`, which is when the payload was built — a fact about the reader'''s own visit that ticks forward on a refresh that changed nothing, and dates a response the CDN may have been holding for ten minutes. It now reads `sync.lastRunAt`, which `trainingData` already published. `generatedAt` stays on the payload for telling a stale edge copy from a fresh one, but now carries a comment saying what it is and isn'''t.

**The whole chain is tightened to five minutes.** Four cadences sit between a run uploading and it appearing, and the slowest one is the delay, so they now line up:

| | Was | Now |
|---|---|---|
| `trainingSync` reads Strava | 20 min | 5 min |
| `trainingData` edge cache | 10 min public + 30 min stale | 60 s edge, browser always revalidates |
| Page poll | 10 min | 5 min |
| `fetchJsonSwr` window | 60 s | 60 s |

On the rate limit: Strava meters reads at 100 per 15 minutes and 1,000 a day at the standard tier, and a caught-up invocation makes exactly one read — the activity listing; the token refresh is a POST to `/oauth/token` and counts against the looser overall bucket. So this is ~288 reads a day and three per quarter hour. Backfill can want more than a window'''s whole share in one invocation, but that was always `QUOTA_SHARE`'''s job: it reads Strava'''s own headers and stands the job down at 60% of either bucket, so a shorter interval can'''t buy a 429 and doesn'''t buy a faster cold start either.

The cache change matters as much as the cadence. A 10-minute public `max-age` with a 30-minute stale window meant a sync could land and a reader go on being served the copy from before it — and `stale-while-revalidate` is exactly the wrong trade for someone refreshing *because* they expect something new. The edge still absorbs a burst (one origin call a minute, deduped again by the in-function memo), but the browser asks every time.

## Test plan

- [x] `vitest run` — 631 pass, including four new cases pinning the interpolation: it passes through every measured point, it never overshoots on a sawtooth, it keeps a monotone run monotone, and it degrades to a straight line under three points.
- [x] `playwright test` — 27 pass, including a new one that scrubs the last run and asserts the readout names a kilometre and carries both a pace and a heart rate.
- [x] `npm run build`
- [x] Rendered the live production payload locally in both themes and looked at it.

Made with [Cursor](https://cursor.com)