### PR TITLE
Read the ring against the training, not beside it

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,42 @@ change. Two consequences:
 - If the sync logs `Oura auth failed`, re-run the script rather than debugging
   the code. That is the designed recovery path.
 
+### Recovery and the fitness model
+
+Sleep and overnight heart rate stay **out** of CTL, ATL and form, permanently.
+Both traces are exponential averages of the same daily load, which is the only
+reason form settles around zero and "+5 is fresh, −20 is buried" means
+anything; feeding a second source into part of that system pushes form
+permanently negative by roughly the daily load of whatever the extra source was
+(this was tried with rides, and reverted — see `_shared/training/fitness.js`).
+
+What the two sources are allowed to do is meet in time, in
+`_shared/training/response.js`, which is read by `metrics.js` and by nothing
+else:
+
+- **The night after a run** (`nightAfterDay`) — sleep, resting heart rate and
+  HRV from the morning after, each against that athlete's own 28-day baseline,
+  attached to the Last run panel. Every other number on that panel is computed
+  from the run itself, so between them they can only repeat what the training
+  log already knew. On the morning of a run there is no night after it yet, so
+  the panel falls back to `nightBeforeDay`: not what the run cost, but what you
+  took into it.
+- **What a hard day costs** (`overnightCost`) — the nights after the hardest
+  third of the block's running days against the nights after everything else,
+  compared on medians, plus how many nights the heart rate takes to come back
+  down. A dose-response curve measured on one athlete rather than assumed.
+- **Form against the markers** (`strainSignal`) — form comes from load alone,
+  so on its own it can only report back what you told it. The overnight numbers
+  are an independent answer to the same question, and the two disagreements are
+  what's worth printing: deep form with markers at baseline is a body absorbing
+  the block, and raised markers with no load behind them are usually illness,
+  travel or short nights. It reaches the Recovery panel and the wording of
+  three recommendation rules; it moves no metric.
+
+The separation is asserted, not just documented: `metrics.test.js` builds the
+same block with and without a ring and requires every training number to be
+identical.
+
 ### Design tokens & theming
 
 `public/styles/global.css` is the single source of truth for design tokens —

--- a/e2e/fixtures/trainingPayload.js
+++ b/e2e/fixtures/trainingPayload.js
@@ -9,6 +9,7 @@
 
 import { shapeActivities } from "../../netlify/functions/_shared/training/shape.js";
 import { buildDashboard } from "../../netlify/functions/_shared/training/metrics.js";
+import { dailyLoads } from "../../netlify/functions/_shared/training/load.js";
 import { loadPlan } from "../../netlify/functions/_shared/training/planFile.js";
 
 // Strava's field names are quoted throughout: they're the API's spelling rather
@@ -70,25 +71,38 @@ function streamsFor({ distance, movingTime, averageHr, next }) {
 	return { time, distance: distanceStream, heartrate, "grade_smooth": grade };
 }
 
-// A month of nights, already shaped the way the sync stores them. Enough for
+// Six weeks of nights, already shaped the way the sync stores them. Enough for
 // the baselines to exist, and varied enough that the panel's chart has
 // something to draw and at least one night falls under the seven-hour line —
 // a fixture of identical perfect nights would pass a rendering test while
 // hiding whether the "short night" case draws at all.
-function nightsUpTo(today, next) {
+//
+// Each night answers to the day before it, because the panel now measures
+// exactly that: what a hard day costs overnight, read off this athlete rather
+// than assumed (see _shared/training/response.js). Nights generated
+// independently of the running would draw a dose-response curve of pure noise
+// and prove nothing about whether the alignment works.
+function nightsUpTo(today, next, loads) {
 	const end = new Date(`${today}T00:00:00Z`);
-	return Array.from({ length: 28 }, (_, i) => {
+	return Array.from({ length: 42 }, (_, i) => {
 		const day = new Date(end);
-		day.setUTCDate(day.getUTCDate() - (27 - i));
-		const sleepSec = Math.round((6.2 + next() * 2.2) * 3600);
+		day.setUTCDate(day.getUTCDate() - (41 - i));
+		const before = new Date(day);
+		before.setUTCDate(before.getUTCDate() - 1);
+		// Nothing subtle: a long run costs the better part of an hour of sleep
+		// and puts four beats on the overnight heart rate, tailing off over
+		// the day after.
+		const strain = Math.min(1, (loads.get(before.toISOString().slice(0, 10)) || 0) / 110);
+
 		return {
 			day: day.toISOString().slice(0, 10),
-			sleepSec,
+			sleepSec: Math.round((7.6 - 1.1 * strain + next() * 0.6) * 3600),
 			efficiencyPct: Math.round(86 + next() * 8),
-			restingHr: Math.round(45 + next() * 5),
-			averageHrv: Math.round(55 + next() * 20),
+			restingHr: Math.round(45 + 4 * strain + next() * 2),
+			averageHrv: Math.round(68 - 12 * strain + next() * 6),
 			sleepScore: Math.round(70 + next() * 22),
 			readinessScore: Math.round(70 + next() * 22),
+			temperatureDeviationC: Number(((next() - 0.5) * 0.6).toFixed(1)),
 		};
 	});
 }
@@ -177,17 +191,22 @@ export function buildTrainingFixture({ today = "2026-08-11" } = {}) {
 		});
 	}
 
+	// Streams are per-activity here, where the real sync fetches them one run
+	// at a time; shapeActivities takes one set for the batch, so shape each run
+	// with its own.
+	const activities = raw
+		.map(({ streams, ...activity }) =>
+			shapeActivities([activity], { streams, thresholds: plan.thresholds })[0])
+		.filter(Boolean);
+
 	return {
 		...buildDashboard({
-			// Streams are per-activity here, where the real sync fetches them
-			// one run at a time; shapeActivities takes one set for the batch,
-			// so shape each run with its own.
-			activities: raw
-				.map(({ streams, ...activity }) =>
-					shapeActivities([activity], { streams, thresholds: plan.thresholds })[0])
-				.filter(Boolean),
+			activities,
 			plan,
-			recovery: nightsUpTo(today, next),
+			// Rides are excluded from the load the nights answer to for the
+			// same reason they're excluded everywhere else: this page is about
+			// running, and a Saturday on the bike costs the page nothing.
+			recovery: nightsUpTo(today, next, dailyLoads(activities.filter((a) => a.sport !== "ride"))),
 			today,
 		}),
 		sync: { lastRunAt: `${today}T12:00:00.000Z`, hasSynced: true, outstanding: 0, backfilling: false },

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -82,10 +82,59 @@ test("recovery is reported beside the training, not inside it", async ({ page })
 	await expect(panel.getByText("average night, last 7")).toBeVisible();
 
 	// The measures that carry the argument: an overnight resting rate and a
-	// variability figure, each against the athlete's own baseline.
-	await expect(panel.getByText("Resting HR")).toBeVisible();
-	await expect(panel.getByText("HRV")).toBeVisible();
+	// variability figure, each against the athlete's own baseline. Scoped to
+	// the summary list, since the panel now reports the same two measures
+	// again as what a hard day does to them.
+	const detail = panel.locator(".detail");
+	await expect(detail.getByText("Resting HR")).toBeVisible();
+	await expect(detail.getByText("HRV")).toBeVisible();
 	await expect(panel.locator(".bar").first()).toBeVisible();
+});
+
+// Beside the training is not the same as unrelated to it. The one thing the
+// ring can do that the training log can't is answer what a hard day actually
+// costs this athlete, and that only exists once nights are lined up with the
+// days before them.
+test("recovery says what a hard day costs, in the athlete's own numbers", async ({ page }) => {
+	await page.goto("/training");
+	const panel = page.locator("section.card").filter({ hasText: "Recovery" }).first();
+	const cost = panel.locator(".cost");
+
+	await expect(cost.getByRole("heading", { name: "What a hard day costs you" })).toBeVisible();
+	// Signed deltas against the nights after everything else, not absolutes.
+	await expect(cost.locator("dd").first()).toHaveText(/^[+-]\d+ min$/);
+	await expect(cost.getByText(/[+-]\d+ bpm/)).toBeVisible();
+	// How long it takes to come back, which is the number you'd plan around.
+	await expect(cost.getByText(/back down by the (next|second) night/)).toBeVisible();
+});
+
+test("the last run carries the night either side of it", async ({ page }) => {
+	await page.goto("/training");
+	const panel = page.locator("section.card").filter({ hasText: "Last run" }).first();
+	const night = panel.locator(".night");
+
+	// The fixture's last run is this morning's, so the night after it hasn't
+	// happened and the panel reports the one it started from instead.
+	await expect(night).toContainText("Went into it on");
+	await expect(night).toContainText(/\d+h \d+m/);
+	await expect(night).toContainText(/\d+ bpm resting/);
+	await expect(night).toContainText("against your own month");
+});
+
+test("form is read against the body, not only against the training log", async ({ page }) => {
+	// Form is derived from load alone, so a fixture that trains normally never
+	// reaches the states worth printing. The classification itself is covered
+	// in the engine's unit tests; this is about the sentence appearing.
+	const payload = buildTrainingFixture();
+	payload.recovery.response.strain = { state: "absorbing", tsb: -31, restingHrUp: false, hrvDown: false };
+	await page.route("**/.netlify/functions/trainingData*", (route) =>
+		route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(payload) }),
+	);
+
+	await page.goto("/training");
+	const panel = page.locator("section.card").filter({ hasText: "Recovery" }).first();
+	await expect(panel.locator(".verdict")).toContainText("absorbing a heavy block");
+	await expect(panel.locator(".verdict")).toContainText("-31");
 });
 
 test("the last run is reported with what it did to the training", async ({ page }) => {

--- a/netlify/functions/_shared/training/fitness.js
+++ b/netlify/functions/_shared/training/fitness.js
@@ -38,6 +38,11 @@ export const ACWR_CEILING = 1.5;
 // The conventional cap on week-over-week volume growth.
 export const SAFE_RAMP_PCT = 10;
 
+// Form below this is accumulated fatigue rather than productive training. It
+// lives here rather than with the advice that acts on it because it's a
+// property of the form scale itself, and two modules now read form against it.
+export const TSB_FATIGUE = -25;
+
 const asMap = (loads) => (loads instanceof Map ? loads : new Map(Object.entries(loads || {})));
 
 /**

--- a/netlify/functions/_shared/training/lastRun.js
+++ b/netlify/functions/_shared/training/lastRun.js
@@ -14,6 +14,7 @@
 
 import { addDays, daysBetween, toDayKey } from "./dates.js";
 import { publicLastRun, WHOLE_SPLIT_M } from "./shape.js";
+import { median } from "./stats.js";
 import { classifyByPace } from "./zones.js";
 
 // How far back "a typical run for you" reaches. Six weeks holds a few long runs
@@ -30,17 +31,6 @@ const MODERATE_SHARE_PCT = 35;
 const number = (value) => Number(value) || 0;
 const finite = (value) => (Number.isFinite(value) ? value : null);
 const sum = (values) => values.reduce((total, v) => total + number(v), 0);
-
-function median(values) {
-	if (values.length === 0) {
-		return null;
-	}
-	const sorted = [...values].sort((a, b) => a - b);
-	const mid = Math.floor(sorted.length / 2);
-	const lower = sorted.at(mid - 1);
-	const upper = sorted.at(mid);
-	return sorted.length % 2 ? upper : (lower + upper) / 2;
-}
 
 /**
  * What the day's running did to fitness, fatigue and form.

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -25,6 +25,7 @@ import {
 } from "./plan.js";
 import { recommendations } from "./recommend.js";
 import { recoverySummary } from "./recovery.js";
+import { nightAfterDay, nightBeforeDay, overnightCost, strainSignal } from "./response.js";
 import { toDayKey } from "./dates.js";
 
 // How far back the intensity distribution looks. A whole block averages away
@@ -162,9 +163,21 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 
 	// Deliberately computed after everything above it and read by none of it.
 	// Recovery is the one input here that isn't training load, and the fitness
-	// model stays a closed system fed only by load — see recovery.js. It
-	// reaches the payload and the recommendations, and nothing else.
+	// model stays a closed system fed only by load — see recovery.js.
 	const recovered = recoverySummary(recovery, { today: day });
+
+	// The two sources meet here and nowhere else, which is the whole point of
+	// this file. Reading them against each other costs the separation nothing:
+	// every number above is already final, and what response.js adds is the
+	// alignment between a training day and the night that followed it — what a
+	// hard day actually costs this athlete, and whether the body agrees with
+	// the training log about how tired it is.
+	const response = recovered
+		? {
+				hardDays: overnightCost({ records: recovery, series, today: day }),
+				strain: strainSignal({ tsb: latest?.tsb ?? null, recovery: recovered }),
+			}
+		: null;
 
 	const prediction = predictRace(collectBestEfforts(runs), race.distanceM || 42195);
 	const goalPace = goalPaceSecPerKm(race.goalTimeSec, race.distanceM || 42195);
@@ -178,6 +191,15 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 	// falls outside the log would otherwise let its second run claim the
 	// session the first one already did.
 	const planMatches = matchRunsToPlan(runs, plan);
+
+	const lastRun = lastRunDetail({
+		runs,
+		series,
+		weeks,
+		planMatch: planMatches.at(-1) ?? null,
+		thresholds,
+		today: day,
+	});
 
 	const remainingDays = daysToRace(plan, day);
 	const totals = runs.reduce(
@@ -279,6 +301,10 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		daysToRace: remainingDays,
 		longRunDecouplingPct: lastLongRun?.decouplingPct ?? null,
 		recovery: recovered,
+		// Form on its own can only repeat what the training log told it. This
+		// is whether the body's own markers agree, which is the difference
+		// between "you're absorbing a big block" and "stop".
+		strain: response?.strain ?? null,
 	});
 
 	return {
@@ -295,7 +321,7 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		efficiency: { points: efficiency.points, trend: efficiency.trend },
 		// Null rather than an empty shell when the ring has nothing to say, so
 		// the panel can be absent instead of drawing a row of dashes.
-		recovery: recovered,
+		recovery: recovered ? { ...recovered, response } : null,
 		weeks,
 		week: current
 			? {
@@ -310,14 +336,18 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		recommendations: advice,
 		// The freshest run, read against the athlete's own recent history —
 		// the one panel that's about a single session rather than a trend.
-		lastRun: lastRunDetail({
-			runs,
-			series,
-			weeks,
-			planMatch: planMatches.at(-1) ?? null,
-			thresholds,
-			today: day,
-		}),
+		// The nights either side of it are attached here rather than inside
+		// lastRun.js, which keeps that module about the running: this file is
+		// where the two sources are allowed to meet. The night after is what
+		// the run cost and the night before is what you took into it — and on
+		// the morning of a run only the second one exists yet.
+		lastRun: lastRun
+			? {
+					...lastRun,
+					night: nightAfterDay(recovery, lastRun.date),
+					nightBefore: nightBeforeDay(recovery, lastRun.date),
+				}
+			: null,
 		// The log carries its plan match so the page can say which runs were
 		// the plan and which were extra. The match comes from the plan file
 		// rather than from Strava, so it adds nothing to what publicRun()

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -604,6 +604,111 @@ describe("buildDashboard with recovery", () => {
 	});
 });
 
+// The one place the two sources are read against each other. Everything above
+// still holds — no training number moves — but a training day and the night
+// that followed it are finally lined up, which is the only way to answer what
+// a hard day costs this athlete or whether the body agrees with the log.
+describe("where the ring meets the training", () => {
+	const hours = (h) => Math.round(h * 3600);
+	const today = "2026-08-11";
+	const isHard = (back) => back % 3 === 1;
+
+	const SESSION = { name: "Session", distanceM: 20000, movingTimeSec: 6600, elapsedTimeSec: 6700, averageHr: 162, load: 130 };
+	const EASY = { name: "Easy run", distanceM: 10000, movingTimeSec: 3300, elapsedTimeSec: 3400, averageHr: 136, load: 45 };
+
+	// A month of running to yesterday, every third day a session.
+	const runs = Array.from({ length: 30 }, (_, i) => {
+		const back = 30 - i;
+		return {
+			id: 3000 + i,
+			type: "Run",
+			startDateLocal: `${addDays(today, -back)}T07:00:00`,
+			elevationGainM: 30,
+			paceSecPerKm: 330,
+			gapPaceSecPerKm: 330,
+			splits: [],
+			bestEfforts: [],
+			...(isHard(back) ? SESSION : EASY),
+		};
+	});
+
+	// Nights to match: the one after a session is short with the heart rate up.
+	const nights = (patch = () => ({})) =>
+		Array.from({ length: 40 }, (_, i) => {
+			const back = 39 - i;
+			const afterHard = isHard(back + 1);
+			return {
+				day: addDays(today, -back),
+				sleepSec: afterHard ? hours(6.5) : hours(7.5),
+				restingHr: afterHard ? 51 : 46,
+				averageHrv: afterHard ? 55 : 64,
+				...patch(back),
+			};
+		});
+
+	const dashboard = (patch) =>
+		buildDashboard({ activities: runs, plan: PLAN, today, recovery: nights(patch) });
+
+	it("attaches the night after the last run to the run itself", () => {
+		const night = dashboard().lastRun.night;
+		expect(night.day).toBe(today);
+		expect(night.sleep.value).toBe(hours(6.5));
+		// Against the athlete's own month, which is what makes it readable.
+		expect(night.restingHr.delta).toBeGreaterThan(2);
+	});
+
+	it("falls back to the night the run started from", () => {
+		// On the morning of a run there is no night after it yet, and the one
+		// it started from is the half of the question that does exist.
+		const out = buildDashboard({
+			activities: runs,
+			plan: PLAN,
+			today,
+			recovery: nights().filter((n) => n.day !== today),
+		});
+		expect(out.lastRun.night).toBeNull();
+		expect(out.lastRun.nightBefore.day).toBe(addDays(today, -1));
+	});
+
+	it("says what a hard day costs, measured rather than assumed", () => {
+		const hard = dashboard().recovery.response.hardDays;
+		expect(hard.afterHard.nights).toBe(10);
+		expect(hard.sleepDeltaSec).toBe(-hours(1));
+		expect(hard.restingHrDelta).toBe(5);
+		expect(hard.hrvDelta).toBe(-9);
+		expect(hard.nightsToBaseline).toBe(2);
+	});
+
+	it("reads form against the body's own markers", () => {
+		const out = dashboard((back) => (back < 7 ? { restingHr: 56 } : {}));
+		const strain = out.recovery.response.strain;
+		expect(strain.restingHrUp).toBe(true);
+		// The same form the rest of the page reports, not a second opinion
+		// about the training.
+		expect(strain.tsb).toBe(out.summary.latest.tsb);
+	});
+
+	it("carries that attribution into the advice", () => {
+		const out = dashboard((back) => (back < 7 ? { restingHr: 56 } : {}));
+		const rhr = out.recommendations.find((r) => r.id === "rhr-elevated");
+		expect(rhr.detail).toMatch(/doesn't explain it|consistent with the block/);
+	});
+
+	it("still moves no training number", () => {
+		const withRing = dashboard();
+		const without = buildDashboard({ activities: runs, plan: PLAN, today });
+		expect(withRing.series).toEqual(without.series);
+		expect(withRing.summary).toEqual(without.summary);
+		expect(withRing.lastRun.impact).toEqual(without.lastRun.impact);
+	});
+
+	it("leaves the run itself alone when there's no ring at all", () => {
+		const out = buildDashboard({ activities: runs, plan: PLAN, today });
+		expect(out.lastRun.night).toBeNull();
+		expect(out.recovery).toBeNull();
+	});
+});
+
 describe("legacy records", () => {
 	it("treats a record with no sport as a run, as every stored one is", () => {
 		// Everything already in Blobs was written before rides were tracked,

--- a/netlify/functions/_shared/training/recommend.js
+++ b/netlify/functions/_shared/training/recommend.js
@@ -11,7 +11,7 @@
 // modes that ruin a marathon build are ramping too fast, running easy days too
 // hard, and skipping the taper; none of those are fixed by working harder.
 
-import { ACWR_CEILING, ACWR_FLOOR, SAFE_RAMP_PCT } from "./fitness.js";
+import { ACWR_CEILING, ACWR_FLOOR, SAFE_RAMP_PCT, TSB_FATIGUE } from "./fitness.js";
 import { EASY_SHARE_TARGET } from "./zones.js";
 import { HRV_DROP_PCT, RHR_RISE_BPM, SLEEP_TARGET_SEC } from "./recovery.js";
 
@@ -19,8 +19,6 @@ import { HRV_DROP_PCT, RHR_RISE_BPM, SLEEP_TARGET_SEC } from "./recovery.js";
 // that make you slower.
 const SEVERITY_RANK = { critical: 0, warning: 1, info: 2, good: 3 };
 
-// Form below this suggests accumulated fatigue rather than productive training.
-const TSB_FATIGUE = -25;
 // A long run beyond this share of weekly volume is a week built around one run.
 const LONG_RUN_SHARE_CEILING = 35;
 // Aerobic decoupling above this on a long run points to endurance not yet built.
@@ -64,6 +62,59 @@ function rule(id, severity, title, detail, metric, threshold, unit = null) {
 	return { id, severity, title, detail, metric, threshold, ...(unit ? { unit } : {}) };
 }
 
+/** Whichever overnight markers are currently raising a hand. */
+function markersOf(strain) {
+	const said = [];
+	if (strain?.restingHrUp) {
+		said.push("your overnight heart rate is up on baseline");
+	}
+	if (strain?.hrvDown) {
+		said.push("HRV is below it");
+	}
+	return said.join(" and ");
+}
+
+/**
+ * What the ring has to say about a form number.
+ *
+ * Form is computed from the training log and nothing else, so it can only ever
+ * report back what you already told it: run a lot and it goes negative,
+ * whether or not you're coping. An overnight heart rate is an independent
+ * measurement of the same question, and it's the disagreements that are worth
+ * printing — the same −28 means "this is landing" or "stop" depending on it.
+ */
+function secondOpinion(strain) {
+	if (strain?.state === "absorbing") {
+		return " Your overnight heart rate and HRV are both at baseline, though, which is your body saying it's absorbing this. Form is derived from the training log alone — it can only tell you what you already told it.";
+	}
+	if (strain?.state === "buried") {
+		return ` Your body agrees: ${markersOf(strain)}. That's the version of this worth acting on rather than training through.`;
+	}
+	return "";
+}
+
+/** The temperature clause, on the rules where it's corroborating something. */
+function temperatureNote(strain) {
+	if (!strain?.temperatureUp) {
+		return "";
+	}
+	return ` Your skin temperature is ${strain.temperatureDeviationC.toFixed(1)} °C above your own normal, which points the same way.`;
+}
+
+/**
+ * Whether the training explains a raised marker — the question the training
+ * log can't answer about itself.
+ */
+function explainedBy(strain) {
+	if (strain?.state === "unexplained") {
+		return ` Your form is ${strain.tsb.toFixed(0)}, so the training doesn't explain it: a rise with no load behind it is more often illness, travel, or a run of short nights than it is the running.${temperatureNote(strain)}`;
+	}
+	if (strain?.state === "buried") {
+		return ` Form is ${strain.tsb.toFixed(0)} as well, so this is consistent with the block you're in — the thing to watch is whether it lifts when you ease off.${temperatureNote(strain)}`;
+	}
+	return "";
+}
+
 /**
  * Build the ranked recommendation list.
  *
@@ -83,6 +134,7 @@ export function recommendations(metrics) {
 		daysToRace = null,
 		longRunDecouplingPct = null,
 		recovery = null,
+		strain = null,
 	} = metrics || {};
 
 	// --- Injury risk -------------------------------------------------------
@@ -133,7 +185,7 @@ export function recommendations(metrics) {
 				"tsb-fatigued",
 				"warning",
 				"You're carrying deep fatigue",
-				`Form is ${latest.tsb.toFixed(0)}, below ${TSB_FATIGUE}. That's normal in a heavy block but not somewhere to live. If it doesn't lift within a week, take two genuinely easy days.`,
+				`Form is ${latest.tsb.toFixed(0)}, below ${TSB_FATIGUE}. That's normal in a heavy block but not somewhere to live. If it doesn't lift within a week, take two genuinely easy days.${secondOpinion(strain)}`,
 				latest.tsb,
 				TSB_FATIGUE,
 			),
@@ -236,7 +288,7 @@ export function recommendations(metrics) {
 				"rhr-elevated",
 				"warning",
 				"Your overnight heart rate is up",
-				`Averaging ${restingHr.recent.toFixed(0)} bpm over the last week against a ${restingHr.baseline.toFixed(0)} bpm baseline, up ${restingHr.delta.toFixed(0)}. A rise of ${RHR_RISE_BPM} or more usually means something the training log can't see: illness coming on, or work you haven't absorbed yet. Worth an easy few days before a key session rather than after one.`,
+				`Averaging ${restingHr.recent.toFixed(0)} bpm over the last week against a ${restingHr.baseline.toFixed(0)} bpm baseline, up ${restingHr.delta.toFixed(0)}. A rise of ${RHR_RISE_BPM} or more usually means something the training log can't see: illness coming on, or work you haven't absorbed yet.${explainedBy(strain)} Worth an easy few days before a key session rather than after one.`,
 				restingHr.delta,
 				RHR_RISE_BPM,
 				"bpm",
@@ -250,7 +302,10 @@ export function recommendations(metrics) {
 				"hrv-suppressed",
 				"info",
 				"Heart-rate variability is below your baseline",
-				`${hrv.recent.toFixed(0)} ms over the last week against a ${hrv.baseline.toFixed(0)} ms baseline, down ${Math.abs(hrv.deltaPct).toFixed(0)}%. HRV is noisy night to night and this is a week against a month, so it's worth noting rather than acting on alone — but read it alongside the resting heart rate above.`,
+				// The attribution is only added when HRV is the one marker
+				// raising a hand; otherwise the heart-rate rule above has
+				// already said it, in the same words.
+				`${hrv.recent.toFixed(0)} ms over the last week against a ${hrv.baseline.toFixed(0)} ms baseline, down ${Math.abs(hrv.deltaPct).toFixed(0)}%. HRV is noisy night to night and this is a week against a month, so it's worth noting rather than acting on alone — but read it alongside the resting heart rate above.${strain?.restingHrUp ? "" : explainedBy(strain)}`,
 				hrv.deltaPct,
 				-HRV_DROP_PCT,
 				"percent",

--- a/netlify/functions/_shared/training/recommend.test.js
+++ b/netlify/functions/_shared/training/recommend.test.js
@@ -261,6 +261,83 @@ describe("recommendations", () => {
 		});
 	});
 
+	// Form is computed from the training log alone, so on its own it can only
+	// repeat what you already told it. These read it against a measurement it
+	// has no access to, and the disagreements are the point.
+	describe("form against the body's own markers", () => {
+		const up = { recovery: { restingHr: { recent: 54, baseline: 47, delta: 7 } } };
+
+		it("tells deep form that the body is absorbing it", () => {
+			const rec = find(
+				recommendations({
+					latest: { tsb: -30 },
+					strain: { state: "absorbing", tsb: -30 },
+				}),
+				"tsb-fatigued",
+			);
+			expect(rec.detail).toContain("absorbing");
+			// Still a warning: the markers are context, not permission.
+			expect(rec.severity).toBe("warning");
+		});
+
+		it("tells deep form that the body agrees, and says how", () => {
+			const rec = find(
+				recommendations({
+					latest: { tsb: -30 },
+					strain: { state: "buried", tsb: -30, restingHrUp: true, hrvDown: true },
+				}),
+				"tsb-fatigued",
+			);
+			expect(rec.detail).toContain("overnight heart rate is up");
+			expect(rec.detail).toContain("HRV is below it");
+		});
+
+		it("says when the training doesn't explain a raised heart rate", () => {
+			const rec = find(
+				recommendations({ ...up, strain: { state: "unexplained", tsb: 3, restingHrUp: true } }),
+				"rhr-elevated",
+			);
+			expect(rec.detail).toContain("doesn't explain it");
+			expect(rec.detail).toContain("form is 3");
+		});
+
+		it("brings in the skin temperature only as corroboration", () => {
+			const rec = find(
+				recommendations({
+					...up,
+					strain: {
+						state: "unexplained",
+						tsb: 3,
+						restingHrUp: true,
+						temperatureUp: true,
+						temperatureDeviationC: 0.7,
+					},
+				}),
+				"rhr-elevated",
+			);
+			expect(rec.detail).toContain("0.7 °C");
+		});
+
+		it("doesn't say the same thing twice when both markers are up", () => {
+			const out = recommendations({
+				recovery: {
+					restingHr: { recent: 54, baseline: 47, delta: 7 },
+					hrv: { recent: 48, baseline: 65, deltaPct: -26 },
+				},
+				strain: { state: "unexplained", tsb: 3, restingHrUp: true, hrvDown: true },
+			});
+			expect(find(out, "rhr-elevated").detail).toContain("doesn't explain it");
+			expect(find(out, "hrv-suppressed").detail).not.toContain("doesn't explain it");
+		});
+
+		it("reads exactly as it did before when there's no ring", () => {
+			const rec = find(recommendations({ latest: { tsb: -30 } }), "tsb-fatigued");
+			expect(rec.detail).toBe(
+				"Form is -30, below -25. That's normal in a heavy block but not somewhere to live. If it doesn't lift within a week, take two genuinely easy days.",
+			);
+		});
+	});
+
 	it("carries the triggering metric and threshold on every rule", () => {
 		const out = recommendations({
 			acwr: { ratio: 1.9 },

--- a/netlify/functions/_shared/training/response.js
+++ b/netlify/functions/_shared/training/response.js
@@ -1,0 +1,340 @@
+// What the training does to the body, and what the body says back.
+//
+// recovery.js keeps sleep and overnight heart rate out of the fitness model on
+// purpose, and that stands: CTL, ATL and form are averages of the same daily
+// load, which is the only reason form is readable at all, and feeding a second
+// source into part of that system is how form ends up permanently underwater
+// (see fitness.js). Nothing here changes any of those numbers either. Every
+// function in this module reads both sides and writes to neither.
+//
+// What it adds is the one thing neither panel could do alone: line the two up
+// in time. Load measures the dose. Sleep, overnight heart rate and HRV measure
+// the response. Kept in separate panels they each answer their own question
+// perfectly well; read against each other by day they answer three the page
+// couldn't ask before.
+//
+//   What did that run cost me?      The night after it, against my own normal.
+//   What does a hard day cost me?   Every hard day of the block against every
+//                                   easy one — a dose-response curve of one.
+//   Is this fatigue from training?  Form is derived entirely from load, so it
+//                                   can only ever tell you what you already
+//                                   told it. Whether your body agrees is a
+//                                   separate measurement, and the interesting
+//                                   case is when it doesn't.
+//
+// The last is the one worth the code. A body that has stopped absorbing the
+// work, or is coming down with something, is invisible to a training log and
+// obvious in an overnight heart rate — and the same form of −28 means "this is
+// landing, keep going" or "stop" depending entirely on which it is.
+//
+// The alignment throughout is that a night belongs to the day before it. Oura
+// dates a night by the morning you wake into it, so the night after Tuesday's
+// run is the record filed under Wednesday.
+
+import { CHRONIC_DAYS, TSB_FATIGUE } from "./fitness.js";
+import { addDays, toDayKey } from "./dates.js";
+import { reading } from "./num.js";
+import { HRV_DROP_PCT, RHR_RISE_BPM, windowMean } from "./recovery.js";
+import { median, readingsOf } from "./stats.js";
+
+// A hard day is one of the hardest third of the days you ran. That fraction
+// puts the long run and the week's quality session on one side and the easy
+// days on the other, which is the split a runner would make by hand.
+const HARD_DAY_DIVISOR = 3;
+
+// Below this many nights on either side, the medians are describing which
+// nights happened to be recorded rather than what a hard day costs, so nothing
+// is reported at all. Deliberately the same instinct as the run log's "not
+// enough runs to compare" gate.
+const MIN_NIGHTS_PER_GROUP = 4;
+
+// How many nights to follow a hard day before giving up on the heart rate
+// coming back down. Four, because past that the next hard day has usually
+// happened and the question stops being answerable.
+const RECOVERY_CAP_NIGHTS = 4;
+
+// How far back the dose-response profile looks. Six weeks is the stored
+// recovery window less a few days, and about as far back as a block's easy
+// days and hard days are still the same easy days and hard days.
+const PROFILE_DAYS = 42;
+
+// Skin temperature this far above your own normal is Oura's own "something is
+// coming" signal. It never triggers anything here — a warm bedroom does this
+// too — but when the heart rate has already raised its hand, it's the piece of
+// evidence that says which kind of tired this is.
+export const TEMP_RISE_C = 0.5;
+
+const finite = (value) => (Number.isFinite(reading(value)) ? reading(value) : null);
+
+/**
+ * The night that followed a day, if the ring recorded one.
+ *
+ * @param {object[]} records shaped nights.
+ * @param {string} day day key of the training day.
+ * @returns {object|null}
+ */
+export function nightAfter(records, day) {
+	const morning = addDays(toDayKey(day), 1);
+	if (!morning) {
+		return null;
+	}
+	return (records || []).find((record) => record?.day === morning) || null;
+}
+
+/**
+ * One measure of one night against the month before it.
+ *
+ * The baseline stops the day before the night itself, so a night is never
+ * compared against an average it is part of — with 28 nights that's a small
+ * effect, but a bad night dragging down the baseline it's measured against is
+ * the kind of quiet self-cancelling that makes a number useless exactly when
+ * it matters.
+ */
+function against(records, night, field, before) {
+	const value = reading(night?.[field]);
+	if (!Number.isFinite(value)) {
+		return null;
+	}
+	const { mean } = windowMean(records, field, { to: before, days: CHRONIC_DAYS });
+	const baseline = Number.isFinite(mean) ? mean : null;
+	const delta = baseline === null ? null : value - baseline;
+	return {
+		value,
+		baseline,
+		delta,
+		deltaPct: delta !== null && baseline > 0 ? (delta / baseline) * 100 : null,
+	};
+}
+
+/** One night, read against the month that preceded it. */
+function readNight(records, night) {
+	if (!night) {
+		return null;
+	}
+	// The baseline stops the day before, so a night is never compared against
+	// an average it's part of.
+	const before = addDays(night.day, -1);
+	return {
+		day: night.day,
+		sleep: against(records, night, "sleepSec", before),
+		restingHr: against(records, night, "restingHr", before),
+		hrv: against(records, night, "averageHrv", before),
+		temperatureDeviationC: finite(night.temperatureDeviationC),
+	};
+}
+
+/**
+ * The night after a training day, read against that athlete's own normal.
+ *
+ * @param {object[]} records shaped nights.
+ * @param {string} day day key of the training day.
+ * @returns {object|null} null when the ring has nothing for that morning —
+ *   the usual case for a run you did this morning, and the reason this is
+ *   reported as an addition to a run rather than part of it.
+ */
+export function nightAfterDay(records, day) {
+	return readNight(records, nightAfter(records, day));
+}
+
+/**
+ * The night a training day started from.
+ *
+ * The other half of the same question, and the half that's always available:
+ * the night after this morning's run hasn't happened yet, but the one you took
+ * into it has. What it answers is different enough to be worth saying — not
+ * what the run cost, but what you had to spend.
+ *
+ * @param {object[]} records shaped nights.
+ * @param {string} day day key of the training day.
+ * @returns {object|null}
+ */
+export function nightBeforeDay(records, day) {
+	const morning = toDayKey(day);
+	return readNight(records, (records || []).find((record) => record?.day === morning) || null);
+}
+
+/**
+ * The hardest third of the days you ran, by rank rather than by a load above
+ * some threshold.
+ *
+ * The threshold version is the obvious one and it doesn't work: most easy days
+ * in a block carry nearly the same load, so a cut taken at the two-thirds mark
+ * lands on that value, every day is then at or above it, and a comparison
+ * meant to isolate the hard days quietly compares all of them against nothing.
+ * Ranking can't degenerate that way. Rest days aren't in the running at all —
+ * a day off is not a soft version of a hard day.
+ */
+function hardestThird(days) {
+	const ran = days.filter((day) => reading(day.load) > 0);
+	const count = Math.floor(ran.length / HARD_DAY_DIVISOR);
+	if (count === 0) {
+		return null;
+	}
+	const ranked = [...ran].sort(
+		(a, b) => reading(b.load) - reading(a.load) || String(a.date).localeCompare(String(b.date)),
+	);
+	return new Set(ranked.slice(0, count).map((day) => day.date));
+}
+
+/** Split the nights of a window by how hard the day before them was. */
+function groupNights(records, days, hardDays) {
+	const hard = [];
+	const easy = [];
+	for (const day of days) {
+		const night = nightAfter(records, day.date);
+		if (night) {
+			const list = hardDays.has(day.date) ? hard : easy;
+			list.push({ ...night, after: day.date });
+		}
+	}
+	return { hard, easy };
+}
+
+function summarise(nights) {
+	return {
+		nights: nights.length,
+		sleepSec: median(readingsOf(nights, "sleepSec")),
+		restingHr: median(readingsOf(nights, "restingHr")),
+		averageHrv: median(readingsOf(nights, "averageHrv")),
+	};
+}
+
+const difference = (a, b) => (Number.isFinite(a) && Number.isFinite(b) ? a - b : null);
+
+/**
+ * How many nights after a day before the overnight heart rate is back down to
+ * `target`.
+ *
+ * @param {object[]} records shaped nights.
+ * @param {string} date day key of the training day.
+ * @param {number} target the heart rate to come back to.
+ * @returns {number|null} 1 when the very next night is already there,
+ *   RECOVERY_CAP_NIGHTS + 1 for "still up four nights later", and null when
+ *   the ring recorded nothing across the window to judge it by.
+ */
+export function nightsUntilBackTo(records, date, target) {
+	let recorded = 0;
+	for (let n = 1; n <= RECOVERY_CAP_NIGHTS; n++) {
+		const hr = reading(nightAfter(records, addDays(date, n - 1))?.restingHr);
+		if (Number.isFinite(hr)) {
+			recorded += 1;
+			if (hr <= target) {
+				return n;
+			}
+		}
+	}
+	return recorded > 0 ? RECOVERY_CAP_NIGHTS + 1 : null;
+}
+
+function nightsToBaseline(records, hard, target) {
+	if (!(target > 0)) {
+		return null;
+	}
+	const counts = hard
+		.map((night) => nightsUntilBackTo(records, night.after, target))
+		.filter((count) => count !== null);
+	return counts.length >= MIN_NIGHTS_PER_GROUP ? median(counts) : null;
+}
+
+/**
+ * What a hard day costs, measured on this athlete rather than assumed.
+ *
+ * Two groups of nights — the ones after the block's hardest days and the ones
+ * after everything else, rest days included — compared on their medians. The
+ * comparison is deliberately crude in one respect: it makes no attempt to
+ * separate the run from the day around it, so a Saturday long run gets credit
+ * for a Saturday night out. Over six weeks that mostly averages out, and the
+ * honest framing is descriptive anyway. This is what your nights after hard
+ * days have looked like, not proof of what caused them.
+ *
+ * @param {object} input
+ * @param {object[]} input.records shaped nights.
+ * @param {object[]} input.series fitness series, for daily load.
+ * @param {string} input.today day key.
+ * @param {number} [input.days] window length.
+ * @returns {object|null} null until there are enough nights on both sides.
+ */
+export function overnightCost({ records = [], series = [], today, days = PROFILE_DAYS }) {
+	const day = toDayKey(today);
+	const from = addDays(day, -(days - 1));
+	// Today is excluded: its night hasn't happened yet, and a day with no
+	// night after it says nothing either way.
+	const window = (series || []).filter((d) => d?.date >= from && d?.date < day);
+	const hardDays = hardestThird(window);
+	if (!hardDays) {
+		return null;
+	}
+
+	const { hard, easy } = groupNights(records, window, hardDays);
+	if (hard.length < MIN_NIGHTS_PER_GROUP || easy.length < MIN_NIGHTS_PER_GROUP) {
+		return null;
+	}
+
+	const afterHard = summarise(hard);
+	const afterEasy = summarise(easy);
+	return {
+		afterHard,
+		afterEasy,
+		sleepDeltaSec: difference(afterHard.sleepSec, afterEasy.sleepSec),
+		restingHrDelta: difference(afterHard.restingHr, afterEasy.restingHr),
+		hrvDelta: difference(afterHard.averageHrv, afterEasy.averageHrv),
+		// Counted in nights rather than days, and capped: past four the next
+		// hard day has usually landed and the question can't be answered.
+		nightsToBaseline: nightsToBaseline(records, hard, afterEasy.restingHr),
+		cappedAt: RECOVERY_CAP_NIGHTS,
+	};
+}
+
+function stressedBy(recovery) {
+	const restingHr = recovery?.restingHr || {};
+	const hrv = recovery?.hrv || {};
+	const temperature = finite(recovery?.latest?.temperatureDeviationC);
+	return {
+		restingHrUp: Number.isFinite(restingHr.delta) && restingHr.delta >= RHR_RISE_BPM,
+		hrvDown: Number.isFinite(hrv.deltaPct) && hrv.deltaPct <= -HRV_DROP_PCT,
+		temperatureUp: temperature !== null && temperature >= TEMP_RISE_C,
+		temperatureDeviationC: temperature,
+	};
+}
+
+function stateOf(heavy, stressed) {
+	if (heavy) {
+		return stressed ? "buried" : "absorbing";
+	}
+	return stressed ? "unexplained" : "clear";
+}
+
+/**
+ * Whether the body agrees with the training log about how tired you are.
+ *
+ * Four cases, of which two are worth a sentence:
+ *
+ *   buried       Form is deep and the markers agree. Expected after a big
+ *                block; a problem if it doesn't lift.
+ *   absorbing    Form is deep and the body is at baseline. The load is
+ *                landing. Form alone would have told you to back off.
+ *   unexplained  Form is fine and the body isn't. Whatever this is, you
+ *                didn't run it — and it's the one case a training log can
+ *                never show you.
+ *   clear        Neither. Nothing to say.
+ *
+ * @param {object} input
+ * @param {number|null} input.tsb form, from the fitness series.
+ * @param {object|null} input.recovery the recovery summary.
+ * @returns {object|null} null without recovery data, so callers can leave the
+ *   subject alone rather than assert everything is fine.
+ */
+export function strainSignal({ tsb = null, recovery = null }) {
+	if (!recovery) {
+		return null;
+	}
+	const markers = stressedBy(recovery);
+	const stressed = markers.restingHrUp || markers.hrvDown;
+	const heavy = Number.isFinite(tsb) && tsb <= TSB_FATIGUE;
+	return {
+		state: stateOf(heavy, stressed),
+		tsb: Number.isFinite(tsb) ? tsb : null,
+		formThreshold: TSB_FATIGUE,
+		...markers,
+	};
+}

--- a/netlify/functions/_shared/training/response.test.js
+++ b/netlify/functions/_shared/training/response.test.js
@@ -1,0 +1,263 @@
+import { describe, it, expect } from "vitest";
+import {
+	nightAfter,
+	nightAfterDay,
+	nightBeforeDay,
+	nightsUntilBackTo,
+	overnightCost,
+	strainSignal,
+	TEMP_RISE_C,
+} from "./response.js";
+import { addDays } from "./dates.js";
+
+const hours = (h) => Math.round(h * 3600);
+
+/**
+ * A run of nights ending on `to`, each one whatever `shape` says for its index
+ * counted back from the end (0 is the last night).
+ */
+function nights(to, count, shape = () => ({})) {
+	return Array.from({ length: count }, (_, i) => {
+		const back = count - 1 - i;
+		return {
+			day: addDays(to, -back),
+			sleepSec: hours(7.5),
+			restingHr: 46,
+			averageHrv: 60,
+			...shape(back),
+		};
+	});
+}
+
+/** A fitness series of the same span, with `loads` keyed by day key. */
+function series(to, count, loads = {}) {
+	return Array.from({ length: count }, (_, i) => {
+		const date = addDays(to, -(count - 1 - i));
+		return { date, load: loads[date] || 0, ctl: 40, atl: 40, tsb: 0 };
+	});
+}
+
+describe("nightAfter", () => {
+	it("takes the night dated the morning after the run", () => {
+		// Oura files a night under the day you wake into it, so Tuesday's run
+		// is followed by Wednesday's record.
+		const records = nights("2026-08-12", 3);
+		expect(nightAfter(records, "2026-08-11").day).toBe("2026-08-12");
+	});
+
+	it("has nothing for a run this morning", () => {
+		const records = nights("2026-08-12", 3);
+		expect(nightAfter(records, "2026-08-12")).toBeNull();
+	});
+});
+
+describe("nightAfterDay", () => {
+	it("reads the night against the month before it", () => {
+		const records = nights("2026-08-12", 30, (back) =>
+			back === 0 ? { sleepSec: hours(6), restingHr: 52, averageHrv: 48 } : {},
+		);
+
+		const night = nightAfterDay(records, "2026-08-11");
+
+		expect(night.day).toBe("2026-08-12");
+		expect(night.sleep.value).toBe(hours(6));
+		expect(night.sleep.baseline).toBeCloseTo(hours(7.5), 0);
+		expect(night.sleep.delta).toBeCloseTo(-hours(1.5), 0);
+		expect(night.restingHr.delta).toBeCloseTo(6, 5);
+		expect(night.hrv.deltaPct).toBeCloseTo(-20, 5);
+	});
+
+	it("excludes the night itself from its own baseline", () => {
+		// Otherwise a bad night quietly drags down the average it's being
+		// measured against, and cancels part of its own signal.
+		const records = nights("2026-08-12", 30, (back) => (back === 0 ? { restingHr: 60 } : {}));
+		expect(nightAfterDay(records, "2026-08-11").restingHr.baseline).toBe(46);
+	});
+
+	it("reports the night without a delta when there's no baseline yet", () => {
+		const records = nights("2026-08-12", 2, (back) => (back === 0 ? { restingHr: 52 } : {}));
+		const night = nightAfterDay(records, "2026-08-11");
+		expect(night.restingHr.value).toBe(52);
+		expect(night.restingHr.baseline).toBeNull();
+		expect(night.restingHr.delta).toBeNull();
+	});
+
+	it("carries the skin temperature, which nothing else reads", () => {
+		const records = nights("2026-08-12", 30, (back) =>
+			back === 0 ? { temperatureDeviationC: 0.8 } : {},
+		);
+		expect(nightAfterDay(records, "2026-08-11").temperatureDeviationC).toBe(0.8);
+	});
+
+	it("is null when the ring recorded nothing that morning", () => {
+		expect(nightAfterDay(nights("2026-08-10", 20), "2026-08-11")).toBeNull();
+	});
+});
+
+describe("nightBeforeDay", () => {
+	it("takes the night you woke up from on the day itself", () => {
+		// The half of the question that exists on the morning of a run: what
+		// you took into it, rather than what it cost.
+		const records = nights("2026-08-12", 30, (back) => (back === 1 ? { sleepSec: hours(5) } : {}));
+		const night = nightBeforeDay(records, "2026-08-11");
+		expect(night.day).toBe("2026-08-11");
+		expect(night.sleep.value).toBe(hours(5));
+		expect(night.sleep.delta).toBeLessThan(0);
+	});
+});
+
+describe("overnightCost", () => {
+	const today = "2026-08-12";
+
+	// Every third day is hard, and the night after a hard day is 40 minutes
+	// shorter with a heart rate 4 beats up.
+	function block({ hardEvery = 3, hardCost = true } = {}) {
+		const days = 30;
+		const loads = {};
+		const hardDays = new Set();
+		for (let back = 1; back <= days; back++) {
+			const date = addDays(today, -back);
+			const hard = back % hardEvery === 0;
+			loads[date] = hard ? 120 : 45;
+			if (hard) {
+				hardDays.add(addDays(date, 1));
+			}
+		}
+		return {
+			series: series(today, days + 1, loads),
+			records: nights(today, days, (back) => {
+				const day = addDays(today, -back);
+				if (!hardCost || !hardDays.has(day)) {
+					return {};
+				}
+				return { sleepSec: hours(7.5) - 2400, restingHr: 50, averageHrv: 52 };
+			}),
+		};
+	}
+
+	it("compares the nights after hard days against the nights after everything else", () => {
+		const { series: fitness, records } = block();
+
+		const cost = overnightCost({ records, series: fitness, today });
+
+		expect(cost.afterHard.nights).toBeGreaterThanOrEqual(4);
+		expect(cost.afterEasy.nights).toBeGreaterThanOrEqual(4);
+		expect(cost.sleepDeltaSec).toBe(-2400);
+		expect(cost.restingHrDelta).toBe(4);
+		expect(cost.hrvDelta).toBe(-8);
+	});
+
+	it("says nothing when hard days cost nothing", () => {
+		const { series: fitness, records } = block({ hardCost: false });
+		const cost = overnightCost({ records, series: fitness, today });
+		expect(cost.restingHrDelta).toBe(0);
+		expect(cost.sleepDeltaSec).toBe(0);
+	});
+
+	it("counts the nights until the heart rate is back down", () => {
+		const { series: fitness, records } = block();
+		const cost = overnightCost({ records, series: fitness, today });
+		// The night after a hard day is the raised one, and the one after
+		// that is back at the easy-day median.
+		expect(cost.nightsToBaseline).toBe(2);
+	});
+
+	it("holds back until there are enough nights on both sides", () => {
+		const loads = { [addDays(today, -2)]: 120, [addDays(today, -4)]: 40 };
+		expect(
+			overnightCost({ records: nights(today, 5), series: series(today, 6, loads), today }),
+		).toBeNull();
+	});
+
+	it("is null before there's any load to divide the days by", () => {
+		expect(overnightCost({ records: nights(today, 20), series: series(today, 20), today })).toBeNull();
+	});
+
+	it("splits by rank, so a block of near-identical days still compares", () => {
+		// The threshold version of this fell over here: with most days on the
+		// same load, a cut at the two-thirds mark lands on that load and every
+		// day ends up "hard".
+		const days = 30;
+		const loads = {};
+		for (let back = 1; back <= days; back++) {
+			loads[addDays(today, -back)] = back % 5 === 0 ? 101 : 100;
+		}
+
+		const cost = overnightCost({ records: nights(today, days), series: series(today, days + 1, loads), today });
+
+		expect(cost.afterHard.nights).toBe(10);
+		expect(cost.afterEasy.nights).toBe(20);
+	});
+
+	it("ignores today, whose night hasn't happened yet", () => {
+		const { series: fitness, records } = block();
+		const spiked = fitness.map((d) => (d.date === today ? { ...d, load: 400 } : d));
+
+		expect(overnightCost({ records, series: spiked, today })).toEqual(
+			overnightCost({ records, series: fitness, today }),
+		);
+	});
+});
+
+describe("nightsUntilBackTo", () => {
+	it("counts from the night after the day itself", () => {
+		const records = nights("2026-08-14", 5, (back) => ({ restingHr: back === 2 ? 52 : 46 }));
+		// The run was on the 11th; the raised night is the 12th, and the 13th
+		// is back down.
+		expect(nightsUntilBackTo(records, "2026-08-11", 46)).toBe(2);
+	});
+
+	it("caps rather than reporting a week", () => {
+		const records = nights("2026-08-20", 12, () => ({ restingHr: 55 }));
+		expect(nightsUntilBackTo(records, "2026-08-11", 46)).toBe(5);
+	});
+
+	it("steps over a night the ring missed", () => {
+		const records = nights("2026-08-16", 6, (back) => ({ restingHr: back === 3 ? 44 : 55 })).filter(
+			(night) => night.day !== "2026-08-12",
+		);
+		expect(nightsUntilBackTo(records, "2026-08-11", 46)).toBe(2);
+	});
+
+	it("says nothing at all when the ring recorded nothing", () => {
+		expect(nightsUntilBackTo(nights("2026-08-11", 5), "2026-08-11", 46)).toBeNull();
+	});
+});
+
+describe("strainSignal", () => {
+	const stressed = { restingHr: { delta: 6 }, hrv: { deltaPct: -18 }, latest: {} };
+	const rested = { restingHr: { delta: 0 }, hrv: { deltaPct: 2 }, latest: {} };
+
+	it("calls deep form with markers to match buried", () => {
+		expect(strainSignal({ tsb: -30, recovery: stressed }).state).toBe("buried");
+	});
+
+	it("calls deep form with a body at baseline absorbing", () => {
+		// The case form alone gets wrong: −30 reads as "back off" and the
+		// body's own numbers say the work is landing.
+		const signal = strainSignal({ tsb: -30, recovery: rested });
+		expect(signal.state).toBe("absorbing");
+		expect(signal.restingHrUp).toBe(false);
+	});
+
+	it("calls a stressed body with no training behind it unexplained", () => {
+		const signal = strainSignal({ tsb: 4, recovery: stressed });
+		expect(signal.state).toBe("unexplained");
+		expect(signal.hrvDown).toBe(true);
+	});
+
+	it("says nothing when both agree there's nothing to say", () => {
+		expect(strainSignal({ tsb: 2, recovery: rested }).state).toBe("clear");
+	});
+
+	it("notes a raised temperature as evidence, never as a trigger", () => {
+		const warm = { ...rested, latest: { temperatureDeviationC: TEMP_RISE_C + 0.2 } };
+		const signal = strainSignal({ tsb: 2, recovery: warm });
+		expect(signal.temperatureUp).toBe(true);
+		expect(signal.state).toBe("clear");
+	});
+
+	it("is null with no ring data at all", () => {
+		expect(strainSignal({ tsb: -30, recovery: null })).toBeNull();
+	});
+});

--- a/netlify/functions/_shared/training/stats.js
+++ b/netlify/functions/_shared/training/stats.js
@@ -1,0 +1,41 @@
+// The two summaries this engine takes of a pile of numbers.
+//
+// Medians rather than means, nearly everywhere: a training block contains a
+// week off with the flu, a night the ring was charging, and a run that Strava
+// filed at 4:00/km because the GPS thought you swam the Don. A mean carries all
+// three into the answer and a median doesn't, which matters when the point of
+// the number is "what's normal for you".
+
+import { reading } from "./num.js";
+
+/**
+ * @param {number[]} values
+ * @returns {number|null} null for an empty list, rather than a number that
+ *   would read as a real answer.
+ */
+export function median(values) {
+	if (!values || values.length === 0) {
+		return null;
+	}
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	const lower = sorted.at(mid - 1);
+	const upper = sorted.at(mid);
+	return sorted.length % 2 ? upper : (lower + upper) / 2;
+}
+
+/**
+ * The finite readings of one field across a list of records.
+ *
+ * Absent readings are dropped rather than zeroed, for the reason set out in
+ * num.js: a night with no heart rate is not a night at 0 bpm.
+ *
+ * @param {object[]} records
+ * @param {string} field
+ * @returns {number[]}
+ */
+export function readingsOf(records, field) {
+	return (records || [])
+		.map((record) => reading(record?.[field]))
+		.filter((value) => Number.isFinite(value));
+}

--- a/netlify/functions/_shared/training/stats.test.js
+++ b/netlify/functions/_shared/training/stats.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { median, readingsOf } from "./stats.js";
+
+describe("median", () => {
+	it("takes the middle of an odd list", () => {
+		expect(median([5, 1, 3])).toBe(3);
+	});
+
+	it("splits the difference on an even one", () => {
+		expect(median([1, 2, 3, 4])).toBe(2.5);
+	});
+
+	it("is null rather than zero for nothing", () => {
+		expect(median([])).toBeNull();
+	});
+
+	it("leaves the caller's array alone", () => {
+		const values = [3, 1, 2];
+		median(values);
+		expect(values).toEqual([3, 1, 2]);
+	});
+});
+
+describe("readingsOf", () => {
+	it("drops absent readings rather than counting them as zero", () => {
+		const records = [{ hr: 46 }, { hr: null }, {}, { hr: 50 }];
+		expect(readingsOf(records, "hr")).toEqual([46, 50]);
+	});
+});

--- a/src/components/Training/lib/balance.test.js
+++ b/src/components/Training/lib/balance.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { bestSplit, columnHeight, imbalanceAt, worthMoving } from "./balance.js";
+import { bestSplit, columnHeight, worthMoving } from "./balance.js";
 
 describe("columnHeight", () => {
 	it("counts the gaps between panels, not around them", () => {

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -24,6 +24,7 @@ export const GLOSSARY = {
 			{ term: "Fitness, fatigue and form", definition: "What the day's running moved. Fitness is the 42-day average of load, fatigue the 7-day one, form the difference. A hard run always adds more fatigue than fitness — that's the trade you're making." },
 			{ term: "Fade", definition: "How much slower the second half of the run was than the first. Under about 2% is even pacing; a negative number means you finished quicker than you started. On a workout the halves are just describing the session — intervals, then a jog home." },
 			{ term: "Drift", definition: "Aerobic decoupling: how far pace-per-heartbeat slipped between the halves of the run. Under 5% means the distance is within your aerobic base. Only shown for runs held at one effort, since on an interval session it measures the intervals rather than your base." },
+			{ term: "The night after", definition: "Sleep, overnight heart rate and HRV from the night that followed the run, each against your own 28-day normal. Everything else on this panel is computed from the run itself and can only report back what the training log already knew; this is the one line measured on you. On the morning of a run that night hasn't happened yet, so the panel shows the one you started from instead." },
 		],
 	},
 
@@ -136,11 +137,14 @@ export const GLOSSARY = {
 			"Sleep and overnight heart rate from an Oura ring, read the same way as the load panel: the last 7 days against the last 28, so every number here is recent measured against your own established normal rather than against anybody else's.",
 			"None of this feeds fitness, fatigue or form. Those are a closed system fed by training load alone, and that's what makes them readable — mixing a second source into part of it is how form ends up permanently negative. Recovery sits alongside instead, and shows up in the recommendations where the combination says more than either half: a 12% jump in volume means something different on eight hours a night than on six.",
 			"Nights with no record are skipped rather than counted as zero. A missing night is a ring left on the bedside table, not a night without sleep, and averaging it in would manufacture exactly the alarm this is meant to raise honestly.",
+			"Where the two sources do meet is in time. Lining each night up with the day before it is what turns sleep from a second dashboard into something about the running: what a hard day costs you, and whether your body agrees with the training log about how tired you are.",
 		],
 		terms: [
 			{ term: "Resting HR", definition: "Your lowest heart rate overnight. Measured asleep, so it's a truer resting rate than any daytime reading, and a rise of about 5 bpm over baseline is a long-standing marker of illness or work you haven't absorbed." },
 			{ term: "HRV", definition: "Heart-rate variability, the beat-to-beat variation while you sleep. Higher generally means better recovered, but it's noisy night to night, which is why it's read as a week against a month." },
 			{ term: "Baseline", definition: "Your own 28-day average for the same measure. Everything here is a deviation from it rather than an absolute judgement." },
+			{ term: "What a hard day costs", definition: "The nights after the hardest third of your training days, against the nights after everything else, over the last six weeks. It's a description rather than a proof — nothing separates the long run from the Saturday around it — but it's measured on you rather than assumed, which is more than any published figure can say." },
+			{ term: "Form against the markers", definition: "Form comes from training load alone, so on its own it can only repeat what you already told it: run a lot and it goes negative whether or not you're coping. Your overnight numbers are an independent answer to the same question. Deep form with markers at baseline is a body absorbing the block; markers up with no load behind them is usually illness, travel or a run of short nights." },
 		],
 	},
 

--- a/src/components/Training/sections/LastRun.svelte
+++ b/src/components/Training/sections/LastRun.svelte
@@ -29,7 +29,7 @@
     import Card from "../../../lib/ui/Card.svelte";
     import ChartFrame from "../charts/ChartFrame.svelte";
     import { areaPath, linePath, niceScale, scaleLinear, smoothPath, xPct, yPct } from "../lib/chart.js";
-    import { daysAgo, formatDistance, pace, pct, signed, timeTaken } from "../lib/format.js";
+    import { daysAgo, formatDistance, formatDuration, pace, pct, signed, timeTaken } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
     import { stravaTag as tagFor } from "../lib/runTags.js";
 
@@ -44,6 +44,16 @@
 
     // Below this the two pace lines are the same line with a wobble.
     const GAP_DIVERGENCE_SEC = 4;
+
+    // Matching the server's thresholds (_shared/training/recovery.js), for the
+    // same reason Recovery.svelte duplicates them: they're constants of the
+    // model rather than of the data, and a panel disagreeing with the advice
+    // about the same night is worse than either being wrong. Sleep gets its
+    // own, because half an hour either way is a normal night and this is
+    // asking whether the run cost you one.
+    const RHR_RISE_BPM = 5;
+    const HRV_DROP_PCT = 15;
+    const SHORT_NIGHT_SEC = 30 * 60;
 
     const stravaTag = $derived(tagFor(run));
 
@@ -254,6 +264,63 @@
                 ]
             : [],
     );
+
+    // What the night afterwards looked like, when the ring has recorded one.
+    // Fitness, fatigue and form above are all computed from the run itself, so
+    // between them they can only say what the training log already knew. This
+    // is the one line on the panel measured on the athlete rather than derived
+    // from the session, and it's usually absent on the day of a run: the night
+    // after this morning hasn't happened yet.
+    // On the morning of a run the night after it hasn't happened, so the panel
+    // falls back to the one you took into it: not what the run cost, but what
+    // you had to spend on it.
+    const night = $derived(run?.night || run?.nightBefore || null);
+    const nightLabel = $derived(run?.night ? "The night after" : "Went into it on");
+
+    const nightNotes = $derived.by(() => {
+        if (!night) return [];
+        const notes = [];
+        if (Number.isFinite(night.sleep?.value)) {
+            notes.push({
+                key: "sleep",
+                label: formatDuration(night.sleep.value),
+                delta: minutes(night.sleep.delta),
+                // Short is the direction worth colouring; a long night after a
+                // hard run is the system working.
+                bad: night.sleep.delta <= -SHORT_NIGHT_SEC,
+            });
+        }
+        if (Number.isFinite(night.restingHr?.value)) {
+            notes.push({
+                key: "hr",
+                label: `${Math.round(night.restingHr.value)} bpm resting`,
+                delta: bpmDelta(night.restingHr.delta),
+                bad: night.restingHr.delta >= RHR_RISE_BPM,
+            });
+        }
+        if (Number.isFinite(night.hrv?.value)) {
+            notes.push({
+                key: "hrv",
+                label: `${Math.round(night.hrv.value)} ms HRV`,
+                delta: percent(night.hrv.deltaPct),
+                bad: night.hrv.deltaPct <= -HRV_DROP_PCT,
+            });
+        }
+        return notes;
+    });
+
+    // All three read "against your own normal", so the baseline is said once
+    // in the label rather than three times in the numbers.
+    function minutes(sec) {
+        if (!Number.isFinite(sec) || Math.abs(sec) < 60) return null;
+        return `${signed(sec / 60, 0)} min`;
+    }
+    function bpmDelta(bpm) {
+        return Number.isFinite(bpm) && Math.abs(bpm) >= 1 ? signed(bpm, 0) : null;
+    }
+    function percent(value) {
+        return Number.isFinite(value) && Math.abs(value) >= 5 ? `${signed(value, 0)}%` : null;
+    }
 
     /** How this run's load sat against the athlete's own recent median. */
     const relativeSize = $derived.by(() => {
@@ -471,6 +538,19 @@
                         {relativeSize}{standout ? `, and ${standout}` : ""}.
                     {/if}
                 </p>
+
+                {#if nightNotes.length}
+                    <p class="night">
+                        <span class="night-label">{nightLabel}</span>
+                        {#each nightNotes as note, i (note.key)}
+                            <span class="night-note" class:bad={note.bad}>
+                                {i > 0 ? "· " : ""}{note.label}
+                                {#if note.delta}<span class="night-delta">{note.delta}</span>{/if}
+                            </span>
+                        {/each}
+                        <span class="night-basis">against your own month</span>
+                    </p>
+                {/if}
             </div>
         {/if}
 
@@ -681,6 +761,31 @@
         line-height: 1.5;
         color: var(--paragraph-colour);
     }
+
+    /* The one line here measured on the body rather than derived from the run,
+       so it's set apart from the deltas above it without becoming a fourth
+       tile competing with fitness, fatigue and form. */
+    .night {
+        display: flex;
+        align-items: baseline;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+        margin: var(--space-3) 0 0;
+        padding-top: var(--space-3);
+        border-top: 1px solid var(--main-green-translucent);
+        font-size: var(--font-xs);
+        color: var(--paragraph-colour);
+    }
+    .night-label {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--main-green);
+    }
+    .night-note { color: var(--header-colour); }
+    .night-note.bad { color: var(--tone-warn); }
+    .night-delta { opacity: 0.65; }
+    .night-basis { opacity: 0.6; }
 
     .facts {
         display: grid;

--- a/src/components/Training/sections/Recovery.svelte
+++ b/src/components/Training/sections/Recovery.svelte
@@ -21,12 +21,24 @@
 
     let { recovery = null } = $props();
 
+    // How long a "back to baseline" answer is worth spelling out in words.
+    const NIGHT_WORDS = new Map([
+        [1, "usually back down by the next night"],
+        [2, "usually back down by the second night"],
+        [3, "usually three nights before it's back down"],
+        [4, "usually four nights before it's back down"],
+    ]);
+
     // Matching the server's thresholds (recovery.js). Duplicated rather than
     // shipped in the payload because they're constants of the model, not of
     // the data — if they diverge, the panel and the advice would disagree
     // about the same night, which is worse than either being wrong.
     const SLEEP_TARGET_SEC = 7 * 3600;
     const RHR_RISE_BPM = 5;
+
+    // Half an hour either way is a normal night; this is asking whether the
+    // hard days are costing you one.
+    const SHORT_NIGHT_SEC = 30 * 60;
 
     const CHART_W = 300;
     const CHART_H = 100;
@@ -108,6 +120,73 @@
         if (rounded === 0) return `level`;
         return `${rounded > 0 ? "+" : ""}${rounded} ${unit}`;
     };
+
+    const signed = (value, unit) =>
+        Number.isFinite(value) ? `${value > 0 ? "+" : ""}${Math.round(value)}${unit}` : "—";
+
+    // What a hard day costs this athlete, measured rather than assumed: the
+    // nights after the hardest third of the block's running days against the
+    // nights after everything else. The panel is otherwise all trend, and a
+    // trend can't answer "what does a session actually do to me".
+    const cost = $derived(recovery?.response?.hardDays || null);
+
+    const costs = $derived(
+        cost
+            ? [
+                    {
+                        key: "sleep",
+                        label: "Sleep",
+                        value: Number.isFinite(cost.sleepDeltaSec) ? `${signed(cost.sleepDeltaSec / 60, "")} min` : "—",
+                        bad: cost.sleepDeltaSec <= -SHORT_NIGHT_SEC,
+                    },
+                    {
+                        key: "hr",
+                        label: "Resting HR",
+                        value: signed(cost.restingHrDelta, " bpm"),
+                        bad: cost.restingHrDelta >= RHR_RISE_BPM,
+                    },
+                    { key: "hrv", label: "HRV", value: signed(cost.hrvDelta, " ms"), bad: false },
+                ]
+            : [],
+    );
+
+    const backDown = $derived(
+        cost && Number.isFinite(cost.nightsToBaseline)
+            ? NIGHT_WORDS.get(Math.round(cost.nightsToBaseline)) ||
+                  `still up ${cost.cappedAt} nights later`
+            : null,
+    );
+
+    // Form is computed from the training log and nothing else, so on its own
+    // it can only tell you what you already told it. This is whether the body
+    // agrees — and the two cases worth a sentence are the ones where it
+    // doesn't. See _shared/training/response.js.
+    const strain = $derived(recovery?.response?.strain || null);
+    // Signed, because form is a quantity whose sign is the whole message: a
+    // bare "3" beside "-31" reads as a small number rather than a fresh one.
+    const form = $derived(Number.isFinite(strain?.tsb) ? signed(strain.tsb, "") : null);
+
+    const verdict = $derived.by(() => {
+        if (strain?.state === "absorbing") {
+            return {
+                tone: "good",
+                text: `Form is ${form} from the training alone, and your overnight numbers are sitting at baseline. That's a body absorbing a heavy block rather than falling behind it.`,
+            };
+        }
+        if (strain?.state === "buried") {
+            return {
+                tone: "bad",
+                text: `Form is ${form} and your body agrees with it${strain.temperatureUp ? ", with skin temperature up as well" : ""}. Fatigue the training explains, but not somewhere to live.`,
+            };
+        }
+        if (strain?.state === "unexplained") {
+            return {
+                tone: "warn",
+                text: `Form is ${form}, so the training doesn't explain this${strain.temperatureUp ? `, and skin temperature is ${strain.temperatureDeviationC.toFixed(1)} °C above your normal` : ""}. A body under strain with no load behind it is more often illness, travel or a run of short nights.`,
+            };
+        }
+        return null;
+    });
 </script>
 
 <Card title="Recovery" info={GLOSSARY.recovery}>
@@ -121,6 +200,10 @@
             </div>
             <p class="status tone-{status.tone}">{status.label}</p>
         </div>
+
+        {#if verdict}
+            <p class="verdict tone-{verdict.tone}">{verdict.text}</p>
+        {/if}
 
         {#if columns.length}
             <div class="chart">
@@ -150,6 +233,24 @@
             </ChartFrame>
             </div>
             <p class="chart-unit">nightly sleep · line at {formatDuration(SLEEP_TARGET_SEC)}</p>
+        {/if}
+
+        {#if cost}
+            <div class="cost">
+                <h3>What a hard day costs you</h3>
+                <dl class="cost-grid">
+                    {#each costs as item (item.key)}
+                        <div>
+                            <dt>{item.label}</dt>
+                            <dd class:over={item.bad}>{item.value}</dd>
+                        </div>
+                    {/each}
+                </dl>
+                <p class="cost-note">
+                    The {cost.afterHard.nights} nights after your hardest training days, against the
+                    {cost.afterEasy.nights} after everything else{backDown ? ` — ${backDown}` : ""}.
+                </p>
+            </div>
         {/if}
 
         <dl class="detail">
@@ -250,6 +351,52 @@
         stroke-dasharray: 3 3;
         opacity: 0.55;
         vector-effect: non-scaling-stroke;
+    }
+
+    /* The one reading here taken against the training rather than against the
+       month, so it sits between the two: below the trend it draws on, above
+       the measures it's built from. */
+    .verdict {
+        margin: var(--space-3) 0 0;
+        padding-left: var(--space-3);
+        border-left: 2px solid var(--main-green-translucent);
+        font-size: var(--font-sm);
+        line-height: 1.5;
+        color: var(--paragraph-colour);
+    }
+    .verdict.tone-good { border-left-color: var(--tone-good); }
+    .verdict.tone-warn { border-left-color: var(--tone-warn); }
+    .verdict.tone-bad { border-left-color: var(--tone-bad); }
+
+    .cost { margin-top: var(--space-4); }
+    .cost h3 {
+        margin: 0 0 var(--space-2);
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--main-green);
+        font-weight: 600;
+    }
+    .cost-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-2);
+        margin: 0;
+    }
+    .cost-grid div {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        padding: var(--space-3);
+        background: var(--item-background);
+        border-radius: var(--radius-sm);
+    }
+    .cost-note {
+        margin: var(--space-2) 0 0;
+        font-size: var(--font-2xs);
+        line-height: 1.5;
+        color: var(--paragraph-colour);
+        opacity: 0.65;
     }
 
     .detail {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sleep and overnight heart rate arrived as a second dashboard: their own panel, their own rules, and no relationship in time to the running they were meant to describe. This gives them one — a night now belongs to the day before it — without touching the thing that separation exists to protect.

**CTL, ATL and form are unchanged, and stay that way.** Both traces are averages of the same daily load, which is the only reason form settles around zero and "+5 is fresh, −20 is buried" means anything; feeding a second source into part of that system is what put form permanently underwater when rides were tried. `metrics.test.js` builds the same block with and without a ring and requires every training number to be identical.

What's new is `_shared/training/response.js`, read by `metrics.js` and nothing else.

### The night after a run — in the Last run panel

Sleep, resting heart rate and HRV from the morning after, each against that athlete's own 28-day baseline (the baseline stops the day before, so a bad night can't quietly drag down the average it's measured against). Every other number on that panel is computed from the run itself, so between them they can only repeat what the training log already knew. This is the one line measured on the athlete.

On the morning of a run there is no night after it yet, so it falls back to the night before: not what the run cost, but what you took into it.

### What a hard day costs — in the Recovery panel

The nights after the hardest third of the block's running days against the nights after everything else, compared on medians, plus how many nights the heart rate takes to come back down. A dose-response curve of one, e.g. *"Sleep −41 min · Resting HR +3 bpm · HRV −7 ms — usually back down by the second night."*

Hard days are picked by rank rather than by a load threshold: most easy days in a block carry nearly the same load, so a cut at the two-thirds mark lands on that value and every day ends up "hard".

### Form against the body's own markers

Form comes from load alone, so on its own it can only report back what you told it. The overnight numbers are an independent answer to the same question, and the disagreements are what's worth printing:

| | markers at baseline | markers raised |
|---|---|---|
| **form deep** | absorbing the block | buried, and it's the training |
| **form fine** | nothing to say | not the running — illness, travel, short nights |

The bottom-right case is the one a training log can never show you, and it's where the previously-unused skin temperature reading earns its keep as corroboration (never as a trigger — a warm bedroom does that too).

This reaches the Recovery panel as a sentence and changes the wording of `tsb-fatigued`, `rhr-elevated` and `hrv-suppressed`. No new rule ids, no rule that fires on it, no metric moved.

### Also here

- `stats.js` — `median` moved out of `lastRun.js` now that two modules want it, plus `readingsOf`, which keeps "absent" distinct from "zero" the way `num.js` does.
- `TSB_FATIGUE` moved from `recommend.js` to `fitness.js`: it's a property of the form scale, and two modules read against it now.
- The e2e fixture's nights answer to the day before them. Nights generated independently of the running would draw a dose-response curve of pure noise and prove nothing about whether any of this works.
- One pre-existing lint error fixed (an unused import in `balance.test.js`).

### Verification

688 unit tests and 33 Playwright tests pass; the build is clean; the changed lines are clean under the strict Codacy profile. Both panels were checked at 1440px and 390px, in each state.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff2d4-4cc7-76de-bf47-3f56bd9cb82c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

