### PR TITLE
Don't count a paused watch as time in a zone

### DIFF
--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -38,10 +38,14 @@ const NAMES = [
 // Without one, those are null and the last-run panel renders its "no heart
 // rate" path — real for a manual entry, but not what the page normally shows.
 //
-// Every ten seconds rather than every minute: the trace resamples in slices of
-// a hundred and fifty metres, and a sample a minute apart is a sample every
-// quarter kilometre, which would leave most of those slices unmeasured and the
-// chart a dotted line through a run that never paused.
+// Every five seconds rather than every minute, for two reasons. The trace
+// resamples in slices of a hundred and fifty metres, and a sample a minute
+// apart is a sample every quarter kilometre, which would leave most of those
+// slices unmeasured and the chart a dotted line through a run that never
+// paused. And anything sparser than ten seconds is a hole in the recording as
+// far as streams.js is concerned, so a run sampled by the minute would arrive
+// with no time in any zone at all.
+//
 // It draws from a generator of its own, seeded from the shared one. Drawing
 // directly would tie the sequence every other activity is built from to how
 // many samples this run happens to take, so changing the sample rate would
@@ -49,7 +53,7 @@ const NAMES = [
 // run, and a handful of unrelated assertions to re-baseline.
 function streamsFor({ distance, movingTime, averageHr, next }) {
 	const noise = sequence(Math.floor(next() * 2147483648));
-	const steps = Math.max(20, Math.round(movingTime / 10));
+	const steps = Math.max(20, Math.round(movingTime / 5));
 	const time = [];
 	const distanceStream = [];
 	const heartrate = [];

--- a/netlify/functions/_shared/training/efficiency.js
+++ b/netlify/functions/_shared/training/efficiency.js
@@ -17,6 +17,7 @@
 
 import { gradeFactor } from "./gap.js";
 import { reading } from "./num.js";
+import { isRecordingGap } from "./streams.js";
 
 // Below this there isn't enough signal for the halves to mean anything.
 const MIN_SAMPLES = 20;
@@ -65,7 +66,12 @@ function samplesFromStreams(streams) {
 		const timeSec = time[i] - time[i - 1];
 		const distanceM = distance[i] - distance[i - 1];
 		const beats = reading(hr[i]);
-		if (!(timeSec > 0) || !(distanceM > 0) || !(beats > 0)) continue;
+		// A pause clears the "moved at all" test on a metre of GPS drift and
+		// then arrives here as one sample worth ten minutes — enough to drag
+		// the efficiency of whichever half holds it toward zero, and to move
+		// the halfway line by a sixth of the run.
+		if (!(timeSec > 0) || isRecordingGap(timeSec)) continue;
+		if (!(distanceM > 0) || !(beats > 0)) continue;
 		samples.push({
 			timeSec,
 			distanceM,

--- a/netlify/functions/_shared/training/efficiency.test.js
+++ b/netlify/functions/_shared/training/efficiency.test.js
@@ -99,6 +99,22 @@ describe("aerobicDecoupling", () => {
 		expect(uphill.decouplingPct).toBeLessThan(flat.decouplingPct + 5);
 	});
 
+	it("ignores a stop the watch didn't record through", () => {
+		// The same run twice, once with ten minutes of standing dropped into
+		// the middle of it. A pause writes no samples, so it arrives as one
+		// sample covering six hundred seconds at walking-pace-on-GPS-drift —
+		// left in, it drags the efficiency of whichever half holds it toward
+		// zero and shifts the halfway line by a sixth of the run.
+		const clean = steady({ count: 400, speedMps: 3, hr: 150 });
+		const paused = steady({ count: 400, speedMps: 3, hr: 150 });
+		for (let i = 200; i < paused.time.length; i++) paused.time[i] += 600;
+
+		expect(aerobicDecoupling(paused).decouplingPct).toBeCloseTo(
+			aerobicDecoupling(clean).decouplingPct,
+			6,
+		);
+	});
+
 	it("returns null for a run too short to halve", () => {
 		expect(aerobicDecoupling(steady({ count: 5, speedMps: 3, hr: 150 }))).toBeNull();
 	});

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -53,7 +53,10 @@ export const RIDE_MIN_M = 20000;
 // 3: records carry `sport`, and rides over RIDE_MIN_M are tracked.
 // 4: runs carry a resampled pace/heart-rate trace (see trace.js), which only
 //    exists while the streams are in hand.
-export const SHAPE_VERSION = 4;
+// 5: time in zone and decoupling skip the holes a paused watch leaves in the
+//    recording, instead of filing a ten-minute stop under the heart rate it
+//    resumed at (see streams.js).
+export const SHAPE_VERSION = 5;
 
 /**
  * Is this a public run we should track?

--- a/netlify/functions/_shared/training/shape.test.js
+++ b/netlify/functions/_shared/training/shape.test.js
@@ -128,12 +128,17 @@ describe("shapeActivity", () => {
 	});
 
 	it("prefers streams for GAP and computes time in zone from them", () => {
-		const streams = {
-			time: [0, 60, 120, 180],
-			distance: [0, 200, 400, 600],
-			heartrate: [140, 140, 160, 180],
-			grade_smooth: [0, 0, 0, 0],
-		};
+		// Recorded once a second, as a watch does. Sampled any coarser and
+		// this is a paused watch rather than a run — see streams.js.
+		const streams = { time: [0], distance: [0], heartrate: [140], grade_smooth: [0] };
+		for (const beats of [140, 160, 180]) {
+			for (let i = 0; i < 60; i++) {
+				streams.time.push(streams.time.at(-1) + 1);
+				streams.distance.push(streams.distance.at(-1) + 10 / 3);
+				streams.heartrate.push(beats);
+				streams.grade_smooth.push(0);
+			}
+		}
 		const shaped = shapeActivity(rawRun(), { thresholds: THRESHOLDS, streams });
 		expect(shaped.gapSource).toBe("streams");
 		expect(shaped.zoneSeconds).toHaveLength(5);

--- a/netlify/functions/_shared/training/streams.js
+++ b/netlify/functions/_shared/training/streams.js
@@ -1,0 +1,36 @@
+// What counts as a measurement, when the recording has holes in it.
+//
+// Strava's `time` stream is elapsed, and a watch that auto-pauses stops writing
+// samples while it's paused. So a stop doesn't arrive as a run of slow samples
+// — it arrives as a single interval spanning the whole thing. Ten minutes at
+// the end of an interval session came back as one dt of 622 seconds, and
+// anything that sums dt books all ten of those minutes into whatever the heart
+// happened to be doing when recording resumed. On that run it put twenty
+// minutes of standing into zone one and reported the session as 49% easy;
+// without the gaps it's 33%.
+//
+// Ten seconds, because the sample rate is nowhere near it. Across a dozen of
+// this athlete's runs there are 34,261 intervals of exactly one second, none at
+// all between two and ten, and then the gaps: 11, 30, 34, 76, 79, 175, 258,
+// 622. The cliff is unmistakable and the threshold sits an order of magnitude
+// above the cadence, so it cannot discard real running.
+//
+// That margin is the thing to check if it ever needs revisiting: a watch set to
+// smart recording samples every few seconds instead of every second, and this
+// would start eating measurements rather than gaps.
+export const MAX_SAMPLE_GAP_SEC = 10;
+
+/**
+ * Is this interval a hole in the recording rather than time that was measured?
+ *
+ * Time inside a gap is not counted as anything — not as easy, not as hard, not
+ * as slow. Nothing was recorded, so there's nothing to attribute, and guessing
+ * from the sample on either side is how ten minutes of standing became easy
+ * running in the first place.
+ *
+ * @param {number} dtSec interval between two consecutive samples.
+ * @returns {boolean}
+ */
+export function isRecordingGap(dtSec) {
+	return dtSec > MAX_SAMPLE_GAP_SEC;
+}

--- a/netlify/functions/_shared/training/zones.js
+++ b/netlify/functions/_shared/training/zones.js
@@ -12,6 +12,7 @@
 // forgotten strap doesn't quietly drop a session out of the distribution.
 
 import { reading } from "./num.js";
+import { isRecordingGap } from "./streams.js";
 
 // Zone boundaries as fractions, for zones 2 through 5. Applied to heart-rate
 // reserve when a resting HR is known (the Karvonen method), and to raw max HR
@@ -98,7 +99,11 @@ export function zoneSecondsFromStreams(streams, floors) {
 	let counted = false;
 	for (let i = 1; i < hr.length && i < time.length; i++) {
 		const dt = time[i] - time[i - 1];
-		if (!(dt > 0)) continue;
+		// A paused watch writes no samples, so the stop arrives as one long
+		// interval and this loop would file all of it under the heart rate it
+		// resumed at — which is a low one, standing still. Time in zone is
+		// time that was recorded.
+		if (!(dt > 0) || isRecordingGap(dt)) continue;
 		const zone = zoneOfHr(hr[i], floors);
 		if (!zone) continue;
 		seconds[zone - 1] += dt;

--- a/netlify/functions/_shared/training/zones.test.js
+++ b/netlify/functions/_shared/training/zones.test.js
@@ -87,14 +87,47 @@ describe("zoneOfHr", () => {
 describe("zoneSecondsFromStreams", () => {
 	const floors = [0, 117, 136.5, 156, 175.5];
 
+	// A watch recording once a second, which is what one does.
+	function recorded(spells) {
+		const time = [0];
+		const heartrate = [spells[0].hr];
+		for (const { hr, sec } of spells) {
+			for (let i = 0; i < sec; i++) {
+				time.push(time.at(-1) + 1);
+				heartrate.push(hr);
+			}
+		}
+		return { time, heartrate };
+	}
+
 	it("accumulates time per zone from stream deltas", () => {
 		const out = zoneSecondsFromStreams(
-			{ time: [0, 60, 120, 180], heartrate: [100, 100, 150, 180] },
+			recorded([
+				{ hr: 100, sec: 60 },
+				{ hr: 150, sec: 60 },
+				{ hr: 180, sec: 60 },
+			]),
 			floors,
 		);
 		expect(out[0]).toBe(60); // zone 1
 		expect(out[2]).toBe(60); // zone 3
 		expect(out[4]).toBe(60); // zone 5
+	});
+
+	it("doesn't book a paused watch as time in a zone", () => {
+		// A second of hard running, ten minutes standing while the watch wrote
+		// nothing at all, then a second more. The stop arrives as a single
+		// interval, and counting it would file all ten minutes under the low
+		// heart rate recording resumed at — which is how an interval session
+		// with standing rests reported itself as half easy running.
+		const out = zoneSecondsFromStreams(
+			{ time: [0, 1, 601, 602], heartrate: [180, 180, 120, 120] },
+			floors,
+		);
+		expect(out[4]).toBe(1);
+		expect(out[1]).toBe(1);
+		// And the ten minutes are nowhere: not easy, not hard, not anywhere.
+		expect(out.reduce((a, b) => a + b, 0)).toBe(2);
 	});
 
 	it("returns null when there's no heart-rate stream", () => {


### PR DESCRIPTION
## Summary

Chasing why the last-run chart started at 0.23 km turned up a bigger problem next door.

Strava's `time` stream is elapsed, and a watch that auto-pauses writes no samples while it's stopped. So a stop doesn't arrive as a run of slow samples — it arrives as a **single interval spanning the whole thing**. Anything that sums those intervals books all of it under whatever the heart was doing when recording resumed, which is a low number, because you were standing still.

Last Wednesday's interval session came back with a 622-second gap in it and reported itself as **49% easy running**. Twenty minutes of that "easy" time was standing at the end of a rep. Without the gaps it's 33%.

```
                     zone 1     easy share
as stored            1202 s        49.1%
gaps excluded         326 s        33.0%
```

- **Ten seconds is the threshold, and the sample rate is nowhere near it.** Across a dozen runs there are 34,261 intervals of exactly one second, none at all between two and ten, and then the gaps: 11, 30, 34, 76, 79, 175, 258, 622. The cliff is unmistakable and the bar sits an order of magnitude above the cadence, so it can't discard real running. The margin is the thing to check if it ever needs revisiting — a watch on smart recording samples every few seconds.
- **Time inside a gap counts as nothing.** Not easy, not hard, not slow. Nothing was recorded, so there's nothing to attribute, and guessing from the sample on either side is how it went wrong to begin with.
- **Decoupling had the same hole and worse.** A pause clears its "moved at all" test on a metre of GPS drift and then lands as a single sample worth ten minutes — enough to drag the efficiency of whichever half holds it toward zero, and to move the halfway line by a sixth of the run.
- **Slow walking still counts**, deliberately. Only the holes in the recording are dropped, not samples the watch actually wrote while you were dawdling.

Grade-adjusted pace and the new trace were already immune: both filter samples by plausible speed, and a metre of drift over ten minutes doesn't come close.

### What moves

Measured against the last 16 runs: 3 are affected, 21.5 minutes of standing comes out, and the block's easy share goes 28.6% → 26.4%. On the individual sessions with long rests it's much larger, which is the point. Load, fitness, fatigue, form and weekly volume read none of this and don't move at all.

`SHAPE_VERSION` goes to 5, since both numbers are stored — so another pass of re-enrichment after deploy, around half an hour.

## Test plan

- [x] `vitest` — 645 pass, with new cases for a stop in the zone tally and the same stop in decoupling
- [x] `playwright` — 30 pass
- [x] `npm run build`
- [x] Replayed against the real Strava streams for the last 20 runs to measure the actual effect

Made with [Cursor](https://cursor.com)