### PR TITLE
Draw the last run at the grain it was run at

### DIFF
--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -33,12 +33,23 @@ const NAMES = [
 	"Recovery Shakeout",
 ];
 
-// A minute-by-minute recording of one run, which is what the sync derives time
-// in zones and aerobic drift from (see shape.js). Without one, those are null
-// and the last-run panel renders its "no heart rate" path — real for a manual
-// entry, but not what the page normally shows.
+// A second-by-second recording of one run, which is what the sync derives time
+// in zones, aerobic drift and the pace/heart-rate trace from (see shape.js).
+// Without one, those are null and the last-run panel renders its "no heart
+// rate" path — real for a manual entry, but not what the page normally shows.
+//
+// Every ten seconds rather than every minute: the trace resamples in slices of
+// a hundred and fifty metres, and a sample a minute apart is a sample every
+// quarter kilometre, which would leave most of those slices unmeasured and the
+// chart a dotted line through a run that never paused.
+// It draws from a generator of its own, seeded from the shared one. Drawing
+// directly would tie the sequence every other activity is built from to how
+// many samples this run happens to take, so changing the sample rate would
+// silently rewrite the whole block — different distances, a different last
+// run, and a handful of unrelated assertions to re-baseline.
 function streamsFor({ distance, movingTime, averageHr, next }) {
-	const steps = Math.max(20, Math.round(movingTime / 60));
+	const noise = sequence(Math.floor(next() * 2147483648));
+	const steps = Math.max(20, Math.round(movingTime / 10));
 	const time = [];
 	const distanceStream = [];
 	const heartrate = [];
@@ -49,8 +60,8 @@ function streamsFor({ distance, movingTime, averageHr, next }) {
 		distanceStream.push((distance / steps) * i);
 		// Drifting up through the run, the way heart rate does at a fixed
 		// effort, plus enough noise to land either side of a zone floor.
-		heartrate.push(averageHr - 6 + (12 * i) / steps + (next() - 0.5) * 6);
-		grade.push((next() - 0.5) * 3);
+		heartrate.push(averageHr - 6 + (12 * i) / steps + (noise() - 0.5) * 6);
+		grade.push((noise() - 0.5) * 3);
 	}
 	return { time, distance: distanceStream, heartrate, "grade_smooth": grade };
 }

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -93,8 +93,9 @@ test("the last run is reported with what it did to the training", async ({ page 
 		/strava\.com\/activities\/\d+/,
 	);
 
-	// How it went: a pace per kilometre, on an axis labelled in paces.
-	const paces = await panel.locator(".y-axis span").allTextContents();
+	// How it went: a pace per kilometre, on an axis labelled in paces. The
+	// left axis specifically — the right one is heart rate, in bpm.
+	const paces = await panel.locator(".y-axis:not(.right) span").allTextContents();
 	expect(paces.length).toBeGreaterThan(2);
 	expect(paces.every((label) => /^\d+:\d{2}$/.test(label))).toBe(true);
 
@@ -241,6 +242,35 @@ test("the last run scrubs a kilometre at a time", async ({ page }) => {
 	await expect(tip.getByText("Pace", { exact: true })).toBeVisible();
 	await expect(tip).toContainText(/\d+:\d\d\/km/);
 	await expect(tip).toContainText(/\d+ bpm/);
+});
+
+test("the last run plots heart rate on its own scale", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "Last run" }).first();
+
+	// Two units on one plot only works if the second one is labelled. Without
+	// the right-hand axis the beats are a shape with no magnitude, and the
+	// height it shares with the pace line is a coincidence of scaling.
+	const beats = card.locator(".y-axis.right span");
+	const labels = (await beats.allTextContents()).map(Number);
+	expect(labels.length).toBeGreaterThan(2);
+	for (const bpm of labels) {
+		expect(bpm).toBeGreaterThan(60);
+		expect(bpm).toBeLessThan(230);
+	}
+	// And it runs the other way up from the pace axis beside it. Pace is
+	// flipped so faster is higher; heart rate isn't, because more beats is
+	// more effort. Compare where they actually sit, since the two scales
+	// agreeing on direction is exactly the mistake this would be.
+	const placed = await beats.evaluateAll((nodes) =>
+		nodes.map((node) => ({
+			bpm: Number(node.textContent),
+			bottom: node.getBoundingClientRect().bottom,
+		})),
+	);
+	const highest = placed.reduce((a, b) => (a.bpm > b.bpm ? a : b));
+	const lowest = placed.reduce((a, b) => (a.bpm < b.bpm ? a : b));
+	expect(highest.bottom).toBeLessThan(lowest.bottom);
 });
 
 test("the chart cursor can be driven from the keyboard", async ({ page }) => {

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -1,5 +1,11 @@
 import { test, expect } from "@playwright/test";
 import { buildTrainingFixture } from "./fixtures/trainingPayload.js";
+import {
+	MIN_GAIN_PX,
+	bestSplit,
+	columnHeight,
+	imbalanceAt,
+} from "../src/components/Training/lib/balance.js";
 
 // /training is the one page on the site built out of charts and dense tables,
 // which makes it the one page that can quietly get wider than a phone. That
@@ -134,22 +140,52 @@ test("neither column runs on far past the other", async ({ page }) => {
 	// page: with the two tallest panels both on the left it finished a
 	// thousand pixels below the right. The split used to be hand-balanced and
 	// went stale every time a panel was added; it's now measured at runtime
-	// (src/components/Training/lib/balance.js), so this can hold it to a much
-	// tighter bound than a hand-tuned constant ever earned.
+	// (src/components/Training/lib/balance.js).
+	//
+	// Asserted against the best split available rather than a ratio, because a
+	// ratio measures the panels and not the balancing. Only ten panels go into
+	// two columns and three of them are seven hundred pixels tall, so the
+	// achievable splits are coarse — the best one here leaves the columns 11%
+	// apart, and the next best leaves them 22% apart. A threshold between
+	// those two numbers passes and fails on how long a panel's prose happens
+	// to be this week.
 	await page.setViewportSize({ width: 1280, height: 900 });
 	await page.goto("/training");
 
-	const columns = page.locator("#training-grid .col:not(.col-full)");
-	const ratio = async () => {
-		const [left, right] = await columns.evaluateAll((cols) =>
-			cols.map((col) => col.getBoundingClientRect().height),
-		);
-		return Math.min(left, right) / Math.max(left, right);
-	};
+	const measure = () =>
+		page.evaluate(() => {
+			const columns = [...document.querySelectorAll("#training-grid .col:not(.col-full)")];
+			const style = getComputedStyle(columns[0]);
+			return {
+				gap: Number.parseFloat(style.rowGap) || 0,
+				split: columns[0].querySelectorAll("[data-panel]").length,
+				// In layout order, which is what a split is an index into.
+				heights: columns.flatMap((col) =>
+					[...col.querySelectorAll("[data-panel]")].map(
+						(panel) => panel.getBoundingClientRect().height,
+					),
+				),
+			};
+		});
 
 	// Balancing runs a frame after the payload renders, so the first paint is
 	// the unbalanced one by design.
-	await expect.poll(ratio).toBeGreaterThan(0.9);
+	await expect
+		.poll(async () => {
+			const { gap, split, heights } = await measure();
+			const ideal = bestSplit(heights, { gap });
+			// Within the bar a move has to clear, since the layout stops as
+			// soon as no remaining move clears it.
+			return imbalanceAt(heights, split, gap) - imbalanceAt(heights, ideal, gap);
+		})
+		.toBeLessThanOrEqual(MIN_GAIN_PX);
+
+	// And a floor under it all, in case a future panel makes every split a bad
+	// one and the assertion above cheerfully certifies the least bad.
+	const { gap, split, heights } = await measure();
+	const left = columnHeight(heights.slice(0, split), gap);
+	const right = columnHeight(heights.slice(split), gap);
+	expect(Math.min(left, right) / Math.max(left, right)).toBeGreaterThan(0.8);
 });
 
 test("a recommendation leads with its evidence and folds the reasoning away", async ({ page }) => {
@@ -225,7 +261,7 @@ test("the footer dates the sync, not the visit", async ({ page }) => {
 	expect(shown).toBe(`Last synced ${expected}`);
 });
 
-test("the last run scrubs a kilometre at a time", async ({ page }) => {
+test("the last run scrubs to a point along it, not a kilometre of it", async ({ page }) => {
 	await page.goto("/training");
 	const card = page.locator("section.card").filter({ hasText: "Last run" }).first();
 	const plot = card.locator(".plot");
@@ -236,12 +272,32 @@ test("the last run scrubs a kilometre at a time", async ({ page }) => {
 
 	const tip = card.locator(".tip");
 	await expect(tip).toBeVisible();
-	// The split, not the run: a kilometre's own pace and what the heart was
-	// doing for it, which is the question the whole panel is a preamble to.
-	await expect(tip.locator(".tip-label")).toHaveText(/Kilometre \d+/);
+	// A distance with metres in it. The panel used to read a kilometre at a
+	// time, which is a resolution that averages an interval session flat: the
+	// reps and the recoveries between them happen inside one split.
+	await expect(tip.locator(".tip-label")).toHaveText(/^\d+\.\d\d km$/);
 	await expect(tip.getByText("Pace", { exact: true })).toBeVisible();
 	await expect(tip).toContainText(/\d+:\d\d\/km/);
 	await expect(tip).toContainText(/\d+ bpm/);
+});
+
+test("the last run is drawn at a finer grain than its splits", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "Last run" }).first();
+
+	const { points, km } = await page.evaluate(async () => {
+		const { lastRun } = await (await fetch("/.netlify/functions/trainingData")).json();
+		return { points: lastRun.trace.m.length, km: lastRun.distanceM / 1000 };
+	});
+	// Several readings to the kilometre, which is the whole point of carrying
+	// a trace at all rather than plotting the splits that were already there.
+	expect(points / km).toBeGreaterThan(3);
+
+	// And they're offered to the keyboard one at a time, so the fine grain is
+	// reachable without a pointer.
+	await card.locator(".plot").focus();
+	await card.page().keyboard.press("ArrowRight");
+	await expect(card.locator(".tip")).toBeVisible();
 });
 
 test("the last run plots heart rate on its own scale", async ({ page }) => {

--- a/netlify/functions/_shared/training/gap.js
+++ b/netlify/functions/_shared/training/gap.js
@@ -35,8 +35,8 @@ export const GRADE_CLAMP = 0.45;
 //
 // 0.5 m/s is far slower than walking, and 8 m/s is faster than this athlete
 // will ever sustain, so neither bound can discard real running.
-const MIN_SEGMENT_SPEED = 0.5;
-const MAX_SEGMENT_SPEED = 8;
+export const MIN_SEGMENT_SPEED = 0.5;
+export const MAX_SEGMENT_SPEED = 8;
 
 /**
  * Metabolic cost of running at a gradient, in J/kg/m.

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -21,6 +21,7 @@ import { activityGap } from "./gap.js";
 import { activityLoad } from "./load.js";
 import { aerobicDecoupling } from "./efficiency.js";
 import { hrZoneFloors, zoneSecondsFromStreams } from "./zones.js";
+import { shapeTrace } from "./trace.js";
 import { reading } from "./num.js";
 import { toDayKey } from "./dates.js";
 
@@ -50,7 +51,9 @@ export const RIDE_MIN_M = 20000;
 // 2: HR zone floors moved to heart-rate reserve; GAP anchored to moving time
 //    and no longer thrown off by stopped time or GPS jumps.
 // 3: records carry `sport`, and rides over RIDE_MIN_M are tracked.
-export const SHAPE_VERSION = 3;
+// 4: runs carry a resampled pace/heart-rate trace (see trace.js), which only
+//    exists while the streams are in hand.
+export const SHAPE_VERSION = 4;
 
 /**
  * Is this a public run we should track?
@@ -200,6 +203,10 @@ export function shapeActivity(raw, options = {}) {
 		zoneSeconds,
 		decouplingPct: decoupling?.decouplingPct ?? null,
 		splits,
+		// Kept on the record because it can only be built while the streams
+		// are in hand, and they aren't stored. A ride has no pace worth
+		// plotting, for the same reason it has no splits.
+		trace: isRide ? null : shapeTrace(streams, { distanceM }),
 		bestEfforts: isRide
 			? []
 			: shapeBestEfforts(raw.best_efforts, raw.start_date_local || raw.start_date),
@@ -266,6 +273,13 @@ function publicSplits(splits) {
 		}));
 }
 
+// Copied field by field like everything else here, so a future addition to the
+// stored trace has to be named before it can be served.
+function publicTrace(trace) {
+	if (!Array.isArray(trace?.m)) return null;
+	return { m: [...trace.m], pace: [...trace.pace], hr: [...trace.hr] };
+}
+
 /**
  * The same, for the one run the dashboard looks at in detail.
  *
@@ -281,6 +295,11 @@ function publicSplits(splits) {
  * per-kilometre elevation isn't carried: a hill profile is the one part of a
  * split list that starts to describe a route rather than a run. The total climb
  * is enough to read the pace by, and is already public on the log.
+ *
+ * The trace holds that line at a finer grain, which is why it carries pace and
+ * heart rate and no grade at all — see trace.js. It's also the one field here
+ * the log deliberately doesn't get: a hundred and twenty points is nothing
+ * once, and thirty times over it is most of the payload.
  *
  * @param {object} activity a stored, shaped activity.
  * @returns {object|null} safe to serve.
@@ -299,6 +318,7 @@ export function publicLastRun(activity) {
 		decouplingPct: activity.decouplingPct,
 		zoneSeconds: publicZoneSeconds(activity.zoneSeconds),
 		splits: publicSplits(activity.splits),
+		trace: publicTrace(activity.trace),
 	};
 }
 

--- a/netlify/functions/_shared/training/shape.test.js
+++ b/netlify/functions/_shared/training/shape.test.js
@@ -140,6 +140,32 @@ describe("shapeActivity", () => {
 		expect(shaped.zoneSeconds.reduce((a, b) => a + b, 0)).toBe(180);
 	});
 
+	it("keeps a pace and heart-rate trace while the streams are in hand", () => {
+		// The only chance to build it: streams aren't stored, so a record
+		// shaped without one can never grow a trace without a re-fetch.
+		const seconds = 3000;
+		const streams = {
+			time: Array.from({ length: seconds }, (_, i) => i),
+			distance: Array.from({ length: seconds }, (_, i) => i * (10000 / seconds)),
+			heartrate: Array.from({ length: seconds }, () => 150),
+			grade_smooth: Array.from({ length: seconds }, () => 4),
+		};
+		const shaped = shapeActivity(rawRun(), { thresholds: THRESHOLDS, streams });
+
+		expect(shaped.trace.m.length).toBeGreaterThan(shaped.splits.length);
+		expect(shaped.trace.pace.every((p) => Math.abs(p - 300) < 5)).toBe(true);
+
+		// Pace and heart rate only. A grade per slice, in distance order, is an
+		// elevation profile, and this payload is published — see trace.js.
+		expect(Object.keys(shaped.trace).sort()).toEqual(["hr", "m", "pace"]);
+	});
+
+	it("gives a ride no trace, for the same reason it gets no splits", () => {
+		const streams = { time: [0, 60], distance: [0, 400], heartrate: [130, 132] };
+		const shaped = shapeActivity(rawRide(), { thresholds: THRESHOLDS, streams });
+		expect(shaped.trace).toBeNull();
+	});
+
 	it("scores load by heart rate when present", () => {
 		const shaped = shapeActivity(rawRun(), { thresholds: THRESHOLDS });
 		expect(shaped.loadMethod).toBe("hr");

--- a/netlify/functions/_shared/training/trace.js
+++ b/netlify/functions/_shared/training/trace.js
@@ -1,0 +1,139 @@
+// Pace and heart rate across a single run, at a finer grain than a kilometre.
+//
+// The stored splits answer "how did it go" one kilometre at a time, which is
+// the wrong resolution for the sessions that are most worth looking at. An
+// interval workout's whole shape — the reps, the recoveries, the heart rate
+// climbing through each effort and falling between them — happens inside a
+// single split and averages away to one number. A 4:59/km kilometre made of
+// 400m at 3:50 and 600m of jogging reads identically to a steady 4:59.
+//
+// Resampled by distance rather than smoothed over time. Each point is the mean
+// across a fixed slice of the run, which is exactly what a split already is,
+// only shorter: no kernel, no window, and nothing invented between samples.
+// The count is fixed rather than the slice, so the cost per run is bounded
+// whether it's 5km or 35km — an interval session is short, and a long run has
+// no 200m features to lose.
+//
+// The privacy line is the same one shape.js draws everywhere else, and it is
+// the reason grade isn't here. Per-kilometre grade adjustment is already
+// published and describes an effort; a hundred and twenty grade samples in
+// distance order is an elevation profile, and an elevation profile is most of
+// the way to naming the route. Pace and heart rate describe what the run cost
+// its runner, which is all this chart is for.
+
+import { MIN_SEGMENT_SPEED, MAX_SEGMENT_SPEED } from "./gap.js";
+
+// How short a slice can get. Not a storage limit — a legibility one, and the
+// number that decides what this chart is for.
+//
+// Pace is a reciprocal, so walking is a very long way from running on a linear
+// axis: a jogged recovery is 6:30/km and a walked one is 13:00, which is
+// further below a 3:30 rep than the rep is below the top of the plot. Slice a
+// workout finely enough and one slice lands almost entirely inside a walk,
+// takes its pace whole, and the axis stretches to reach it — leaving every rep
+// squashed into the top tenth of the chart. Wider slices blend that walk with
+// the running either side, which is what Strava's smoothed view does and why
+// its recoveries bottom out around 8:00 rather than 13:00.
+//
+// 150m is about the shortest that survives it, and still gives four or five
+// points to a 400m rep.
+export const MIN_SLICE_M = 150;
+
+// And an upper bound on the count, so a marathon costs the same as a 10k.
+export const TRACE_POINTS = 120;
+
+/**
+ * Resample a run's streams into a fixed number of points across its distance.
+ *
+ * Stored as parallel arrays rather than an array of points: this sits in the
+ * activity index, which is read whole on every build of the dashboard, and
+ * three arrays of numbers cost about half what a hundred and twenty
+ * `{m, pace, hr}` objects do once serialised.
+ *
+ * @param {object|null} streams keyed by type, as trainingSync fetches them.
+ * @param {object} [options]
+ * @param {number} [options.distanceM] the activity's own total, preferred over
+ *   the last distance sample, which a GPS drop can leave short.
+ * @param {number} [options.maxPoints]
+ * @param {number} [options.minSliceM]
+ * @returns {{m: number[], pace: (number|null)[], hr: (number|null)[]}|null}
+ *   null when there's nothing to resample — a manual entry has no streams.
+ *   `pace` is seconds per km and `hr` bpm; either can be null for a slice that
+ *   measured neither.
+ */
+export function shapeTrace(
+	streams,
+	{ distanceM = 0, maxPoints = TRACE_POINTS, minSliceM = MIN_SLICE_M } = {},
+) {
+	const distance = streams?.distance;
+	const time = streams?.time;
+	if (!Array.isArray(distance) || !Array.isArray(time)) return null;
+	if (distance.length < 2 || time.length !== distance.length) return null;
+
+	const total = distanceM > 0 ? distanceM : Number(distance.at(-1));
+	if (!(total > 0)) return null;
+
+	const heartrate =
+		Array.isArray(streams?.heartrate) && streams.heartrate.length === distance.length
+			? streams.heartrate
+			: null;
+
+	// A short run gets fewer points at the same slice width rather than the
+	// same points at a narrower one, so every chart reads at one grain.
+	const points = Math.max(2, Math.min(maxPoints, Math.floor(total / minSliceM)));
+	const slice = total / points;
+	const sliceOf = (metres) => Math.min(points - 1, Math.max(0, Math.floor(metres / slice)));
+
+	const movingSec = new Array(points).fill(0);
+	const coveredM = new Array(points).fill(0);
+	const beats = new Array(points).fill(0);
+	const reads = new Array(points).fill(0);
+
+	for (let i = 1; i < distance.length; i++) {
+		const d = Number(distance[i]) - Number(distance[i - 1]);
+		const t = Number(time[i]) - Number(time[i - 1]);
+		if (!(d > 0) || !(t > 0)) continue;
+
+		// The same bounds gap.js uses, for the same reason: Strava's `time` is
+		// elapsed, so a stop at a crossing arrives as one sample covering
+		// minutes, and a signal re-acquisition as one covering a street.
+		const speed = d / t;
+		if (speed < MIN_SEGMENT_SPEED || speed > MAX_SEGMENT_SPEED) continue;
+
+		// Samples are a second or two apart and a slice is tens of metres, so
+		// a segment falls inside one slice essentially always. Attributing it
+		// to the one it ended in is exact often enough not to be worth
+		// splitting a segment across a boundary.
+		const at = sliceOf(Number(distance[i]));
+		movingSec[at] += t;
+		coveredM[at] += d;
+	}
+
+	// Heart rate counts every sample, including the ones the speed filter just
+	// dropped. Standing at the end of a rep is precisely when the interesting
+	// thing is happening — a recovery is a heart rate coming down — and
+	// discarding it alongside the pace would erase the reason to plot it.
+	if (heartrate) {
+		for (const [i, metres] of distance.entries()) {
+			const bpm = Number(heartrate[i]);
+			if (!(bpm > 0)) continue;
+			const at = sliceOf(Number(metres));
+			beats[at] += bpm;
+			reads[at] += 1;
+		}
+	}
+
+	const m = [];
+	const pace = [];
+	const hr = [];
+	for (let i = 0; i < points; i++) {
+		// The middle of the slice, since the value is its average and pinning
+		// it to either edge would shift the whole trace half a slice.
+		m.push(Math.round((i + 0.5) * slice));
+		pace.push(coveredM[i] > 0 ? Math.round(movingSec[i] / (coveredM[i] / 1000)) : null);
+		hr.push(reads[i] > 0 ? Math.round(beats[i] / reads[i]) : null);
+	}
+
+	const measured = pace.some((v) => v !== null) || hr.some((v) => v !== null);
+	return measured ? { m, pace, hr } : null;
+}

--- a/netlify/functions/_shared/training/trace.test.js
+++ b/netlify/functions/_shared/training/trace.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { shapeTrace, MIN_SLICE_M, TRACE_POINTS } from "./trace.js";
+
+/**
+ * A run recorded once a second.
+ *
+ * @param {{speed: number, sec: number, bpm?: number}[]} legs
+ */
+function record(legs) {
+	const distance = [0];
+	const time = [0];
+	const heartrate = [legs[0]?.bpm ?? 0];
+	for (const leg of legs) {
+		for (let s = 0; s < leg.sec; s++) {
+			distance.push(distance.at(-1) + leg.speed);
+			time.push(time.at(-1) + 1);
+			heartrate.push(leg.bpm ?? 0);
+		}
+	}
+	return { distance, time, heartrate };
+}
+
+// 5:00/km and 4:00/km, in m/s.
+const EASY = 1000 / 300;
+const FAST = 1000 / 240;
+
+describe("shapeTrace", () => {
+	it("has nothing to say about a run with no streams", () => {
+		expect(shapeTrace(null)).toBe(null);
+		expect(shapeTrace({})).toBe(null);
+		expect(shapeTrace({ distance: [0], time: [0] })).toBe(null);
+		// Streams that don't line up can't be zipped, and guessing which one
+		// is short would silently misplace every sample after the gap.
+		expect(shapeTrace({ distance: [0, 10, 20], time: [0, 1] })).toBe(null);
+	});
+
+	it("resamples across the distance at a fixed slice width", () => {
+		// 6km at 5:00/km.
+		const trace = shapeTrace(record([{ speed: EASY, sec: 1800, bpm: 150 }]));
+		expect(6000 / trace.m.length).toBeCloseTo(MIN_SLICE_M, -1);
+		expect(trace.pace).toHaveLength(trace.m.length);
+		expect(trace.hr).toHaveLength(trace.m.length);
+
+		// Ascending, and spanning the run rather than stopping short of it.
+		expect(trace.m).toEqual([...trace.m].sort((a, b) => a - b));
+		expect(trace.m.at(-1)).toBeGreaterThan(5900);
+		for (const pace of trace.pace) expect(pace).toBeCloseTo(300, 0);
+		for (const bpm of trace.hr) expect(bpm).toBe(150);
+	});
+
+	it("caps the count so a long run costs no more than a short one", () => {
+		// A marathon at the same slice width would be nearly 300 points.
+		const trace = shapeTrace(record([{ speed: EASY, sec: 12_600, bpm: 145 }]));
+		expect(trace.m).toHaveLength(TRACE_POINTS);
+		expect(trace.m.at(-1)).toBeGreaterThan(41_000);
+	});
+
+	it("keeps the intervals a kilometre split would average away", () => {
+		// Six 400m reps with 400m of jogging between them. Every kilometre of
+		// this averages to much the same number, which is the whole problem.
+		const legs = [];
+		for (let rep = 0; rep < 6; rep++) {
+			legs.push({ speed: FAST, sec: Math.round(400 / FAST), bpm: 178 });
+			legs.push({ speed: EASY, sec: Math.round(400 / EASY), bpm: 140 });
+		}
+		const trace = shapeTrace(record(legs));
+
+		const paces = trace.pace.filter((v) => v !== null);
+		expect(Math.min(...paces)).toBeLessThan(250);
+		expect(Math.max(...paces)).toBeGreaterThan(290);
+
+		// And the heart rate swings with them rather than sitting at its mean.
+		expect(Math.min(...trace.hr)).toBeLessThan(145);
+		expect(Math.max(...trace.hr)).toBeGreaterThan(173);
+	});
+
+	it("keeps the heart rate through a stop that the pace filter drops", () => {
+		// A rep, then standing still with the heart rate coming down, then
+		// another rep. The standing samples aren't running and can't be paced,
+		// but they're the recovery — the reason to draw heart rate at all. It
+		// covers no ground, so it lands inside the slice it happened in and
+		// pulls that slice down rather than getting one to itself.
+		const legs = [
+			{ speed: FAST, sec: 96, bpm: 180 },
+			{ speed: 0.05, sec: 60, bpm: 120 },
+			{ speed: FAST, sec: 96, bpm: 180 },
+		];
+		const trace = shapeTrace(record(legs));
+
+		expect(Math.min(...trace.hr.filter((v) => v !== null))).toBeLessThan(170);
+		// And nothing implausible reached the pace line.
+		for (const pace of trace.pace.filter((v) => v !== null)) {
+			expect(pace).toBeLessThan(400);
+		}
+	});
+
+	it("prefers the activity's own distance to the last sample", () => {
+		// A GPS drop at the finish leaves the stream short; the summary's
+		// total is the one the rest of the page is drawn from, and a trace
+		// that disagreed would put the last kilometre in the wrong place.
+		const streams = record([{ speed: EASY, sec: 600, bpm: 150 }]);
+		const trace = shapeTrace(streams, { distanceM: 4000 });
+		expect(trace.m.at(-1)).toBeGreaterThan(3900);
+		expect(trace.m.at(-1)).toBeLessThanOrEqual(4000);
+	});
+
+	it("reports a slice it couldn't measure rather than inventing one", () => {
+		const trace = shapeTrace(record([{ speed: EASY, sec: 600 }]), { maxPoints: 4 });
+		// No heart rate recorded at all: nulls, not zeroes, which would plot
+		// as a heart that stopped.
+		expect(trace.hr).toEqual([null, null, null, null]);
+		expect(trace.pace.every((v) => v > 0)).toBe(true);
+	});
+});

--- a/src/components/Training/charts/ChartFrame.svelte
+++ b/src/components/Training/charts/ChartFrame.svelte
@@ -27,6 +27,15 @@
 		height = 180,
 		/** From axisTicks(): [{ value, label, pct }], pct measured from the bottom. */
 		yTicks = [],
+		/**
+		 * A second scale down the right-hand edge, for a chart plotting two
+		 * units at once. Labels only, deliberately: gridlines belong to one
+		 * scale, and a second set at different fractions turns the plot into
+		 * a lattice where neither series can be read off either.
+		 *
+		 * Same shape as yTicks.
+		 */
+		rightTicks = [],
 		/** [{ key, label, pct, anchor: "start" | "middle" | "end" }] */
 		xTicks = [],
 		/**
@@ -139,6 +148,7 @@
 
 <figure
 	class="frame"
+	class:dual={rightTicks.length > 0}
 	style="--plot-height: {height}px"
 	role={scrubbable ? undefined : "img"}
 	aria-label={scrubbable ? undefined : label}
@@ -206,6 +216,14 @@
 		{/if}
 	</div>
 
+	{#if rightTicks.length}
+		<div class="y-axis right" aria-hidden="true">
+			{#each rightTicks as tick (tick.value)}
+				<span style="bottom: {tick.pct}%">{tick.label}</span>
+			{/each}
+		</div>
+	{/if}
+
 	{#if xTicks.length}
 		<div class="x-axis" aria-hidden="true">
 			{#each xTicks as tick (tick.key)}
@@ -229,6 +247,9 @@
 		column-gap: var(--space-2);
 		margin: 0;
 	}
+	/* Only when there's a second scale: an empty third column would still
+	   cost a column-gap of dead space on every other chart. */
+	.frame.dual { grid-template-columns: auto minmax(0, 1fr) auto; }
 
 	.y-axis {
 		grid-column: 1;
@@ -239,6 +260,10 @@
 		   0.7rem digits, which covers "1.30" and "-20". */
 		min-width: 2.1rem;
 	}
+	.y-axis.right {
+		grid-column: 3;
+		min-width: 1.9rem;
+	}
 	.y-axis span {
 		position: absolute;
 		right: 0;
@@ -248,6 +273,10 @@
 		color: var(--paragraph-colour);
 		opacity: 0.55;
 		white-space: nowrap;
+	}
+	.y-axis.right span {
+		right: auto;
+		left: 0;
 	}
 
 	.plot {
@@ -301,8 +330,6 @@
 		margin: 0 0 -4.5px -4.5px;
 		border-radius: 50%;
 		background: var(--dot);
-		/* Ringed in the card's own background so a dot stays legible where it
-		   sits on top of the line it belongs to. */
 		/* Ringed in an opaque surface so a dot stays legible where it sits on
 		   top of the line it belongs to. */
 		box-shadow: 0 0 0 2px var(--background-one);

--- a/src/components/Training/lib/balance.js
+++ b/src/components/Training/lib/balance.js
@@ -16,6 +16,11 @@
 // because a declared weight is a guess that goes stale the moment a panel says
 // something longer than it used to.
 
+// How much better a split has to be before it's worth taking. See worthMoving
+// for why there has to be a bar at all; the settled layout can therefore sit
+// this far off the best split available, by design.
+export const MIN_GAIN_PX = 64;
+
 /**
  * Total height of a column, including the gaps between its panels.
  *
@@ -95,7 +100,7 @@ export function bestSplit(heights, { gap = 0, min = 2 } = {}) {
  * @param {number} [options.minGain] pixels of improvement to justify a move.
  * @returns {boolean}
  */
-export function worthMoving(heights, from, to, { gap = 0, minGain = 64 } = {}) {
+export function worthMoving(heights, from, to, { gap = 0, minGain = MIN_GAIN_PX } = {}) {
 	if (!Number.isFinite(to) || to === from) return false;
 	return imbalanceAt(heights, from, gap) - imbalanceAt(heights, to, gap) > minGain;
 }

--- a/src/components/Training/lib/chart.js
+++ b/src/components/Training/lib/chart.js
@@ -288,16 +288,28 @@ function niceNum(range, round) {
  *
  * @param {[number, number]} extent data min and max.
  * @param {number} [count] rough number of intervals wanted.
+ * @param {object} [options]
+ * @param {number[]} [options.steps] ascending step sizes to choose from,
+ *   instead of the decimal 1/2/5 ladder. Round numbers are base ten only
+ *   because we count in it: an axis in seconds wants halves and quarters of a
+ *   minute, and left to itself this lands on a 100-second step, which puts
+ *   gridlines at 1:40 and 3:20 and rounds a run's range out to nearly twice
+ *   its size to reach them.
  * @returns {{min: number, max: number, step: number, ticks: number[]}}
  */
-export function niceScale([min, max], count = 4) {
+export function niceScale([min, max], count = 4, { steps = null } = {}) {
 	let lo = Number.isFinite(min) ? min : 0;
 	let hi = Number.isFinite(max) ? max : 1;
 	if (hi < lo) [lo, hi] = [hi, lo];
 	// A flat series still needs an axis with two ends to it.
 	if (hi === lo) hi = lo === 0 ? 1 : lo + Math.abs(lo) * 0.1;
 
-	const step = niceNum(niceNum(hi - lo, false) / Math.max(1, count), true);
+	// The smallest offered step that doesn't overrun the axis with labels,
+	// since a tighter step is also a tighter fit around the data.
+	const spans = (s) => Math.round((Math.ceil(hi / s) * s - Math.floor(lo / s) * s) / s);
+	const step = steps
+		? (steps.find((s) => s > 0 && spans(s) <= count + 2) ?? steps.at(-1))
+		: niceNum(niceNum(hi - lo, false) / Math.max(1, count), true);
 	const niceMin = Math.floor(lo / step) * step;
 	const niceMax = Math.ceil(hi / step) * step;
 

--- a/src/components/Training/lib/chart.test.js
+++ b/src/components/Training/lib/chart.test.js
@@ -235,6 +235,24 @@ describe("niceScale", () => {
 		expect(Number.isFinite(scale.min)).toBe(true);
 		expect(Number.isFinite(scale.max)).toBe(true);
 	});
+
+	// Base ten isn't round for an axis in seconds. An interval session spanning
+	// 3:10 to 8:30 lands on a 100-second step left to itself, which is
+	// gridlines at 1:40 and 3:20 and an axis reaching 10:00 for a run that
+	// never went slower than 8:30.
+	it("takes a ladder of steps for an axis that isn't decimal", () => {
+		const seconds = [15, 30, 60, 120, 300];
+		const scale = niceScale([190, 510], 4, { steps: seconds });
+		expect(seconds).toContain(scale.step);
+		expect(scale.min).toBe(180);
+		expect(scale.max).toBe(540);
+
+		// Tighter data gets a tighter step off the same ladder.
+		const steady = niceScale([292, 316], 4, { steps: seconds });
+		expect(steady.step).toBe(15);
+		expect(steady.min).toBe(285);
+		expect(steady.max).toBe(330);
+	});
 });
 
 describe("axisTicks", () => {

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -39,6 +39,26 @@ export function speed(distanceM, movingTimeSec) {
 }
 
 /**
+ * How long something took, spelled so it can't be read as a distance.
+ *
+ * formatDuration's "48m" is fine in a sentence and fine beside an "h", but a
+ * headline stat sits next to "9.30 km" in a row of large numbers, and there
+ * "48m" is forty-eight metres to anyone reading quickly. Under the hour it
+ * says "min"; over it, the "h" does that work already and "1h15m" reads as one
+ * time rather than two units.
+ *
+ * @param {number} sec
+ * @returns {string}
+ */
+export function timeTaken(sec) {
+	if (!(sec > 0)) return "—";
+	// Minutes first, so 59m30s rolls the hour instead of printing "60min".
+	const total = Math.round(sec / 60);
+	const h = Math.floor(total / 60);
+	return h > 0 ? `${h}h${pad(total % 60)}m` : `${total}min`;
+}
+
+/**
  * A race time as h:mm:ss.
  *
  * @param {number} sec

--- a/src/components/Training/lib/format.test.js
+++ b/src/components/Training/lib/format.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed, speed, readout, splitLead } from "./format.js";
+import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed, speed, readout, splitLead, timeTaken } from "./format.js";
 
 describe("readout", () => {
 	it("binds symbols to both numbers and says words once", () => {
@@ -151,6 +151,18 @@ describe("training formatters", () => {
 	it("prints a race time with hours only when there are any", () => {
 		expect(clock(13200)).toBe("3:40:00");
 		expect(clock(1800)).toBe("30:00");
+	});
+
+	it("spells a headline duration so it can't be read as metres", () => {
+		// "48m" beside "9.30 km" is forty-eight metres at a glance.
+		expect(timeTaken(2880)).toBe("48min");
+		expect(timeTaken(4500)).toBe("1h15m");
+		// The "h" already says these are times, so the "m" is safe again.
+		expect(timeTaken(13_200)).toBe("3h40m");
+		expect(timeTaken(3900)).toBe("1h05m");
+		// And the rounding rolls the hour instead of reaching sixty minutes.
+		expect(timeTaken(3599)).toBe("1h00m");
+		expect(timeTaken(null)).toBe("—");
 	});
 
 	it("drops noise decimals on big distances", () => {

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -29,7 +29,7 @@
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
     import { areaPath, linePath, niceScale, scaleLinear, smoothPath, xPct, yPct } from "../lib/chart.js";
-    import { daysAgo, formatDistance, formatDuration, pace, pct, signed } from "../lib/format.js";
+    import { daysAgo, formatDistance, pace, pct, signed, timeTaken } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
     import { stravaTag as tagFor } from "../lib/runTags.js";
 
@@ -47,16 +47,48 @@
 
     const stravaTag = $derived(tagFor(run));
 
+    const beatsShown = $derived.by(() => {
+        if (!(run?.averageHr > 0)) return "—";
+        const avg = Math.round(run.averageHr);
+        return run.maxHr > 0 ? `${avg}/${Math.round(run.maxHr)}` : String(avg);
+    });
+
     const splits = $derived((run?.splits || []).filter((s) => s.paceSecPerKm > 0));
 
+    // Where along the run each reading was taken, and what it read.
+    //
+    // The stored trace when there is one — a hundred and twenty slices, fine
+    // enough that an interval session looks like one. Splits when there isn't,
+    // which is a manual entry or a run whose streams didn't come back: a
+    // kilometre at a time, plotted at each kilometre's midpoint, because that
+    // is the distance its average actually describes.
+    const traced = $derived(Array.isArray(run?.trace?.m) && run.trace.m.length > 1);
+    const samples = $derived.by(() => {
+        if (traced) {
+            const { m, pace: paces, hr } = run.trace;
+            return m.map((metres, i) => ({
+                m: metres,
+                paceSecPerKm: paces[i] > 0 ? paces[i] : null,
+                hr: hr[i] > 0 ? hr[i] : null,
+            }));
+        }
+        return splits.map((s) => ({
+            m: (s.km - 0.5) * 1000,
+            paceSecPerKm: s.paceSecPerKm,
+            hr: s.averageHr > 0 ? s.averageHr : null,
+        }));
+    });
+
+    const span = $derived(Math.max(run?.distanceM || 0, samples.at(-1)?.m || 0));
+    const atX = $derived((metres) => (span > 0 ? (metres / span) * WIDTH : 0));
+
+    // Gridlines a runner reads without converting: quarters of a minute up to
+    // a minute, then whole and half minutes.
+    const PACE_STEPS = [15, 30, 60, 120, 300];
+
+    const paces = $derived(samples.map((s) => s.paceSecPerKm).filter((p) => p > 0));
     const scale = $derived(
-        niceScale(
-            [
-                Math.min(...splits.map((s) => s.paceSecPerKm)) - 8,
-                Math.max(...splits.map((s) => s.paceSecPerKm)) + 8,
-            ],
-            4,
-        ),
+        niceScale([Math.min(...paces) - 8, Math.max(...paces) + 8], 4, { steps: PACE_STEPS }),
     );
 
     // Pace runs the other way to every other axis on the page: the smallest
@@ -70,11 +102,34 @@
         })),
     );
 
-    const step = $derived(splits.length > 1 ? WIDTH / (splits.length - 1) : 0);
-    const pacePoints = $derived(splits.map((s, i) => ({ x: i * step, y: y(s.paceSecPerKm) })));
+    // Contiguous stretches of measured points. A slice the watch couldn't pace
+    // — standing at a crossing, a moment of lost signal — leaves a hole in the
+    // line, rather than a straight segment drawn across it that would read as
+    // running the whole way.
+    function stretches(points) {
+        const out = [];
+        let current = [];
+        for (const point of points) {
+            if (point) current.push(point);
+            else if (current.length > 1) { out.push(current); current = []; }
+            else current = [];
+        }
+        if (current.length > 1) out.push(current);
+        return out;
+    }
+
+    const paceLines = $derived(
+        stretches(samples.map((s) => (s.paceSecPerKm > 0 ? { x: atX(s.m), y: y(s.paceSecPerKm) } : null))),
+    );
+
+    // The grade-adjusted line is a kilometre-resolution measure, so it's drawn
+    // only on the kilometre-resolution chart. Over a trace it would invite
+    // comparing a slice against the whole kilometre containing it, which is
+    // the one comparison it can't support — and the run's grade adjustment is
+    // in the facts below either way.
     const gapPoints = $derived(
-        splits.every((s) => s.gapPaceSecPerKm > 0)
-            ? splits.map((s, i) => ({ x: i * step, y: y(s.gapPaceSecPerKm) }))
+        !traced && splits.length > 1 && splits.every((s) => s.gapPaceSecPerKm > 0)
+            ? splits.map((s) => ({ x: atX((s.km - 0.5) * 1000), y: y(s.gapPaceSecPerKm) }))
             : [],
     );
     const showGap = $derived(
@@ -84,7 +139,7 @@
 
     const averageY = $derived(run?.paceSecPerKm > 0 ? y(run.paceSecPerKm) : null);
 
-    // Heart rate over the same kilometres, on its own scale down the right.
+    // Heart rate along the same distance, on its own scale down the right.
     //
     // Two units on one plot is a thing to do carefully, and there are two
     // reasons it earns its place here. The chart already reads faster-is-higher,
@@ -92,24 +147,23 @@
     // expects. And the divergence is the interesting part: pace flat while the
     // line beneath it climbs is drift, which the panel already reports as a
     // single number under "Drift" — this is where it happened.
-    //
-    // All or nothing rather than skipping gaps. A line that vanishes for two
-    // kilometres invites reading the join as a measurement.
-    const hasHr = $derived(splits.length > 1 && splits.every((s) => s.averageHr > 0));
+    const beats = $derived(samples.map((s) => s.hr).filter((b) => b > 0));
+    const hasHr = $derived(beats.length > 1);
 
     const hrScale = $derived.by(() => {
         if (!hasHr) return null;
-        const beats = splits.map((s) => s.averageHr);
-        // Four, not three. Three asks for a step so coarse it rounds a run
-        // that lived between 130 and 175 out to an axis of 100 to 200, and
+        // Four ticks, not three. Three asks for a step so coarse it rounds a
+        // run that lived between 130 and 175 out to an axis of 100 to 200, and
         // half the plot's height goes to heart rates nobody had.
         return niceScale([Math.min(...beats) - 4, Math.max(...beats) + 4], 4);
     });
 
     // Not flipped, unlike pace: more beats is more effort, and up is more.
     const hrY = $derived(hrScale ? scaleLinear([hrScale.min, hrScale.max], [HEIGHT, 0]) : null);
-    const hrPoints = $derived(
-        hrScale ? splits.map((s, i) => ({ x: i * step, y: hrY(s.averageHr) })) : [],
+    const hrLines = $derived(
+        hrScale
+            ? stretches(samples.map((s) => (s.hr > 0 ? { x: atX(s.m), y: hrY(s.hr) } : null)))
+            : [],
     );
     const hrTicks = $derived(
         hrScale
@@ -121,66 +175,67 @@
             : [],
     );
 
-    // A number under every kilometre is unreadable on a phone, so thin them to
-    // about half a dozen: both ends, then an even step in between, dropping
-    // any that would crowd the last one.
-    const tickStep = $derived(Math.max(1, Math.ceil(splits.length / 6)));
-    const xTicks = $derived(
-        splits
-            .map((s, i) => ({ s, i }))
-            .filter(({ i }) => {
-                const last = splits.length - 1;
-                if (i === 0 || i === last) return true;
-                return i % tickStep === 0 && last - i >= tickStep;
-            })
-            .map(({ s, i }) => ({
-                key: s.km,
-                label: `${s.km}`,
-                pct: (i / Math.max(1, splits.length - 1)) * 100,
-                anchor: i === 0 ? "start" : i === splits.length - 1 ? "end" : "middle",
-            })),
-    );
+    // Kilometre marks, thinned to about half a dozen: a label per kilometre is
+    // unreadable on a phone by about 8km.
+    const tickStepKm = $derived(Math.max(1, Math.ceil(span / 1000 / 6)));
+    const xTicks = $derived.by(() => {
+        const out = [];
+        for (let km = 0; km * 1000 <= span; km += tickStepKm) {
+            out.push({
+                key: km,
+                label: String(km),
+                pct: span > 0 ? ((km * 1000) / span) * 100 : 0,
+                anchor: km === 0 ? "start" : "middle",
+            });
+        }
+        return out;
+    });
 
-    // A kilometre at a time. The dots carried a title attribute, which put the
-    // pace behind a hover delay and a browser tooltip; this is the same three
-    // numbers you'd actually compare across a run — what it cost in pace, what
-    // the hills made of it, and what your heart was doing for it.
+    // What the run was doing at a given point along it. The dots used to carry
+    // a title attribute, which put the pace behind a hover delay and a browser
+    // tooltip; this is the pair you'd actually compare — what it cost in pace,
+    // and what your heart was doing for it.
     const scrub = $derived(
-        splits.map((split, i) => ({
-            key: split.km,
-            pct: xPct(pacePoints[i].x, WIDTH),
-            label: `Kilometre ${split.km}`,
-            readouts: [
-                {
-                    label: "Pace",
-                    value: pace(split.paceSecPerKm),
-                    colour: "var(--main-green)",
-                    yPct: yPct(pacePoints[i].y, HEIGHT),
-                },
-                ...(showGap && split.gapPaceSecPerKm > 0
-                    ? [
-                            {
-                                label: "Grade adjusted",
-                                value: pace(split.gapPaceSecPerKm),
-                                colour: "var(--paragraph-colour)",
-                                yPct: yPct(gapPoints[i].y, HEIGHT),
-                            },
-                        ]
-                    : []),
-                ...(split.averageHr > 0
-                    ? [
-                            {
-                                label: "Heart rate",
-                                value: `${Math.round(split.averageHr)} bpm`,
-                                colour: "var(--tone-bad)",
-                                // Only where it's drawn; on a run without a
-                                // full set of splits it's a number, not a point.
-                                yPct: hasHr ? yPct(hrPoints[i].y, HEIGHT) : undefined,
-                            },
-                        ]
-                    : []),
-            ],
-        })),
+        samples
+            .map((sample, i) => ({ sample, i }))
+            .filter(({ sample }) => sample.paceSecPerKm > 0 || sample.hr > 0)
+            .map(({ sample, i }) => ({
+                key: sample.m,
+                pct: xPct(atX(sample.m), WIDTH),
+                label: traced ? `${(sample.m / 1000).toFixed(2)} km` : `Kilometre ${splits[i].km}`,
+                readouts: [
+                    ...(sample.paceSecPerKm > 0
+                        ? [
+                                {
+                                    label: "Pace",
+                                    value: pace(sample.paceSecPerKm),
+                                    colour: "var(--main-green)",
+                                    yPct: yPct(y(sample.paceSecPerKm), HEIGHT),
+                                },
+                            ]
+                        : []),
+                    ...(showGap && splits[i]?.gapPaceSecPerKm > 0
+                        ? [
+                                {
+                                    label: "Grade adjusted",
+                                    value: pace(splits[i].gapPaceSecPerKm),
+                                    colour: "var(--paragraph-colour)",
+                                    yPct: yPct(y(splits[i].gapPaceSecPerKm), HEIGHT),
+                                },
+                            ]
+                        : []),
+                    ...(sample.hr > 0
+                        ? [
+                                {
+                                    label: "Heart rate",
+                                    value: `${Math.round(sample.hr)} bpm`,
+                                    colour: "var(--tone-bad)",
+                                    yPct: hrY ? yPct(hrY(sample.hr), HEIGHT) : undefined,
+                                },
+                            ]
+                        : []),
+                ],
+            })),
     );
 
     const form = $derived(run?.impact?.form || null);
@@ -327,20 +382,25 @@
                 <span>distance</span>
             </div>
             <div class="stat">
-                <strong>{formatDuration(run.movingTimeSec)}</strong>
+                <strong>{timeTaken(run.movingTimeSec)}</strong>
                 <span>moving</span>
             </div>
             <div class="stat">
                 <strong>{pace(run.paceSecPerKm)}</strong>
                 <span>average pace</span>
             </div>
+            <!-- "159 / bpm · 189 max" left the headline number unlabelled
+                 beside three that say what they are, so the one figure on this
+                 row that has a matching maximum was the one you had to infer
+                 was a mean. The pair now reads off the caption in the order
+                 it's written, and the caption fits on one line. -->
             <div class="stat">
-                <strong>{run.averageHr ? `${Math.round(run.averageHr)}` : "—"}</strong>
-                <span>{run.maxHr ? `bpm · ${Math.round(run.maxHr)} max` : "bpm average"}</span>
+                <strong>{beatsShown}</strong>
+                <span>{run.maxHr && run.averageHr ? "average/max hr" : "average hr"}</span>
             </div>
         </div>
 
-        {#if splits.length > 1}
+        {#if paceLines.length || hrLines.length}
             <div class="chart">
                 <ChartFrame
                     height={HEIGHT}
@@ -348,7 +408,7 @@
                     {xTicks}
                     {scrub}
                     rightTicks={hrTicks}
-                    label="Pace{hasHr ? ' and heart rate' : ''} for each kilometre of the run"
+                    label="Pace{hasHr ? ' and heart rate' : ''} across the run"
                 >
                     <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
                         <!-- Filled and underneath, so that where it crosses the
@@ -356,20 +416,27 @@
                              rather than as the two being equal — which, on two
                              different scales, is a coincidence of axis choice
                              and means nothing at all. -->
-                        {#if hasHr}
-                            <path class="hr-fill" d={areaPath(hrPoints, HEIGHT, { smooth: true })} />
-                            <path class="hr" d={smoothPath(hrPoints)} />
-                        {/if}
+                        {#each hrLines as line, i (i)}
+                            <path class="hr-fill" d={areaPath(line, HEIGHT, { smooth: true })} />
+                            <path class="hr" d={smoothPath(line)} />
+                        {/each}
                         {#if averageY !== null}
                             <line class="average" x1="0" x2={WIDTH} y1={averageY} y2={averageY} />
                         {/if}
                         {#if showGap}
                             <path class="gap" d={linePath(gapPoints)} />
                         {/if}
-                        <path class="line" d={linePath(pacePoints)} />
-                        {#each pacePoints as point (point.x)}
-                            <circle class="dot" cx={point.x} cy={point.y} r="4" />
+                        {#each paceLines as line, i (i)}
+                            <path class="line" d={smoothPath(line)} />
                         {/each}
+                        <!-- Only where a point is a measurement in its own
+                             right. On a trace they'd be a hundred and twenty
+                             beads on a string. -->
+                        {#if !traced}
+                            {#each paceLines.flat() as point (point.x)}
+                                <circle class="dot" cx={point.x} cy={point.y} r="4" />
+                            {/each}
+                        {/if}
                     </svg>
                 </ChartFrame>
                 <p class="legend">
@@ -505,16 +572,20 @@
         opacity: 0.55;
         vector-effect: non-scaling-stroke;
     }
+    /* Deliberately the quieter of the two. The pair cross each other many
+       times over an interval session, and two lines of equal weight crossing
+       repeatedly is a thicket; heart rate reads as the band underneath and
+       pace as the line on top of it. */
     .hr {
         fill: none;
         stroke: var(--tone-bad);
-        stroke-width: 1.5;
-        opacity: 0.65;
+        stroke-width: 1.25;
+        opacity: 0.5;
         vector-effect: non-scaling-stroke;
     }
     .hr-fill {
         fill: var(--tone-bad);
-        opacity: 0.1;
+        opacity: 0.12;
     }
     .average {
         stroke: var(--header-colour);

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -14,7 +14,13 @@
     The pace chart is drawn with a flipped y-axis so faster is higher, which is
     the only orientation people read without translating; the axis is labelled
     in pace so there's nothing to translate anyway. It scrubs like the rest of
-    the page's charts, which is where a single kilometre is legible at all. Grade-adjusted pace goes
+    the page's charts, which is where a single kilometre is legible at all.
+
+    Heart rate goes under it on a second scale down the right-hand edge. Two
+    units on one plot is a thing to do carefully, and it earns its place here
+    because the divergence is the point: pace holding while the beats climb is
+    drift, which the facts grid already reports as one number, and this is
+    where in the run it happened. Grade-adjusted pace goes
     over it as a second line whenever the two actually diverge — on a hilly run
     that gap is the explanation for a slow kilometre, and on a flat one drawing
     it twice would just be noise.
@@ -22,7 +28,7 @@
 <script>
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
-    import { linePath, niceScale, scaleLinear, xPct, yPct } from "../lib/chart.js";
+    import { areaPath, linePath, niceScale, scaleLinear, smoothPath, xPct, yPct } from "../lib/chart.js";
     import { daysAgo, formatDistance, formatDuration, pace, pct, signed } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
     import { stravaTag as tagFor } from "../lib/runTags.js";
@@ -78,6 +84,43 @@
 
     const averageY = $derived(run?.paceSecPerKm > 0 ? y(run.paceSecPerKm) : null);
 
+    // Heart rate over the same kilometres, on its own scale down the right.
+    //
+    // Two units on one plot is a thing to do carefully, and there are two
+    // reasons it earns its place here. The chart already reads faster-is-higher,
+    // so effort and pace rise together and the pair moves the way a runner
+    // expects. And the divergence is the interesting part: pace flat while the
+    // line beneath it climbs is drift, which the panel already reports as a
+    // single number under "Drift" — this is where it happened.
+    //
+    // All or nothing rather than skipping gaps. A line that vanishes for two
+    // kilometres invites reading the join as a measurement.
+    const hasHr = $derived(splits.length > 1 && splits.every((s) => s.averageHr > 0));
+
+    const hrScale = $derived.by(() => {
+        if (!hasHr) return null;
+        const beats = splits.map((s) => s.averageHr);
+        // Four, not three. Three asks for a step so coarse it rounds a run
+        // that lived between 130 and 175 out to an axis of 100 to 200, and
+        // half the plot's height goes to heart rates nobody had.
+        return niceScale([Math.min(...beats) - 4, Math.max(...beats) + 4], 4);
+    });
+
+    // Not flipped, unlike pace: more beats is more effort, and up is more.
+    const hrY = $derived(hrScale ? scaleLinear([hrScale.min, hrScale.max], [HEIGHT, 0]) : null);
+    const hrPoints = $derived(
+        hrScale ? splits.map((s, i) => ({ x: i * step, y: hrY(s.averageHr) })) : [],
+    );
+    const hrTicks = $derived(
+        hrScale
+            ? hrScale.ticks.map((value) => ({
+                    value,
+                    label: String(Math.round(value)),
+                    pct: ((value - hrScale.min) / (hrScale.max - hrScale.min)) * 100,
+                }))
+            : [],
+    );
+
     // A number under every kilometre is unreadable on a phone, so thin them to
     // about half a dozen: both ends, then an even step in between, dropping
     // any that would crowd the last one.
@@ -125,7 +168,16 @@
                         ]
                     : []),
                 ...(split.averageHr > 0
-                    ? [{ label: "Heart rate", value: `${Math.round(split.averageHr)} bpm` }]
+                    ? [
+                            {
+                                label: "Heart rate",
+                                value: `${Math.round(split.averageHr)} bpm`,
+                                colour: "var(--tone-bad)",
+                                // Only where it's drawn; on a run without a
+                                // full set of splits it's a number, not a point.
+                                yPct: hasHr ? yPct(hrPoints[i].y, HEIGHT) : undefined,
+                            },
+                        ]
                     : []),
             ],
         })),
@@ -290,8 +342,24 @@
 
         {#if splits.length > 1}
             <div class="chart">
-                <ChartFrame height={HEIGHT} {yTicks} {xTicks} {scrub} label="Pace for each kilometre of the run">
+                <ChartFrame
+                    height={HEIGHT}
+                    {yTicks}
+                    {xTicks}
+                    {scrub}
+                    rightTicks={hrTicks}
+                    label="Pace{hasHr ? ' and heart rate' : ''} for each kilometre of the run"
+                >
                     <svg viewBox="0 0 {WIDTH} {HEIGHT}" preserveAspectRatio="none">
+                        <!-- Filled and underneath, so that where it crosses the
+                             pace line reads as one sitting above the other
+                             rather than as the two being equal — which, on two
+                             different scales, is a coincidence of axis choice
+                             and means nothing at all. -->
+                        {#if hasHr}
+                            <path class="hr-fill" d={areaPath(hrPoints, HEIGHT, { smooth: true })} />
+                            <path class="hr" d={smoothPath(hrPoints)} />
+                        {/if}
                         {#if averageY !== null}
                             <line class="average" x1="0" x2={WIDTH} y1={averageY} y2={averageY} />
                         {/if}
@@ -309,6 +377,7 @@
                     <!-- Swatch and label in one span: wrapped apart, a dash
                          sitting alone at the end of a line is just a dash. -->
                     {#if showGap}<span class="key"><span class="swatch"></span> grade adjusted</span>{/if}
+                    {#if hasHr}<span class="key"><span class="swatch beats"></span> bpm, right</span>{/if}
                     {#if pacingNote}<span class="pacing">{pacingNote}</span>{/if}
                 </p>
             </div>
@@ -436,6 +505,17 @@
         opacity: 0.55;
         vector-effect: non-scaling-stroke;
     }
+    .hr {
+        fill: none;
+        stroke: var(--tone-bad);
+        stroke-width: 1.5;
+        opacity: 0.65;
+        vector-effect: non-scaling-stroke;
+    }
+    .hr-fill {
+        fill: var(--tone-bad);
+        opacity: 0.1;
+    }
     .average {
         stroke: var(--header-colour);
         stroke-width: 1;
@@ -466,6 +546,11 @@
         width: 14px;
         height: 0;
         border-top: 1.5px dashed var(--paragraph-colour);
+    }
+    .swatch.beats {
+        border-top-style: solid;
+        border-top-color: var(--tone-bad);
+        opacity: 0.65;
     }
     .pacing {
         padding-left: var(--space-2);


### PR DESCRIPTION
## Summary

The last-run chart plotted per-kilometre splits, which is the wrong resolution for the sessions most worth looking at: an interval workout's reps and the recoveries between them happen inside one split and average away to a single number. A session of 3:30 reps with walked rests drew as a gently wobbling line at 5:10.

Runs now store a pace and heart-rate trace, resampled by distance from the streams at sync time — the streams aren't kept, so that's the only chance to build one — and the chart plots that, with heart rate on its own right-hand scale.

- **Sliced at 150m, not a fixed count.** Pace is a reciprocal, so a walked recovery sits further below a rep than the rep sits below the top of the plot. Slice finely enough that one slice lands inside the walk and it takes that pace whole, the axis stretches to 13:00 to reach it, and every rep is squashed into the top tenth of the chart. Wider slices blend the walk with the running either side — which is what Strava's smoothed view does, and why its recoveries bottom out around 8:00 rather than 13:00.
- **No grade in the trace, and none coming.** Per-kilometre grade adjustment is already published and describes an effort; a hundred grade samples in distance order is an elevation profile, and that is most of the way to naming the route. The cost is the chart's grade-adjusted line on any run that has a trace — a kilometre-resolution measure laid over a sub-kilometre one invites the one comparison it can't support — and the adjustment is still in the facts below the chart.
- **An axis in seconds now takes a ladder of steps.** Base ten isn't round for time: left to itself this run landed on a 100-second step, with gridlines at 1:40 and 3:20 and an axis reaching 10:00 for a run that never went slower than 8:33.
- **Headline stats.** "48m" beside "9.30 km" reads as forty-eight metres, so under the hour it says `48min` and over it `1h15m`. Heart rate reads `159/189` under one `average/max hr` caption, rather than leaving the first number to be inferred as a mean.

`SHAPE_VERSION` goes to 4, so `trainingSync` re-enriches the stored block a batch at a time once this is live — around half an hour before every run carries a trace. Until then the chart falls back to splits, which is also the permanent path for a manual entry or a run whose streams don't come back.

The column-balance E2E now asserts that the layout takes the best split available (within the 64px bar a move has to clear) rather than a ratio. Only ten panels go into two columns and three are ~700px tall, so the achievable splits are coarse: the best leaves the columns 11% apart and the next best 22%, and any threshold between those measures the panels rather than the balancing.

## Test plan

- [x] `vitest` — 643 pass, including a new `trace.test.js` covering the interval case, the stop the pace filter drops, the slice width and the count cap
- [x] `playwright` — 30 pass, including the finer scrub grain, the keyboard path, the heart-rate axis and the rebuilt balance assertion
- [x] `npm run build`
- [x] Rendered against the real payload for the 9.3km interval session, light and dark