### PR TITLE
Stop a re-shape reading as a half-imported history

### DIFF
--- a/netlify/functions/_tests/trainingData.test.js
+++ b/netlify/functions/_tests/trainingData.test.js
@@ -188,17 +188,32 @@ describe("trainingData behaviour", () => {
 	it("reports that the history is still being imported", async () => {
 		seed(shapeActivities([rawRun()], { thresholds: PLAN_THRESHOLDS }), {
 			lastRunAt: "2026-08-09T12:00:00.000Z",
-			outstanding: 42,
+			missing: 42,
 			stored: 15,
 		});
 		const { body } = await payload();
 		expect(body.sync).toMatchObject({ hasSynced: true, outstanding: 42, backfilling: true });
 	});
 
+	// A run waiting to be re-shaped after a SHAPE_VERSION bump is stored, and
+	// the history it belongs to is whole. Counting it as missing put a "still
+	// importing" banner on a complete page for the length of every re-shape,
+	// and the last records to be re-shaped are run-up seeds from months before
+	// anything the page draws.
+	it("says nothing about runs it means to re-shape", async () => {
+		seed(shapeActivities([rawRun()], { thresholds: PLAN_THRESHOLDS }), {
+			lastRunAt: "2026-08-09T12:00:00.000Z",
+			missing: 0,
+			stale: 7,
+		});
+		const { body } = await payload();
+		expect(body.sync).toMatchObject({ backfilling: false, outstanding: 0 });
+	});
+
 	it("distinguishes a complete history from one that has never synced", async () => {
 		seed(shapeActivities([rawRun()], { thresholds: PLAN_THRESHOLDS }), {
 			lastRunAt: "2026-08-09T12:00:00.000Z",
-			outstanding: 0,
+			missing: 0,
 		});
 		expect((await payload()).body.sync).toMatchObject({ hasSynced: true, backfilling: false });
 

--- a/netlify/functions/_tests/trainingSync.test.js
+++ b/netlify/functions/_tests/trainingSync.test.js
@@ -151,12 +151,12 @@ describe("trainingSync", () => {
 		const first = await sync();
 
 		expect(first.body.synced).toBe(30);
-		expect(first.body.outstanding).toBe(10);
+		expect(first.body.missing).toBe(10);
 		expect(cursor().lastActivityEpoch).toBeNull();
 
 		const second = await sync();
 		expect(second.body.synced).toBe(10);
-		expect(second.body.outstanding).toBe(0);
+		expect(second.body.missing).toBe(0);
 		expect(index()).toHaveLength(40);
 		expect(cursor().lastActivityEpoch).toBeGreaterThan(0);
 	});
@@ -184,7 +184,7 @@ describe("trainingSync", () => {
 
 		expect(body.quotaPaused).toBe(true);
 		expect(body.synced).toBeLessThan(30);
-		expect(body.outstanding).toBeGreaterThan(0);
+		expect(body.missing).toBeGreaterThan(0);
 		expect(calls.filter((c) => /\/activities\/\d+\?/.test(c)).length).toBeLessThan(30);
 	});
 
@@ -192,7 +192,7 @@ describe("trainingSync", () => {
 		mockStrava({ activities: summaries(40) });
 		await sync();
 
-		expect(cursor()).toMatchObject({ outstanding: 10, stored: 30 });
+		expect(cursor()).toMatchObject({ missing: 10, stored: 30 });
 		expect(cursor().lastRunAt).toEqual(expect.any(String));
 	});
 
@@ -229,7 +229,8 @@ describe("trainingSync", () => {
 		mockStrava({ activities: summaries(2), listing: [] });
 		const { body } = await sync();
 		expect(body.synced).toBe(2);
-		expect(body.outstanding).toBe(0);
+		expect(body.missing).toBe(0);
+		expect(body.stale).toBe(0);
 		expect(index().every((a) => a.v === SHAPE_VERSION)).toBe(true);
 	});
 
@@ -255,6 +256,32 @@ describe("trainingSync", () => {
 		const listings = calls.filter((c) => c.includes("/athlete/activities"));
 		expect(listings).toHaveLength(1);
 		expect(Number(new URL(listings[0]).searchParams.get("after"))).toBe(caughtUp);
+	});
+
+	// The distinction the page hangs on. A re-shape that can't finish leaves a
+	// complete history whose numbers are slightly old — which is nothing like
+	// a history with runs absent from it, and only the second is worth telling
+	// a reader about. See syncState in trainingData.
+	it("counts a run it can't re-shape as stale, never as missing", async () => {
+		mockStrava({ activities: summaries(2) });
+		await sync();
+		blobs.set(
+			"index.json",
+			index().map((a) => ({ ...a, v: SHAPE_VERSION - 1 })),
+		);
+
+		mockStrava({
+			activities: summaries(2),
+			listing: [],
+			quota: { limit: "100,1000", usage: "99,999" },
+		});
+		const { body } = await sync();
+
+		expect(body.quotaPaused).toBe(true);
+		expect(body.synced).toBe(0);
+		expect(body.missing).toBe(0);
+		expect(body.stale).toBe(2);
+		expect(cursor()).toMatchObject({ missing: 0, stale: 2 });
 	});
 
 	it("still pages the whole block back when asked outright", async () => {

--- a/netlify/functions/trainingData.js
+++ b/netlify/functions/trainingData.js
@@ -49,9 +49,14 @@ const memo = createMemo(60_000);
 // half-filled index doesn't produce slightly-off numbers, it produces numbers
 // for a training block the athlete didn't do. Until the backfill lands, that
 // has to be said out loud rather than left to look like a bad month.
+//
+// Only activities that are genuinely absent count. The sync also tracks runs
+// it means to re-shape after a SHAPE_VERSION bump, and those are none of a
+// reader's business: the run is stored, the history is whole, and some of its
+// numbers are about to move slightly. See the accounting in trainingSync.
 function syncState(cursor) {
-	const outstanding = Number(cursor?.outstanding);
-	const pending = Number.isFinite(outstanding) ? Math.max(0, outstanding) : 0;
+	const missing = Number(cursor?.missing);
+	const pending = Number.isFinite(missing) ? Math.max(0, missing) : 0;
 	return {
 		lastRunAt: cursor?.lastRunAt || null,
 		// No cursor at all means the scheduled sync has never completed —

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -469,16 +469,26 @@ export default async function handler(req) {
 	const scanNotes = !rateLimited && work.length === 0 && Date.now() - lastNoteScan >= NOTE_RESCAN_MS;
 	const notesRefreshed = scanNotes ? await refreshNotes(merged, token, todayKey(), deadline) : 0;
 
-	// What the sync still owes: records stored at an older version, plus
-	// anything the listing found that isn't stored at all.
+	// Two kinds of incomplete, and only one of them is worth interrupting a
+	// reader over.
+	//
+	// Missing is an activity the listing found and there's no record of at
+	// all. Every metric on the page reads the whole block — fitness is a
+	// 42-day average, the projection reads the block's best efforts — so a
+	// short history doesn't render slightly-off numbers, it renders numbers
+	// for a block the athlete didn't do. That has to be said out loud.
+	//
+	// Stale is an activity that's stored and complete and merely shaped by an
+	// older version of the code. Re-shaping moves some of its numbers and
+	// changes nothing else about it. Counted together with missing, as they
+	// were, every SHAPE_VERSION bump hung a "still importing" banner on a page
+	// that was already whole — and since the queue runs newest-first, the
+	// stragglers are the oldest run-up records, which exist only to seed a CTL
+	// four months before anything on the page and are the least visible
+	// records in the store.
 	const stored = new Map(merged.map((a) => [String(a.id), a]));
-	const owed = new Set();
-	for (const record of merged) {
-		if (record?.v !== SHAPE_VERSION) owed.add(String(record.id));
-	}
-	for (const summary of candidates) {
-		if (!stored.has(String(summary.id))) owed.add(String(summary.id));
-	}
+	const missing = candidates.filter((a) => !stored.has(String(a.id))).length;
+	const stale = merged.filter((a) => a?.v !== SHAPE_VERSION).length;
 
 	// The cursor guards the listing and nothing else, so it may advance as
 	// soon as every activity the listing found is stored. A record still
@@ -498,8 +508,11 @@ export default async function handler(req) {
 			// finds nothing to do doesn't retry every five minutes.
 			notesScannedAt: scanNotes ? new Date().toISOString() : cursor?.notesScannedAt || null,
 			lastActivityEpoch: allListedStored ? latestEpoch : cursor?.lastActivityEpoch || null,
-			outstanding: owed.size,
-			// What the page needs to describe a partial history honestly.
+			// What the page needs to describe a partial history honestly. Only
+			// `missing` reaches a reader; `stale` is here to be read in a log
+			// when a re-shape looks like it has stopped.
+			missing,
+			stale,
 			stored: merged.length,
 		}),
 	]);
@@ -511,7 +524,8 @@ export default async function handler(req) {
 		synced: shaped.length,
 		notesRefreshed,
 		stored: merged.length,
-		outstanding: owed.size,
+		missing,
+		stale,
 		shapeVersion: SHAPE_VERSION,
 		rescan,
 		rateLimited,

--- a/src/components/Training/sections/SyncNotice.svelte
+++ b/src/components/Training/sections/SyncNotice.svelte
@@ -7,6 +7,10 @@
     metric zero) and during a backfill (a truncated history, which reads as a
     much lower CTL than the athlete has). Both used to look exactly like a
     finished page reporting bad training.
+
+    A run the sync means to re-shape is deliberately not one of them, and the
+    payload doesn't count it — the history is whole and a few of its numbers
+    are about to move. See syncState in trainingData.
 -->
 <script>
     let { sync = null, runCount = 0 } = $props();


### PR DESCRIPTION
The sync counted two different things as `outstanding`, and only one of them is worth telling a reader about.

**Missing** is an activity the listing found and we have no record of at all. Every metric on the page reads the whole block — fitness is a 42-day average, the projection reads the block's best efforts — so a short history doesn't render slightly-off numbers, it renders numbers for a block that didn't happen. That earns a banner.

**Stale** is an activity that's stored, complete, and merely shaped by older code. Re-shaping moves a few of its numbers and changes nothing else.

Counted together, every `SHAPE_VERSION` bump hung *"Still importing — 7 runs to go"* on a page that was already whole, for as long as the re-shape took. Worse, the queue runs newest-first, so the stragglers are the **oldest** records in the store. In today's case the final seven were run-up seeds from 26 January to 15 February — four months before the block starts, present only to give CTL somewhere to begin, and outside the published payload entirely. The last record to clear is reliably the least consequential one we hold.

## What changed

The cursor now keeps `missing` and `stale` apart. Only `missing` reaches the page; `stale` exists to be read in a log when a re-shape looks like it has stopped.

The public payload keeps the field name `outstanding` and simply stops counting the second kind, so `SyncNotice` needs no change beyond a note about what it deliberately won't warn about.

## Not a bug, for the record

The seven runs that prompted this were never stuck. Read usage was 763 against the guard's ceiling of 750 — the backfill cleared 72 runs and ran out of daily budget with seven to go, all of which fetch and shape cleanly when tried by hand. They land on the first invocation after the counter resets.

## Test plan

- [x] 685 unit tests, 33 e2e
- [x] New: a run that can't be re-shaped counts as stale and never as missing, with the quota guard blocking
- [x] New: `trainingData` reports `backfilling: false` for a cursor carrying stale records and nothing missing
- [x] Existing "reports that the history is still being imported" still holds for genuinely absent runs


Made with [Cursor](https://cursor.com)