### PR TITLE
Put all site text back on Inter

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,11 @@ https://github.com/maxeisen/
          up front rather than on first image request. -->
     <link rel="preconnect" href="https://res.cloudinary.com" crossorigin>
     <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin>
+    <!-- Fraunces is no longer used for text anywhere — the only thing left
+         drawing it is the ME monogram (header logo, favicon.svg, logo.svg),
+         which has to match the pre-rendered PNG/ICO icons that
+         scripts/generate_logo_icons.py bakes from this same file. It stays
+         preloaded because that logo is above the fold on every route. -->
     <link rel="preload" href="/fonts/fraunces-latin.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="alternate icon" href="/favicon.ico" sizes="any">
@@ -86,6 +91,7 @@ https://github.com/maxeisen/
             src: url(/fonts/inter-latin.woff2) format("woff2");
             unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
         }
+        /* Monogram only — see the preload note above. */
         @font-face {
             font-family: "Fraunces";
             font-style: normal;

--- a/public/styles/global.css
+++ b/public/styles/global.css
@@ -54,7 +54,6 @@
 
     /* Typography */
     --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-    --font-serif: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
     --font-2xs: 0.7rem;
     --font-xs: 0.8rem;
     --font-sm: 0.9rem;

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -272,9 +272,8 @@ video::-webkit-media-controls-overlay-play-button {
     margin-top: 20px;
     margin-bottom: 10px;
     text-align: left;
-    font-family: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
+    font-family: var(--font-sans);
     font-weight: 600;
-    font-optical-sizing: auto;
     letter-spacing: -0.02em;
 }
 

--- a/src/components/Bach/lib/bach.css
+++ b/src/components/Bach/lib/bach.css
@@ -11,7 +11,7 @@
 }
 
 .host .display {
-	font-family: 'Fraunces', serif;
+	font-family: var(--font-sans);
 	font-weight: 700;
 	letter-spacing: -0.03em;
 	color: var(--header-colour);
@@ -160,7 +160,7 @@
 	opacity: 0.8;
 }
 .host .bar-code-value {
-	font-family: 'Fraunces', serif;
+	font-family: var(--font-sans);
 	font-weight: 700;
 	font-size: 1.6rem;
 	letter-spacing: 0.1em;
@@ -179,7 +179,7 @@
 }
 .host .lobby-join { text-align: center; }
 .host .section-title {
-	font-family: 'Fraunces', serif;
+	font-family: var(--font-sans);
 	font-weight: 600;
 	font-size: 1.4rem;
 	color: var(--header-colour);
@@ -187,7 +187,7 @@
 }
 .host .join-hint { opacity: 0.8; font-size: 0.95rem; margin: 1rem 0 0.5rem; }
 .host .bigcode {
-	font-family: 'Fraunces', serif;
+	font-family: var(--font-sans);
 	font-weight: 700;
 	font-size: clamp(3rem, 9vw, 5.5rem);
 	letter-spacing: 0.18em;
@@ -224,7 +224,7 @@
 	opacity: 0.85;
 }
 .host .join-pw {
-	font-family: 'Fraunces', serif;
+	font-family: var(--font-sans);
 	font-weight: 600;
 	font-size: 1.35rem;
 	color: var(--header-colour);
@@ -285,7 +285,7 @@
 /* --- Centered phases --- */
 .host .centered { text-align: center; max-width: 760px; margin: 4vh auto 0; }
 .host .progress-big {
-	font-family: 'Fraunces', serif; font-weight: 700;
+	font-family: var(--font-sans); font-weight: 700;
 	font-size: clamp(2rem, 6vw, 3.5rem); color: var(--main-green);
 	margin: 0.5rem 0 1.5rem;
 }
@@ -339,7 +339,7 @@
 .host .story-hidden-hint { max-width: 28rem; margin: 0 auto 0.75rem; }
 .host .story-reveal-btn { margin: 0 auto; }
 .host .story-title {
-	font-family: 'Fraunces', serif; font-weight: 700;
+	font-family: var(--font-sans); font-weight: 700;
 	font-size: clamp(2rem, 5vw, 3.2rem); color: var(--header-colour);
 	letter-spacing: -0.02em; margin: 0 0 1.5rem; text-align: center;
 }
@@ -396,7 +396,7 @@
 /* --- Results --- */
 .host .trophy { font-size: clamp(3rem, 10vw, 6rem); line-height: 1; }
 .host .mvp-quote {
-	font-family: 'Fraunces', serif; font-style: italic;
+	font-family: var(--font-sans); font-style: italic;
 	font-size: clamp(1.4rem, 4vw, 2.4rem); color: var(--header-colour); margin: 0.5rem 0;
 	overflow-wrap: anywhere;
 }
@@ -482,7 +482,7 @@
 }
 .player .player-leave:hover { opacity: 1; }
 .player .title {
-	font-family: 'Fraunces', serif;
+	font-family: var(--font-sans);
 	font-weight: 700;
 	font-size: clamp(1.6rem, 7vw, 2.2rem);
 	letter-spacing: -0.02em;

--- a/src/components/Dashboard/SpotifyVizOverlay.svelte
+++ b/src/components/Dashboard/SpotifyVizOverlay.svelte
@@ -212,7 +212,7 @@
         50% { opacity: 1; transform: scale(1.1); }
     }
     .viz-overlay-track {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: clamp(1.3rem, 2.2vw, 2rem);
         line-height: 1.1;

--- a/src/components/Dashboard/widgets/ClockWidget.svelte
+++ b/src/components/Dashboard/widgets/ClockWidget.svelte
@@ -100,7 +100,7 @@
 
 <style>
     .clock-time {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-feature-settings: "tnum";
         font-size: min(clamp(3rem, 12vw, 11rem), 36cqh);
@@ -109,7 +109,7 @@
         color: var(--header-colour);
     }
     .clock-meridiem {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 500;
         font-size: clamp(0.9rem, 1.4vw, 1.4rem);
         margin-left: 0.4em;
@@ -125,7 +125,7 @@
         margin-top: 0.25rem;
     }
     .clock-greeting {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: clamp(1.1rem, 1.9vw, 1.9rem);
         letter-spacing: -0.02em;
@@ -166,7 +166,7 @@
         color: var(--main-green);
     }
     .clock-progress-pct {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: 1rem;
         letter-spacing: -0.02em;

--- a/src/components/Dashboard/widgets/GalleryWidget.svelte
+++ b/src/components/Dashboard/widgets/GalleryWidget.svelte
@@ -90,7 +90,7 @@
         text-shadow: 0 1px 8px rgba(0, 0, 0, 0.6);
     }
     .gallery-cta {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: 1rem;
         color: #fff;

--- a/src/components/Dashboard/widgets/GithubWidget.svelte
+++ b/src/components/Dashboard/widgets/GithubWidget.svelte
@@ -131,7 +131,7 @@
     }
     .github-main :global(*) { text-decoration: none; }
     .github-repo {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: clamp(1rem, 1.25vw, 1.4rem);
         color: var(--header-colour);
@@ -218,7 +218,7 @@
         flex-shrink: 0;
     }
     .github-graph-total {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         color: var(--header-colour);
         font-size: clamp(0.95rem, 1.15vw, 1.25rem);

--- a/src/components/Dashboard/widgets/SpotifyWidget.svelte
+++ b/src/components/Dashboard/widgets/SpotifyWidget.svelte
@@ -274,7 +274,7 @@
         50% { opacity: 1; transform: scale(1.1); }
     }
     .spotify-track {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: clamp(1.1rem, 1.7vw, 1.7rem);
         line-height: 1.15;

--- a/src/components/Dashboard/widgets/StravaWidget.svelte
+++ b/src/components/Dashboard/widgets/StravaWidget.svelte
@@ -184,7 +184,7 @@
     }
     .strava-row-main { flex: 1; min-width: 0; }
     .strava-row-name {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: 1rem;
         color: var(--header-colour);
@@ -205,7 +205,7 @@
         text-align: right;
     }
     .strava-row-stats strong {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         color: var(--header-colour);
         display: block;
@@ -257,7 +257,7 @@
     }
     .strava-ytd-icon { font-size: 0.9rem; }
     .strava-ytd-item strong {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         color: var(--header-colour);
     }

--- a/src/components/Dashboard/widgets/WeatherWidget.svelte
+++ b/src/components/Dashboard/widgets/WeatherWidget.svelte
@@ -232,7 +232,7 @@
         display: flex; flex-direction: column; justify-content: space-between; gap: 0.5rem;
     }
     .weather-temp {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: clamp(2rem, 4vw, 3.5rem);
         line-height: 1;
@@ -292,7 +292,7 @@
     .moon-emoji { font-size: 1.6rem; line-height: 1; }
     .moon-text { display: flex; flex-direction: column; min-width: 0; }
     .moon-name {
-        font-family: 'Fraunces', serif; font-weight: 600;
+        font-family: var(--font-sans); font-weight: 600;
         font-size: 0.95rem;
         color: var(--header-colour);
         letter-spacing: -0.01em;

--- a/src/components/Gallery/Gallery.svelte
+++ b/src/components/Gallery/Gallery.svelte
@@ -442,9 +442,8 @@
     }
 
     h1 {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
-        font-optical-sizing: auto;
         font-size: clamp(2rem, 4vw, 3.5rem);
         letter-spacing: -0.03em;
         margin: 0;

--- a/src/components/Gallery/GalleryFilters.svelte
+++ b/src/components/Gallery/GalleryFilters.svelte
@@ -171,7 +171,7 @@
     }
     .group-title {
         margin: 0;
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: 1rem;
         letter-spacing: -0.01em;

--- a/src/components/Home/layout/ModalProvider.svelte
+++ b/src/components/Home/layout/ModalProvider.svelte
@@ -134,9 +134,8 @@
 	   under different class names — these consolidate the duplicates.
 	   =================================================================== */
 	:global(.modal-title) {
-		font-family: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
+		font-family: var(--font-sans);
 		font-weight: 600;
-		font-optical-sizing: auto;
 		letter-spacing: -0.02em;
 		font-size: 35px;
 		margin: 15px 15px 10px 15px;

--- a/src/components/Home/modals/ActivityModal.svelte
+++ b/src/components/Home/modals/ActivityModal.svelte
@@ -142,7 +142,7 @@
     }
 
     :global(.activity-modal .strava-profile-ytd-stats strong) {
-        font-family: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: 1rem;
         letter-spacing: -0.01em;

--- a/src/components/Home/sections/Intro.svelte
+++ b/src/components/Home/sections/Intro.svelte
@@ -256,9 +256,8 @@
         margin-top: 10px;
         margin-bottom: 10px;
         text-align: left;
-        font-family: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
-        font-optical-sizing: auto;
         letter-spacing: -0.02em;
     }
 

--- a/src/components/Home/sections/Profile.svelte
+++ b/src/components/Home/sections/Profile.svelte
@@ -34,9 +34,8 @@
 
 <style>
     .profile-name {
-        font-family: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
-        font-optical-sizing: auto;
         letter-spacing: -0.025em;
     }
 

--- a/src/components/Home/widgets/StravaActivityList.svelte
+++ b/src/components/Home/widgets/StravaActivityList.svelte
@@ -196,7 +196,7 @@
     }
 
     .strava-row-stats strong {
-        font-family: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: 1rem;
         letter-spacing: -0.01em;

--- a/src/components/Toronto/PinPanel.svelte
+++ b/src/components/Toronto/PinPanel.svelte
@@ -59,7 +59,7 @@
     }
 
     .pin-panel-name {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         font-size: 1.55rem;
         line-height: 1.2;

--- a/src/components/Toronto/Toronto.svelte
+++ b/src/components/Toronto/Toronto.svelte
@@ -168,7 +168,7 @@
         max-width: calc(100vw - 7rem);
     }
     .toronto-header h1 {
-        font-family: 'Fraunces', serif;
+        font-family: var(--font-sans);
         font-weight: 600;
         letter-spacing: -0.02em;
         font-size: 1.1rem;

--- a/src/components/Training/sections/IntensityMix.svelte
+++ b/src/components/Training/sections/IntensityMix.svelte
@@ -122,7 +122,7 @@
     .dot-hard { background: var(--tone-bad); }
     .legend-label { opacity: 0.75; }
     .legend strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         color: var(--header-colour);
     }
     .legend-time { opacity: 0.55; }

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -499,7 +499,7 @@
 
     .title {
         display: block;
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-lg);
         font-weight: 600;
         color: var(--header-colour);
@@ -537,7 +537,7 @@
     }
     .stat { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
     .stat strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 700;
         color: var(--header-colour);
@@ -663,7 +663,7 @@
         opacity: 0.7;
     }
     .change strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 700;
         color: var(--header-colour);
@@ -697,7 +697,7 @@
     }
     dd {
         margin: 0;
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/LoadRisk.svelte
+++ b/src/components/Training/sections/LoadRisk.svelte
@@ -98,7 +98,7 @@
         line-height: 1.1;
     }
     .gauge-value strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-2xl);
         font-weight: 700;
         letter-spacing: -0.03em;
@@ -170,7 +170,7 @@
     }
     dd {
         margin: 0;
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/RaceHeader.svelte
+++ b/src/components/Training/sections/RaceHeader.svelte
@@ -120,7 +120,7 @@
         margin: 0 0 var(--space-2) 0;
     }
     h1 {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: clamp(2rem, 6vw, 3.2rem);
         font-weight: 700;
         letter-spacing: -0.03em;
@@ -147,7 +147,7 @@
         line-height: 1;
     }
     .countdown-value {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: clamp(2.5rem, 8vw, 4rem);
         font-weight: 700;
         letter-spacing: -0.04em;
@@ -196,7 +196,7 @@
         color: var(--main-green);
     }
     .stat-value {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-xl);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/RacePrediction.svelte
+++ b/src/components/Training/sections/RacePrediction.svelte
@@ -76,7 +76,7 @@
         line-height: 1.05;
     }
     .projected strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: clamp(2rem, 6vw, 2.8rem);
         font-weight: 700;
         letter-spacing: -0.03em;
@@ -117,7 +117,7 @@
         color: var(--main-green);
     }
     .model strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/Recommendations.svelte
+++ b/src/components/Training/sections/Recommendations.svelte
@@ -238,14 +238,14 @@
     }
 
     .rec-metric {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-xs);
         color: var(--paragraph-colour);
         opacity: 0.7;
         white-space: nowrap;
     }
     h3 {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/Recovery.svelte
+++ b/src/components/Training/sections/Recovery.svelte
@@ -197,7 +197,7 @@
         line-height: 1.1;
     }
     .value strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-2xl);
         font-weight: 700;
         letter-spacing: -0.03em;
@@ -267,7 +267,7 @@
     }
     dd {
         margin: 0;
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/RunLog.svelte
+++ b/src/components/Training/sections/RunLog.svelte
@@ -163,7 +163,7 @@
     .row-main { flex: 1; min-width: 0; }
     .row-name {
         display: block;
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-sm);
         font-weight: 600;
         color: var(--header-colour);
@@ -201,7 +201,7 @@
         text-align: right;
     }
     .row-stat strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-sm);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/SyncNotice.svelte
+++ b/src/components/Training/sections/SyncNotice.svelte
@@ -71,7 +71,7 @@
     }
     strong {
         display: block;
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-sm);
         font-weight: 600;
         color: var(--header-colour);

--- a/src/components/Training/sections/WeekPlan.svelte
+++ b/src/components/Training/sections/WeekPlan.svelte
@@ -171,7 +171,7 @@
         color: var(--main-green);
     }
     .metric-head strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-size: var(--font-md);
         font-weight: 600;
         color: var(--header-colour);
@@ -220,7 +220,7 @@
         color: var(--main-green);
     }
     .long-run strong {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-weight: 600;
         color: var(--header-colour);
     }
@@ -284,7 +284,7 @@
         text-overflow: ellipsis;
         white-space: nowrap;
     }
-    .day-km { font-family: var(--font-serif); text-align: right; white-space: nowrap; }
+    .day-km { font-family: var(--font-sans); text-align: right; white-space: nowrap; }
     .day-km strong { color: var(--main-green); font-weight: 600; }
     .day.done .day-km strong { color: var(--tone-good); }
     .day.extra .day-km strong { color: var(--header-colour); }
@@ -337,7 +337,7 @@
     }
     dd {
         margin: 0;
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-weight: 600;
         color: var(--header-colour);
     }
@@ -372,7 +372,7 @@
     }
     .week-date { flex: 1; opacity: 0.75; }
     .week-km {
-        font-family: var(--font-serif);
+        font-family: var(--font-sans);
         font-weight: 600;
         color: var(--header-colour);
     }

--- a/src/lib/ui/Card.svelte
+++ b/src/lib/ui/Card.svelte
@@ -116,7 +116,7 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-2);
-		font-family: var(--font-serif);
+		font-family: var(--font-sans);
 		font-size: var(--font-lg);
 		font-weight: 600;
 		color: var(--header-colour);

--- a/src/lib/ui/GateOverlay.svelte
+++ b/src/lib/ui/GateOverlay.svelte
@@ -75,7 +75,7 @@
 		gap: 0.8rem;
 	}
 	.gate-title {
-		font-family: var(--font-serif);
+		font-family: var(--font-sans);
 		font-weight: 700;
 		font-size: 1.7rem;
 		letter-spacing: -0.02em;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reverts the Fraunces display serif. Every piece of text on the site is Inter again.

## What changed

`--font-serif` is gone from the design tokens, and all 60 declarations that used it (or hardcoded a `'Fraunces', … serif` stack) now point at `--font-sans`. That covers the home section titles and profile name, modal titles, the shared `Card`/`GateOverlay` primitives, all of `/training`, all the `/dashboard` widgets and the Spotify viz overlay, `/gallery` headers and filters, `/toronto`, and the `/bach` host + player screens.

Only the typeface changes. The `font-weight`, `font-size` and negative `letter-spacing` values each rule paired with the serif are untouched, so the type hierarchy and layout stay put. The five `font-optical-sizing: auto` lines are removed — they were there for the Fraunces `opsz` axis, and `auto` is the CSS default regardless.

## What deliberately did not change

**The ME monogram is still Fraunces.** It's a logo mark, not text: it's drawn in `MenuBar.svelte`, `public/favicon.svg` and `public/img/logo.svg`, and it has to match the PNG/ICO icons that `scripts/generate_logo_icons.py` bakes from that same woff2. So `fonts/fraunces-latin.woff2`, its `@font-face` and its preload all stay, now with a comment in `index.html` saying why, so the font-face doesn't read as dead weight. If you'd rather the monogram were Inter too, that's a small follow-up: repoint the three SVGs and rerun the icon script, then the font file and its preload can go (~67 kB).

Two smaller judgment calls worth a look:

- Weight coverage differs. The self-hosted Inter declares 300/400/600; Fraunces declared 500–700. Rules asking for 700 (Bach's `.progress-big`, `.story-title`, the training `h1`s) now resolve to the 600 face, and `.clock-meridiem`'s 500 resolves to 400. Both render fine, just marginally lighter than the serif was.
- Declarations rather than deletions. Many of these rules only existed to override the body font, so they're now redundant with what they'd inherit. I pointed them at the token instead of deleting them: it's safe for elements that don't inherit `font-family` (form controls), and it keeps the display-role call sites visible if you ever reintroduce a display face. Happy to strip them if you'd prefer the smaller stylesheet.

`public/content/blog/sense-of-design.md` needed no edit — it already says the site's font is Inter, "from headers to paragraphs", which is true again.

## Testing

`npm run build` succeeds and `npm run test:run` passes (645 tests, 44 files). `npm run lint` reports one pre-existing error, an unused import in `src/components/Training/lib/balance.test.js`, untouched by this change.

Checked the production build in a browser: the home page name and section titles, the experience/project modal titles, the dashboard clock, greeting, temperature and widget headings, and the `/gallery` heading all render sans-serif, with the ME monogram still serif and no clipped or overflowing text anywhere. `/training` couldn't be judged visually — with no API credentials locally it only renders its error state — but its rules all went through the shared token, and the built CSS confirms it: no compiled stylesheet in `dist/` mentions `Fraunces` or `--font-serif` any more, and the only remaining references in the output are the monogram SVGs and the `@font-face` that feeds them.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb5a-fcda-7d1a-9222-ef097afa5866?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb5a-fcda-7d1a-9222-ef097afa5866&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

