### PR TITLE
Stop the backfill spending its quota on the listing

### DIFF
--- a/netlify/functions/_tests/trainingSync.test.js
+++ b/netlify/functions/_tests/trainingSync.test.js
@@ -56,7 +56,10 @@ function detailFor(summary) {
 
 // Stand in for Strava. `quota` is echoed back as rate-limit headers so the
 // budget logic can be driven from a test.
-function mockStrava({ activities = [], quota = null, failStreams = false } = {}) {
+// `listing` overrides what /athlete/activities returns without changing what
+// the detail endpoint will serve, which is how a re-shape looks from here: the
+// runs are all stored, nothing is new, and the listing has nothing to say.
+function mockStrava({ activities = [], listing = null, quota = null, failStreams = false } = {}) {
 	const calls = [];
 	globalThis.fetch = vi.fn(async (url) => {
 		const target = String(url);
@@ -72,7 +75,7 @@ function mockStrava({ activities = [], quota = null, failStreams = false } = {})
 		}
 		if (target.includes("/athlete/activities")) {
 			const page = Number(new URL(target).searchParams.get("page"));
-			return reply(page === 1 ? activities : []);
+			return reply(page === 1 ? (listing ?? activities) : []);
 		}
 		if (target.includes("/athlete/zones")) {
 			return reply({ heart_rate: { zones: [{ min: 0, max: 130 }] } });
@@ -211,6 +214,10 @@ describe("trainingSync", () => {
 
 	// Bumping SHAPE_VERSION is the only way stored records get corrected, since
 	// the derived fields come from streams that aren't kept.
+	//
+	// The listing here has nothing to offer — every run is already stored and
+	// none are new — so a re-shape that waited to be told what to fetch would
+	// do nothing at all. The stale records are queued from the index.
 	it("re-enriches records left behind by an older shape version", async () => {
 		mockStrava({ activities: summaries(2) });
 		await sync();
@@ -219,10 +226,48 @@ describe("trainingSync", () => {
 			index().map((a) => ({ ...a, v: SHAPE_VERSION - 1 })),
 		);
 
+		mockStrava({ activities: summaries(2), listing: [] });
 		const { body } = await sync();
+		expect(body.synced).toBe(2);
+		expect(body.outstanding).toBe(0);
+		expect(index().every((a) => a.v === SHAPE_VERSION)).toBe(true);
+	});
+
+	// The bug that made a version bump take days instead of an hour. Paging
+	// back through the block costs three reads, and at a five-minute cadence
+	// that's 864 a day against a limit of a thousand — so the sync spent its
+	// entire quota being told ids it had on disk, and had nothing left to
+	// fetch them with. One run trickled in every five minutes.
+	it("re-shapes without paging back through the block", async () => {
+		mockStrava({ activities: summaries(2) });
+		await sync();
+		const caughtUp = cursor().lastActivityEpoch;
+		expect(caughtUp).toBeGreaterThan(0);
+		blobs.set(
+			"index.json",
+			index().map((a) => ({ ...a, v: SHAPE_VERSION - 1 })),
+		);
+
+		const calls = mockStrava({ activities: summaries(2), listing: [] });
+		const { body } = await sync();
+
+		expect(body.rescan).toBe(false);
+		const listings = calls.filter((c) => c.includes("/athlete/activities"));
+		expect(listings).toHaveLength(1);
+		expect(Number(new URL(listings[0]).searchParams.get("after"))).toBe(caughtUp);
+	});
+
+	it("still pages the whole block back when asked outright", async () => {
+		mockStrava({ activities: summaries(2) });
+		await sync();
+
+		const calls = mockStrava({ activities: summaries(2) });
+		const { body } = await sync("?full=1");
+
 		expect(body.rescan).toBe(true);
 		expect(body.synced).toBe(2);
-		expect(index().every((a) => a.v === SHAPE_VERSION)).toBe(true);
+		const listing = calls.find((c) => c.includes("/athlete/activities"));
+		expect(Number(new URL(listing).searchParams.get("after"))).toBeLessThan(cursor().lastActivityEpoch);
 	});
 
 	it("stores a manual entry that has no streams rather than dropping it", async () => {

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -61,7 +61,15 @@ const MAX_PAGES = 4;
 // The most of each Strava rate-limit window this job will spend. The same app
 // credentials serve the /dashboard widgets, which are in a visitor's request
 // path, so a backfill must not be able to starve them into 429s.
-const QUOTA_SHARE = { shortShare: 0.6, dailyShare: 0.6 };
+//
+// The daily share is the one that binds. Steady state is one listing per
+// invocation, which at a five-minute cadence is 288 reads a day of the 1,000
+// allowed — and a SHAPE_VERSION bump adds two more per stored activity, about
+// 240 for a block. At 60% those two together didn't fit, so a re-shape stalled
+// halfway and waited for midnight. Three quarters fits both with room to
+// spare, and still holds back 250 reads a day for widgets that are edge-cached
+// for five minutes and only called on an actual visit.
+const QUOTA_SHARE = { shortShare: 0.6, dailyShare: 0.75 };
 
 // Stop enriching with time to spare and write what we have. Overrunning the
 // 30s limit doesn't just truncate the work — the invocation is killed before
@@ -315,14 +323,25 @@ export default async function handler(req) {
 	// and there's no reason three quick requests should queue behind it.
 	const recoveryWork = syncRecovery(store, todayKey());
 
-	// Re-list the whole block whenever anything might need rebuilding, so
-	// stale records are actually visible to the pass below. ?full=1 forces it;
-	// otherwise a stale record left over from a previous invocation does. The
-	// listing never reaches back past the block's run-up either way.
+	// The listing's job is finding activities we have never seen. That's all,
+	// and it matters that it's all: paging back through the block costs three
+	// reads against a limit of a thousand a day, and at a five-minute cadence
+	// that's 864 a day spent before a single activity is fetched.
+	//
+	// A re-shape used to force exactly that, on the reasoning that stale
+	// records have to be visible to the pass below. They already are — they're
+	// in the stored index, with their ids — so the listing was being walked to
+	// rediscover what was on disk, and a SHAPE_VERSION bump then had no quota
+	// left to act on what it found. Stale records are queued from the index
+	// instead, and the listing stays incremental.
+	//
+	// So only ?full=1 pages back, plus a cold start, which falls out of the
+	// cursor being empty. The gap this leaves is an activity uploaded with a
+	// date behind the cursor — a backdated manual entry — which no amount of
+	// listing forward will find; ?full=1 is the answer to that too.
 	const url = new URL(req.url);
 	const full = url.searchParams.get("full") === "1";
-	const hasStale = (existing || []).some((a) => a?.v !== SHAPE_VERSION);
-	const rescan = full || hasStale;
+	const rescan = full;
 	const after = rescan ? blockStart : Math.max(cursor?.lastActivityEpoch || 0, blockStart || 0) || null;
 
 	let summaries;
@@ -350,27 +369,51 @@ export default async function handler(req) {
 		return !stored || stored.v !== SHAPE_VERSION;
 	};
 
-	// Newest first, so a cold start fills in the most recent (most relevant)
-	// weeks before working backwards through the block.
-	const pending = candidates
-		.filter((a) => (full ? true : isStale(String(a.id))))
-		.sort((a, b) => String(b.start_date_local).localeCompare(String(a.start_date_local)));
-	const needsDetail = pending.slice(0, DETAIL_BUDGET);
+	// Two sources, one queue. The listing contributes activities that aren't
+	// stored; the index contributes records shaped by an older version, which
+	// need no listing at all. Newest first, so a cold start fills in the most
+	// recent (most relevant) weeks before working backwards through the block.
+	const queued = new Set();
+	const work = [];
+	const enqueue = (item) => {
+		if (queued.has(String(item.id))) return;
+		queued.add(String(item.id));
+		work.push(item);
+	};
+	for (const summary of candidates) {
+		if (!full && !isStale(String(summary.id))) continue;
+		enqueue({
+			id: summary.id,
+			summary,
+			isRide: isTrackableRide(summary),
+			date: summary.start_date_local,
+		});
+	}
+	for (const record of existing || []) {
+		if (!full && record?.v === SHAPE_VERSION) continue;
+		enqueue({
+			id: record?.id,
+			summary: null,
+			isRide: record?.sport === "ride",
+			date: record?.startDateLocal,
+		});
+	}
+	work.sort((a, b) => String(b.date).localeCompare(String(a.date)));
+	const needsDetail = work.slice(0, DETAIL_BUDGET);
 
-	// Zones only move when the athlete edits them, and every avoidable call is
-	// quota the dashboard widgets can have instead. Refresh them when there's
-	// enrichment to spend them on, or when we've never managed to store any.
+	// Fetched once and then kept. Zones only move when the athlete edits them,
+	// and since they're now the third choice behind a measured threshold (see
+	// zones.js) they usually aren't read at all — so re-reading them on every
+	// invocation of a backfill was a call a minute spent on a value that
+	// mostly doesn't apply. ?full=1 picks up an edit.
 	const storedZones = await readJson(store, ATHLETE_KEY, null);
-	const zones =
-		needsDetail.length > 0 || !storedZones
-			? (await fetchAthleteZones(token)) || storedZones
-			: storedZones;
+	const zones = (storedZones && !full ? null : await fetchAthleteZones(token)) || storedZones;
 
 	const deadline = Date.now() + WORK_DEADLINE_MS;
 	let rateLimited = false;
 	let timedOut = false;
 	let quotaPaused = false;
-	const fetched = await mapWithConcurrency(needsDetail, FETCH_CONCURRENCY, async (summary) => {
+	const fetched = await mapWithConcurrency(needsDetail, FETCH_CONCURRENCY, async (item) => {
 		if (rateLimited) return null;
 
 		// A ride is complete as it stands. Everything the detailed activity
@@ -378,8 +421,8 @@ export default async function handler(req) {
 		// pace, decoupling — is a running measure a ride doesn't carry, so it
 		// shapes straight from the summary for no API calls at all. Tracking
 		// rides therefore takes nothing from the budget the runs need.
-		if (isTrackableRide(summary)) {
-			return shapeActivity(summary, { thresholds, athleteZones: zones });
+		if (item.isRide && item.summary) {
+			return shapeActivity(item.summary, { thresholds, athleteZones: zones });
 		}
 
 		if (Date.now() > deadline) {
@@ -394,8 +437,11 @@ export default async function handler(req) {
 		}
 		try {
 			const [detail, streams] = await Promise.all([
-				stravaGet(`/activities/${summary.id}?include_all_efforts=true`, token),
-				fetchStreams(summary.id, token),
+				stravaGet(`/activities/${item.id}?include_all_efforts=true`, token),
+				// A ride queued off the index has no summary to shape from, so
+				// it costs the detail — but still not the streams, which it
+				// would carry no number derived from.
+				item.isRide ? null : fetchStreams(item.id, token),
 			]);
 			return shapeActivity(detail, { streams, thresholds, athleteZones: zones });
 		} catch (err) {
@@ -406,7 +452,7 @@ export default async function handler(req) {
 				console.warn("Strava rate limit hit; deferring the rest to the next run");
 				return null;
 			}
-			console.error(`Failed to sync activity ${summary.id}`, err);
+			console.error(`Failed to sync activity ${item.id}`, err);
 			return null;
 		}
 	});
@@ -420,17 +466,25 @@ export default async function handler(req) {
 	// there's backfill outstanding, which is when the calls are worth more
 	// spent on runs that have no numbers at all yet.
 	const lastNoteScan = Date.parse(cursor?.notesScannedAt || "") || 0;
-	const scanNotes = !rateLimited && pending.length === 0 && Date.now() - lastNoteScan >= NOTE_RESCAN_MS;
+	const scanNotes = !rateLimited && work.length === 0 && Date.now() - lastNoteScan >= NOTE_RESCAN_MS;
 	const notesRefreshed = scanNotes ? await refreshNotes(merged, token, todayKey(), deadline) : 0;
 
-	// Only advance the cursor once every candidate has an up-to-date stored
-	// record — otherwise a budget-limited run would skip past the ones it
-	// didn't get to and they'd never be fetched again.
+	// What the sync still owes: records stored at an older version, plus
+	// anything the listing found that isn't stored at all.
 	const stored = new Map(merged.map((a) => [String(a.id), a]));
-	const outstanding = candidates.filter((a) => {
-		const record = stored.get(String(a.id));
-		return !record || record.v !== SHAPE_VERSION;
-	});
+	const owed = new Set();
+	for (const record of merged) {
+		if (record?.v !== SHAPE_VERSION) owed.add(String(record.id));
+	}
+	for (const summary of candidates) {
+		if (!stored.has(String(summary.id))) owed.add(String(summary.id));
+	}
+
+	// The cursor guards the listing and nothing else, so it may advance as
+	// soon as every activity the listing found is stored. A record still
+	// waiting to be re-shaped no longer holds it back: that one is queued from
+	// the index now, and listing it again wouldn't help.
+	const allListedStored = candidates.every((a) => stored.has(String(a.id)));
 	const latestEpoch = merged.length
 		? Math.floor(new Date(merged.at(-1).startDateLocal).getTime() / 1000)
 		: cursor?.lastActivityEpoch || null;
@@ -443,8 +497,8 @@ export default async function handler(req) {
 			// Stamped on the attempt rather than on a success, so a sweep that
 			// finds nothing to do doesn't retry every five minutes.
 			notesScannedAt: scanNotes ? new Date().toISOString() : cursor?.notesScannedAt || null,
-			lastActivityEpoch: outstanding.length === 0 ? latestEpoch : cursor?.lastActivityEpoch || null,
-			outstanding: outstanding.length,
+			lastActivityEpoch: allListedStored ? latestEpoch : cursor?.lastActivityEpoch || null,
+			outstanding: owed.size,
 			// What the page needs to describe a partial history honestly.
 			stored: merged.length,
 		}),
@@ -457,7 +511,7 @@ export default async function handler(req) {
 		synced: shaped.length,
 		notesRefreshed,
 		stored: merged.length,
-		outstanding: outstanding.length,
+		outstanding: owed.size,
 		shapeVersion: SHAPE_VERSION,
 		rescan,
 		rateLimited,
@@ -483,10 +537,17 @@ export default async function handler(req) {
 // Backfill is the expensive case, at up to DETAIL_BUDGET × 2 reads an
 // invocation — more than a quarter hour's whole share in one go. That is fine,
 // and it's why the quota guard exists: it reads Strava's own headers and
-// stands the job down at 60% of either bucket, so a cold start moves at
+// stands the job down at its share of either bucket, so a cold start moves at
 // whatever the window allows and defers the rest. Shortening the interval
 // therefore doesn't buy a faster backfill and can't buy a 429 either; both are
 // the guard's business. What it buys is the steady state.
+//
+// The thing that has to stay true for any of that to hold is that a backfill
+// costs the same *per activity* however often this runs. It didn't, once: a
+// re-shape re-listed the whole block every invocation, so shortening the
+// interval multiplied a fixed 3-read overhead by 288 a day and left nothing to
+// enrich with. See the listing comment in the handler. Per-invocation overhead
+// is the number to watch here, not per-activity cost.
 //
 // A schedule is also the ONLY thing that ever writes this store — a scheduled
 // function can't be invoked over HTTP — so the gap between deploying and the


### PR DESCRIPTION
A `SHAPE_VERSION` bump was importing roughly one run every five minutes instead of finishing inside an hour. The enrichment wasn't the problem — the listing was.

## What was happening

Re-shaping forced a full rescan, on the reasoning that stale records have to be visible to the pass that fetches them. They already were: they're in the stored index, with their ids. So every invocation paged back through four months of history to be told what was already on disk.

Measured against the live account, that listing is **3 reads per invocation**, plus one `/athlete/zones`:

| | reads/day at a 5-minute cadence |
| --- | --- |
| listing, paged back through the block | 864 |
| `/athlete/zones` while backfilling | 288 |
| **overhead before fetching a single activity** | **1,152** |
| Strava's daily read limit | 1,000 |
| what the quota guard allowed (60%) | 600 |

So the sync spent its entire daily quota rediscovering ids, had nothing left to enrich with, and stalled outright once the daily counter passed its share. At the time of writing, read usage was 661 against a 600 ceiling with 79 activities still outstanding — the backfill was not going to finish at all today.

The overhead is fixed per *invocation*, which is why this only became fatal when we moved the schedule to five minutes. Nothing was wrong with the per-activity cost.

## The fix

The listing now only looks for activities we have never seen, and stale records are queued straight from the index. A re-shape costs two reads per activity and nothing else. `?full=1` still pages the whole block back, and a cold start still falls out of an empty cursor.

Athlete zones are fetched once and kept rather than on every backfill invocation — which matters more now they're the third choice behind a measured threshold and usually aren't consulted at all.

That puts a re-shape at ~240 reads on top of a steady state of 288. Those two didn't fit under a 60% daily share, hence three quarters, which still holds back 250 reads a day for the `/dashboard` widgets that share these credentials and are edge-cached for five minutes.

The cursor moves with it: it guards the listing and nothing else, so it advances as soon as everything the listing found is stored. A record waiting to be re-shaped no longer holds it back, because listing it again wouldn't help it. `outstanding` is counted off the index instead.

## Expected behaviour after deploy

Backfill becomes bounded by the short window rather than the daily one — about 29 activities per 15 minutes, so the ~79 still outstanding finish in well under an hour.

## Test plan

- [x] 683 unit tests
- [x] New: a re-shape completes when the listing returns nothing at all, proving stale records are queued from the index
- [x] New: a re-shape asks for activities `after` the cursor rather than the block start, and makes exactly one listing call
- [x] New: `?full=1` still pages back past the cursor
- [x] Existing convergence, budget and quota-guard tests unchanged
- [ ] After deploy, check `outstanding` falls steadily rather than by ones


Made with [Cursor](https://cursor.com)