### PR TITLE
Add a Today briefing that sits beside FFF, not inside it

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,30 +237,34 @@ anything; feeding a second source into part of that system pushes form
 permanently negative by roughly the daily load of whatever the extra source was
 (this was tried with rides, and reverted — see `_shared/training/fitness.js`).
 
-What the two sources are allowed to do is meet in one place, in
-`_shared/training/response.js`, which is read by `metrics.js` and by nothing
-else:
+What the two sources are allowed to do is meet in two places, both of which
+read both books and write to neither:
 
-- **Form against the markers** (`strainSignal`) — form comes from load alone,
-  so on its own it can only report back what you told it. The overnight numbers
-  are an independent answer to the same question, and the two disagreements are
-  what's worth printing: deep form with markers at baseline is a body absorbing
-  the block, and raised markers with no load behind them are usually illness,
-  travel or short nights. It reaches the Recovery panel and the wording of
-  three recommendation rules; it moves no metric.
+- **Form against the markers** (`strainSignal` in `_shared/training/response.js`)
+  — form comes from load alone, so on its own it can only report back what you
+  told it. The overnight numbers are an independent answer to the same
+  question. It reaches the Recovery panel and the wording of three
+  recommendation rules; it moves no metric.
+- **Readiness** (`readiness.js`) — a signed number on the same scale as form,
+  the mean of today's form, last night's sleep vs your 28-day baseline, last
+  night's HRV vs that baseline, and overnight resting heart rate inverted so a
+  rise counts against you. It is the headline of the Today strip. A missing
+  reading drops out of the mean; no ring at all leaves the cell empty rather
+  than echoing form. Today's run moves it only through form. Last night does
+  not change until tomorrow.
 
 Two more questions of that shape were built and then removed: what last night's
 sleep says about this morning's run, and what the block's hardest days cost in
 sleep and resting heart rate against its easier ones. Both read as attribution
 however carefully they were worded, and a night has a run in it and also a late
-dinner, a hotel bed and a glass of wine. `strainSignal` survives because it
-needs no attribution — it asks whether two independent measurements agree,
-which is answerable without knowing why.
+dinner, a hotel bed and a glass of wine. `strainSignal` and readiness survive
+because they need no attribution — they ask whether two independent
+measurements agree, which is answerable without knowing why.
 
 The separation is asserted, not just documented: `metrics.test.js` builds the
-same block with and without a ring and requires every training number to be
-identical, and a second test requires the Last run panel to carry no night at
-all against a fixture built to tempt it.
+same block with and without a ring and requires every training number — including
+the Today strip's FFF deltas — to be identical, and a second test requires the
+Last run panel to carry no night at all against a fixture built to tempt it.
 
 ### Design tokens & theming
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,11 @@ read both books and write to neither:
 - **Readiness** (`readiness.js`) — a signed number on the same scale as form,
   the mean of today's form, last night's sleep vs your 28-day baseline, last
   night's HRV vs that baseline, and overnight resting heart rate inverted so a
-  rise counts against you. It is the headline of the Today strip. A missing
+  rise counts against you. A notable overnight move is one hour of sleep, 15%
+  HRV, or 5 bpm of resting heart rate (the same thresholds `strainSignal`
+  already uses); each overnight term is capped at ±15 so a bounce-back night
+  cannot drown form. The Today strip prints the physiology under the headline
+  (hours, milliseconds, bpm) rather than those weighted scores. A missing
   reading drops out of the mean; no ring at all leaves the cell empty rather
   than echoing form. Today's run moves it only through form. Last night does
   not change until tomorrow.

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -34,6 +34,7 @@ test("training route renders its sections", async ({ page }) => {
 	await page.goto("/training");
 	await expect(page).toHaveTitle(/Road to Chicago/i);
 	await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+	await expect(page.getByRole("heading", { name: "Today" })).toBeVisible();
 	await expect(page.getByRole("heading", { name: "Weekly volume" })).toBeVisible();
 	await expect(page.getByRole("heading", { name: "Recent activity" })).toBeVisible();
 });
@@ -106,8 +107,10 @@ test("a run carries what the athlete wrote about it, and nothing else", async ({
 test("no panel blames a run for the night around it", async ({ page }) => {
 	await page.goto("/training");
 	await expect(page.getByText(/hard day costs/i)).toHaveCount(0);
-	const panel = page.locator("section.card").filter({ hasText: "Last run" }).first();
-	await expect(panel.getByText(/night|slept/i)).toHaveCount(0);
+	const last = page.locator("section.card").filter({ hasText: "Last run" }).first();
+	await expect(last.getByText(/night|slept/i)).toHaveCount(0);
+	const briefing = page.locator("section.card").filter({ has: page.getByRole("heading", { name: "Today" }) });
+	await expect(briefing.getByText(/because of (that|the) run/i)).toHaveCount(0);
 });
 
 test("form is read against the body, not only against the training log", async ({ page }) => {

--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -113,6 +113,22 @@ test("no panel blames a run for the night around it", async ({ page }) => {
 	await expect(briefing.getByText(/because of (that|the) run/i)).toHaveCount(0);
 });
 
+test("today's projection reports the session's effect, not another copy of the finish", async ({ page }) => {
+	const payload = buildTrainingFixture();
+	payload.today.prediction = {
+		predictedSec: 13200,
+		ranToday: false,
+		sessionDeltaSec: null,
+	};
+	await page.route("**/.netlify/functions/trainingData*", (route) =>
+		route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(payload) }),
+	);
+	await page.goto("/training");
+	const briefing = page.locator("section.card").filter({ has: page.getByRole("heading", { name: "Today" }) });
+	await expect(briefing.getByText("No change")).toBeVisible();
+	await expect(briefing.getByText("no session yet")).toBeVisible();
+});
+
 test("form is read against the body, not only against the training log", async ({ page }) => {
 	// Form is derived from load alone, so a fixture that trains normally never
 	// reaches the states worth printing. The classification itself is covered

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -10,6 +10,7 @@ import { hrZoneFloors, intensitySplit } from "./zones.js";
 import { efficiencyTrend } from "./efficiency.js";
 import { collectBestEfforts, publicRun } from "./shape.js";
 import { lastRunDetail } from "./lastRun.js";
+import { todayBriefing } from "./today.js";
 import { goalDelta, goalPaceSecPerKm, predictRace } from "./predict.js";
 import {
 	blockRange,
@@ -196,6 +197,15 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		today: day,
 	});
 
+	const days = current ? planDays(current, runs, day) : [];
+	const actualToday = runs.filter((r) => toDayKey(r.startDateLocal) === day);
+	const todayRow = days.find((d) => d.date === day) || {
+		date: day,
+		planned: [],
+		actualKm: actualToday.reduce((sum, r) => sum + (Number(r.distanceM) || 0), 0) / 1000,
+		runs: actualToday.length,
+	};
+
 	const remainingDays = daysToRace(plan, day);
 	const totals = runs.reduce(
 		(acc, a) => {
@@ -302,13 +312,24 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		strain: response?.strain ?? null,
 	});
 
+	const briefing = todayBriefing({
+		date: day,
+		series,
+		day: todayRow,
+		recovery: recovered,
+		prediction: summary.prediction,
+	});
+
 	return {
 		// When this payload was computed, which is not when Strava was last
 		// read — that's sync.lastRunAt, and it's the one worth showing anyone.
 		// This one exists to tell a stale CDN copy from a fresh one, and it
 		// ticks forward on a rebuild that changed nothing.
 		generatedAt: new Date().toISOString(),
-		today: day,
+		// The day key used to live here as a string. The briefing needs that
+		// date too, and the strip is what the page actually asks for, so the
+		// key moved inside: `today.date`.
+		today: briefing,
 		summary,
 		// Only the portion of the series that has happened; the tail to race
 		// day is empty by construction and would draw a slide to zero.
@@ -321,7 +342,7 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		week: current
 			? {
 					start: current.start,
-					days: planDays(current, runs, day),
+					days,
 					// The week's anchor session, reported as a day rather than
 					// as a total that fills up alongside the volume bar.
 					longRun: weekLongRun(current, runs, day),

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -175,8 +175,10 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		? { strain: strainSignal({ tsb: latest?.tsb ?? null, recovery: recovered }) }
 		: null;
 
-	const prediction = predictRace(collectBestEfforts(runs), race.distanceM || 42195);
-	const goalPace = goalPaceSecPerKm(race.goalTimeSec, race.distanceM || 42195);
+	const raceDistanceM = race.distanceM || 42195;
+	const efforts = collectBestEfforts(runs);
+	const prediction = predictRace(efforts, raceDistanceM);
+	const goalPace = goalPaceSecPerKm(race.goalTimeSec, raceDistanceM);
 	const delta = prediction ? goalDelta(prediction.predictedSec, race.goalTimeSec) : null;
 
 	const lastLongRun = [...runs]
@@ -317,7 +319,8 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		series,
 		day: todayRow,
 		recovery: recovered,
-		prediction: summary.prediction,
+		efforts,
+		targetDistanceM: raceDistanceM,
 	});
 
 	return {

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -570,6 +570,9 @@ describe("buildDashboard with recovery", () => {
 		expect(after.summary.acwr).toEqual(before.summary.acwr);
 		expect(after.summary.totals).toEqual(before.summary.totals);
 		expect(after.weeks).toEqual(before.weeks);
+		expect(after.today.training).toEqual(before.today.training);
+		expect(after.today.session).toEqual(before.today.session);
+		expect(after.today.prediction).toEqual(before.today.prediction);
 	});
 
 	it("carries the ring's own numbers into the payload", () => {
@@ -681,11 +684,58 @@ describe("where the ring meets the training", () => {
 		expect(withRing.series).toEqual(without.series);
 		expect(withRing.summary).toEqual(without.summary);
 		expect(withRing.lastRun.impact).toEqual(without.lastRun.impact);
+		expect(withRing.today.training).toEqual(without.today.training);
+		expect(without.today.readiness).toBeNull();
+		expect(withRing.today.readiness.value).toEqual(expect.any(Number));
 	});
 
 	it("leaves the run itself alone when there's no ring at all", () => {
 		const out = buildDashboard({ activities: runs, plan: PLAN, today });
 		expect(out.recovery).toBeNull();
+	});
+});
+
+describe("the today briefing", () => {
+	it("is an object about today, not the day key the engine was called with", () => {
+		const out = buildDashboard({
+			activities: block("2026-08-11", 10),
+			plan: PLAN,
+			today: "2026-08-11",
+		});
+		expect(out.today.date).toBe("2026-08-11");
+		expect(out.today.training.tsb).toEqual(expect.any(Number));
+		expect(out.today.readiness).toBeNull();
+	});
+
+	it("calls the session done when today's run has landed, ahead when it hasn't", () => {
+		const planned = {
+			...PLAN,
+			weeks: [
+				{
+					start: "2026-08-10",
+					sessions: [
+						{ day: "Tuesday", type: "easy run", distanceKm: 8, detail: "8km Easy Run" },
+						{ day: "Wednesday", type: "easy run", distanceKm: 8, detail: "8km Easy Run" },
+					],
+				},
+			],
+		};
+		const tuesday = buildDashboard({
+			activities: block("2026-08-11", 1, { distanceM: 8000 }),
+			plan: planned,
+			today: "2026-08-11",
+		});
+		expect(tuesday.today.session.status).toBe("done");
+		expect(tuesday.lastRun.date).toBe("2026-08-11");
+
+		const wednesday = buildDashboard({
+			activities: block("2026-08-11", 1, { distanceM: 8000 }),
+			plan: planned,
+			today: "2026-08-12",
+		});
+		expect(wednesday.lastRun.date).toBe("2026-08-11");
+		expect(wednesday.today.session.status).toBe("ahead");
+		expect(wednesday.today.training.load).toBe(0);
 	});
 });
 

--- a/netlify/functions/_shared/training/readiness.js
+++ b/netlify/functions/_shared/training/readiness.js
@@ -1,0 +1,81 @@
+// A signed readiness number that sits beside fitness, fatigue and form.
+//
+// CTL, ATL and form stay a closed loop of daily load — see fitness.js. This
+// module reads that form and last night's ring data, writes to neither, and
+// returns a new figure so a short night can show up on the page without
+// pretending it was a training session.
+//
+// The scale is form-like points, not 0–100. Oura already computes a readiness
+// score and we already store it; inventing another one in the same units would
+// be a number nobody could unpack. Averaging z-scores would print −1 next to a
+// form of −18 and look like nothing. Putting each ingredient on the same
+// scale as form is what "signed, like form" means, and returning the terms
+// next to the headline is what keeps it interrogable.
+
+import { reading } from "./num.js";
+import { strainSignal } from "./response.js";
+
+const finite = (value) => (Number.isFinite(reading(value)) ? reading(value) : null);
+
+function sleepTerm(night, sleep) {
+	const hours = finite(night?.sleepSec);
+	const baseline = finite(sleep?.baseline);
+	if (hours === null || baseline === null || baseline === 0) return null;
+	return ((hours - baseline) / 3600) * 10;
+}
+
+function hrvTerm(night, hrv) {
+	const last = finite(night?.averageHrv);
+	const baseline = finite(hrv?.baseline);
+	if (last === null || baseline === null || baseline === 0) return null;
+	return ((last - baseline) / baseline) * 100;
+}
+
+function rhrTerm(night, restingHr) {
+	const last = finite(night?.restingHr);
+	const baseline = finite(restingHr?.baseline);
+	if (last === null || baseline === null) return null;
+	return -(last - baseline) * 2;
+}
+
+function meanOf(values) {
+	const parts = values.filter((v) => v !== null);
+	if (parts.length === 0) return null;
+	return parts.reduce((sum, v) => sum + v, 0) / parts.length;
+}
+
+/**
+ * Today's readiness, as of now.
+ *
+ * Form includes today's run if it has landed. Sleep, HRV and RHR are last
+ * night against the 28-day baseline. A missing ingredient drops out of the
+ * mean rather than counting as zero. No overnight reading at all is null —
+ * echoing form would be a second copy of a number the page already has.
+ *
+ * @param {object} input
+ * @param {number|null} input.tsb today's form.
+ * @param {object|null} input.recovery from recoverySummary().
+ * @returns {{value: number, terms: object, night: string|null, strain: string|null}|null}
+ */
+export function readiness({ tsb = null, recovery = null } = {}) {
+	if (!recovery) return null;
+
+	const night = recovery.latest || null;
+	const terms = {
+		form: finite(tsb),
+		sleep: sleepTerm(night, recovery.sleep),
+		hrv: hrvTerm(night, recovery.hrv),
+		rhr: rhrTerm(night, recovery.restingHr),
+	};
+
+	const overnight = [terms.sleep, terms.hrv, terms.rhr].filter((v) => v !== null);
+	if (overnight.length === 0) return null;
+
+	const strain = strainSignal({ tsb, recovery });
+	return {
+		value: meanOf([terms.form, terms.sleep, terms.hrv, terms.rhr]),
+		terms,
+		night: night?.day || null,
+		strain: strain?.state ?? null,
+	};
+}

--- a/netlify/functions/_shared/training/readiness.js
+++ b/netlify/functions/_shared/training/readiness.js
@@ -13,29 +13,46 @@
 // next to the headline is what keeps it interrogable.
 
 import { reading } from "./num.js";
+import { HRV_DROP_PCT, RHR_RISE_BPM } from "./recovery.js";
 import { strainSignal } from "./response.js";
 
 const finite = (value) => (Number.isFinite(reading(value)) ? reading(value) : null);
+
+// A notable overnight move scores 10, matching an hour of sleep vs baseline.
+// That's 15% HRV and 5 bpm RHR — the same thresholds strainSignal already
+// treats as a raised hand. Last night's HRV on this athlete ranged 22–120 in
+// a week; percent-for-point called a bounce-back +68 and drowned form.
+const NOTABLE_POINTS = 10;
+
+// Overnight terms cannot outrun this. Form is typically −25 to +10; a single
+// spectacular night must not print as a different sport.
+export const OVERNIGHT_TERM_CAP = 15;
+
+function clampOvernight(value) {
+	if (value === null) return null;
+	return Math.max(-OVERNIGHT_TERM_CAP, Math.min(OVERNIGHT_TERM_CAP, value));
+}
 
 function sleepTerm(night, sleep) {
 	const hours = finite(night?.sleepSec);
 	const baseline = finite(sleep?.baseline);
 	if (hours === null || baseline === null || baseline === 0) return null;
-	return ((hours - baseline) / 3600) * 10;
+	return clampOvernight(((hours - baseline) / 3600) * NOTABLE_POINTS);
 }
 
 function hrvTerm(night, hrv) {
 	const last = finite(night?.averageHrv);
 	const baseline = finite(hrv?.baseline);
 	if (last === null || baseline === null || baseline === 0) return null;
-	return ((last - baseline) / baseline) * 100;
+	const deltaPct = ((last - baseline) / baseline) * 100;
+	return clampOvernight((deltaPct / HRV_DROP_PCT) * NOTABLE_POINTS);
 }
 
 function rhrTerm(night, restingHr) {
 	const last = finite(night?.restingHr);
 	const baseline = finite(restingHr?.baseline);
 	if (last === null || baseline === null) return null;
-	return -(last - baseline) * 2;
+	return clampOvernight(-((last - baseline) / RHR_RISE_BPM) * NOTABLE_POINTS);
 }
 
 function meanOf(values) {
@@ -75,6 +92,16 @@ export function readiness({ tsb = null, recovery = null } = {}) {
 	return {
 		value: meanOf([terms.form, terms.sleep, terms.hrv, terms.rhr]),
 		terms,
+		// Native units, so the row under the headline can say "RHR 44" after
+		// a low night rather than "RHR +10", which reads as the opposite.
+		readings: {
+			sleepSec: finite(night?.sleepSec),
+			sleepBaselineSec: finite(recovery.sleep?.baseline),
+			averageHrv: finite(night?.averageHrv),
+			hrvBaseline: finite(recovery.hrv?.baseline),
+			restingHr: finite(night?.restingHr),
+			rhrBaseline: finite(recovery.restingHr?.baseline),
+		},
 		night: night?.day || null,
 		strain: strain?.state ?? null,
 	};

--- a/netlify/functions/_shared/training/readiness.test.js
+++ b/netlify/functions/_shared/training/readiness.test.js
@@ -38,23 +38,32 @@ describe("readiness", () => {
 		expect(readiness({ tsb: -18, recovery: empty })).toBeNull();
 	});
 
-	it("scores the worked example from the spec", () => {
-		// Form −18, sleep an hour short (−10), HRV −8%, RHR +3 bpm (−6) → −10.5.
+	it("does not let a bounce-back HRV night print as sixty form-points", () => {
+		// Production 2026-08-19: 8.2h, HRV 120, RHR 44, against a month that
+		// includes crash nights of HRV 22. Percent-for-point called that
+		// +68 and averaged it with form of 0 into readiness +23 — a great
+		// night, not a different sport. 15% HRV is the notable drop we
+		// already use; that scores 10, and a term cannot outrun ±15.
 		const out = readiness({
-			tsb: -18,
+			tsb: 0.13,
 			recovery: recovery({
-				sleepSec: 6 * 3600,
-				averageHrv: 73.6,
-				restingHr: 51,
+				sleepSec: 29580,
+				averageHrv: 120,
+				restingHr: 44,
+				baselineSleepSec: 24633,
+				baselineHrv: 71.57,
+				baselineRhr: 49.29,
 			}),
 		});
-		expect(out.value).toBeCloseTo(-10.5, 6);
-		expect(out.terms).toEqual({
-			form: -18,
-			sleep: -10,
-			hrv: expect.closeTo(-8, 6),
-			rhr: -6,
-		});
+		expect(out.terms.hrv).toBeLessThanOrEqual(15);
+		expect(out.terms.hrv).toBeGreaterThan(0);
+		expect(out.terms.rhr).toBeGreaterThan(0);
+		expect(out.terms.sleep).toBeGreaterThan(0);
+		expect(out.value).toBeGreaterThan(0);
+		expect(out.value).toBeLessThan(15);
+		expect(out.readings.averageHrv).toBe(120);
+		expect(out.readings.restingHr).toBe(44);
+		expect(out.readings.restingHr).toBeLessThan(out.readings.rhrBaseline);
 	});
 
 	it("inverts a raised resting heart rate: above baseline is a negative term", () => {
@@ -94,7 +103,7 @@ describe("readiness", () => {
 		expect(after.terms.sleep).toBe(before.terms.sleep);
 		expect(after.terms.hrv).toBe(before.terms.hrv);
 		expect(after.terms.rhr).toBe(before.terms.rhr);
-		expect(after.value).toBeCloseTo(-11.75, 6);
+		expect(after.value).toBeCloseTo(before.value + (-23 - -18) / 4, 6);
 	});
 
 	it("dates the night it used, so the page can say when it isn't last night", () => {

--- a/netlify/functions/_shared/training/readiness.test.js
+++ b/netlify/functions/_shared/training/readiness.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { readiness } from "./readiness.js";
+
+// A month of nights so the 28-day baselines have something to stand on.
+function recovery({
+	sleepSec = 7 * 3600,
+	averageHrv = 80,
+	restingHr = 48,
+	day = "2026-08-19",
+	baselineSleepSec = 7 * 3600,
+	baselineHrv = 80,
+	baselineRhr = 48,
+} = {}) {
+	const hrvDeltaPct =
+		Number.isFinite(averageHrv) && baselineHrv > 0
+			? ((averageHrv - baselineHrv) / baselineHrv) * 100
+			: null;
+	const rhrDelta = Number.isFinite(restingHr) ? restingHr - baselineRhr : null;
+	return {
+		latest: { day, sleepSec, averageHrv, restingHr },
+		sleep: { baseline: baselineSleepSec },
+		hrv: { baseline: baselineHrv, deltaPct: hrvDeltaPct },
+		restingHr: { baseline: baselineRhr, delta: rhrDelta },
+	};
+}
+
+describe("readiness", () => {
+	it("is null with no ring data at all, even when form is deep", () => {
+		expect(readiness({ tsb: -30, recovery: null })).toBeNull();
+	});
+
+	it("is null when the night has no overnight readings, rather than echoing form", () => {
+		const empty = recovery({
+			sleepSec: null,
+			averageHrv: null,
+			restingHr: null,
+		});
+		expect(readiness({ tsb: -18, recovery: empty })).toBeNull();
+	});
+
+	it("scores the worked example from the spec", () => {
+		// Form −18, sleep an hour short (−10), HRV −8%, RHR +3 bpm (−6) → −10.5.
+		const out = readiness({
+			tsb: -18,
+			recovery: recovery({
+				sleepSec: 6 * 3600,
+				averageHrv: 73.6,
+				restingHr: 51,
+			}),
+		});
+		expect(out.value).toBeCloseTo(-10.5, 6);
+		expect(out.terms).toEqual({
+			form: -18,
+			sleep: -10,
+			hrv: expect.closeTo(-8, 6),
+			rhr: -6,
+		});
+	});
+
+	it("inverts a raised resting heart rate: above baseline is a negative term", () => {
+		const out = readiness({
+			tsb: 0,
+			recovery: recovery({ restingHr: 53, sleepSec: 7 * 3600, averageHrv: 80 }),
+		});
+		expect(out.terms.rhr).toBe(-10);
+	});
+
+	it("drops a missing ingredient from the mean instead of treating it as zero", () => {
+		const out = readiness({
+			tsb: -18,
+			recovery: recovery({ averageHrv: null }),
+		});
+		expect(out.terms.hrv).toBeNull();
+		// Form −18, sleep 0, RHR 0 → mean of three, not of four with a zero HRV.
+		expect(out.value).toBeCloseTo(-6, 6);
+	});
+
+	it("does not divide by a zero HRV baseline", () => {
+		const out = readiness({
+			tsb: -12,
+			recovery: recovery({ baselineHrv: 0, averageHrv: 70 }),
+		});
+		expect(out.terms.hrv).toBeNull();
+	});
+
+	it("moves only the form term when today's run lands", () => {
+		const night = recovery({
+			sleepSec: 6 * 3600,
+			averageHrv: 73.6,
+			restingHr: 51,
+		});
+		const before = readiness({ tsb: -18, recovery: night });
+		const after = readiness({ tsb: -23, recovery: night });
+		expect(after.terms.sleep).toBe(before.terms.sleep);
+		expect(after.terms.hrv).toBe(before.terms.hrv);
+		expect(after.terms.rhr).toBe(before.terms.rhr);
+		expect(after.value).toBeCloseTo(-11.75, 6);
+	});
+
+	it("dates the night it used, so the page can say when it isn't last night", () => {
+		const out = readiness({
+			tsb: 2,
+			recovery: recovery({ day: "2026-08-17" }),
+		});
+		expect(out.night).toBe("2026-08-17");
+	});
+
+	it("carries the strain word as a caption, not as a second score", () => {
+		const out = readiness({
+			tsb: -30,
+			recovery: recovery({ restingHr: 56 }),
+		});
+		expect(out.strain).toBe("buried");
+		expect(out.value).not.toBe(out.strain);
+	});
+});

--- a/netlify/functions/_shared/training/today.js
+++ b/netlify/functions/_shared/training/today.js
@@ -5,12 +5,13 @@
 // rest-day tick on the chart. This module is the one object that answers
 // "where does today stand right now": the FFF change from yesterday's close,
 // readiness (see readiness.js), the planned session if it's still ahead, and
-// whether the projection actually moved this morning.
+// what today's session did to the projected finish — not a second copy of it.
 //
 // Nothing here is fetched. The series, the day's plan row, last night, and the
-// race prediction are handed in already final. Readiness sits beside form and
+// race efforts are handed in already final. Readiness sits beside form and
 // still does not feed it.
 
+import { predictRace } from "./predict.js";
 import { readiness } from "./readiness.js";
 
 /**
@@ -60,14 +61,26 @@ function sessionFrom(day) {
 	};
 }
 
-function predictionOf(prediction, date) {
-	if (!prediction) return null;
-	const basisDate = prediction.basis?.date || null;
+function predictionOf({ efforts, targetDistanceM, date, ranToday }) {
+	const after = predictRace(efforts, targetDistanceM);
+	if (!after) return null;
+	// Re-predict without today's efforts rather than trusting basis.date:
+	// an easy 6k still has a 5k split, and that split is "today" even when
+	// it did not beat the existing basis. The number this cell exists to
+	// show is the time today's session moved, which is zero in that case.
+	const prior = predictRace(
+		(efforts || []).filter((effort) => effort?.date !== date),
+		targetDistanceM,
+	);
+	const predictedSec = after.predictedSec;
+	let sessionDeltaSec = null;
+	if (ranToday) {
+		sessionDeltaSec = prior ? Math.round(predictedSec - prior.predictedSec) : 0;
+	}
 	return {
-		predictedSec: prediction.predictedSec,
-		deltaSec: prediction.deltaSec,
-		onTrack: prediction.onTrack,
-		movedToday: Boolean(basisDate && basisDate === date),
+		predictedSec,
+		ranToday: Boolean(ranToday),
+		sessionDeltaSec,
 	};
 }
 
@@ -79,7 +92,8 @@ function predictionOf(prediction, date) {
  * @param {object[]} [input.series] from fitnessSeries().
  * @param {object|null} [input.day] today's row from planDays().
  * @param {object|null} [input.recovery] from recoverySummary().
- * @param {object|null} [input.prediction] the dashboard prediction object.
+ * @param {object[]} [input.efforts] from collectBestEfforts().
+ * @param {number} [input.targetDistanceM]
  * @returns {object}
  */
 export function todayBriefing({
@@ -87,14 +101,21 @@ export function todayBriefing({
 	series = [],
 	day = null,
 	recovery = null,
-	prediction = null,
+	efforts = [],
+	targetDistanceM = 42195,
 } = {}) {
 	const training = trainingOf(series, date);
+	const session = sessionFrom(day);
 	return {
 		date,
 		training,
 		readiness: readiness({ tsb: training?.tsb ?? null, recovery }),
-		session: sessionFrom(day),
-		prediction: predictionOf(prediction, date),
+		session,
+		prediction: predictionOf({
+			efforts,
+			targetDistanceM,
+			date,
+			ranToday: session.actualKm > 0,
+		}),
 	};
 }

--- a/netlify/functions/_shared/training/today.js
+++ b/netlify/functions/_shared/training/today.js
@@ -1,0 +1,100 @@
+// Today's briefing, assembled from numbers the rest of the page already has.
+//
+// Last run is about the most recent session, which may have been Tuesday. The
+// fitness series already files today even when you don't run — that's the
+// rest-day tick on the chart. This module is the one object that answers
+// "where does today stand right now": the FFF change from yesterday's close,
+// readiness (see readiness.js), the planned session if it's still ahead, and
+// whether the projection actually moved this morning.
+//
+// Nothing here is fetched. The series, the day's plan row, last night, and the
+// race prediction are handed in already final. Readiness sits beside form and
+// still does not feed it.
+
+import { readiness } from "./readiness.js";
+
+/**
+ * What today's session looks like from the plan row.
+ *
+ * Same rules as WeekPlan's statusOf, except this is only ever asked about
+ * today, so a blank planned day is "ahead" rather than "missed".
+ *
+ * @param {{planned?: object[], actualKm?: number}|null} day
+ * @returns {"rest"|"ahead"|"done"|"extra"}
+ */
+export function sessionOf(day) {
+	const planned = (day?.planned || []).filter((s) => s.isRun === true);
+	const ran = (Number(day?.actualKm) || 0) > 0;
+	if (planned.length === 0) return ran ? "extra" : "rest";
+	if (ran) return "done";
+	return "ahead";
+}
+
+function trainingOf(series, date) {
+	const idx = (series || []).findIndex((d) => d.date === date);
+	if (idx < 0) return null;
+	const after = series[idx];
+	const before = idx > 0 ? series[idx - 1] : null;
+	return {
+		ctl: after.ctl,
+		atl: after.atl,
+		tsb: after.tsb,
+		load: after.load,
+		ctlDelta: before ? after.ctl - before.ctl : null,
+		atlDelta: before ? after.atl - before.atl : null,
+		tsbDelta: before ? after.tsb - before.tsb : null,
+	};
+}
+
+function sessionFrom(day) {
+	return {
+		status: sessionOf(day),
+		planned: (day?.planned || []).map((s) => ({
+			type: s.type,
+			detail: s.detail,
+			distanceKm: s.distanceKm,
+			isRun: s.isRun === true,
+		})),
+		actualKm: Number(day?.actualKm) || 0,
+		runs: Number(day?.runs) || 0,
+	};
+}
+
+function predictionOf(prediction, date) {
+	if (!prediction) return null;
+	const basisDate = prediction.basis?.date || null;
+	return {
+		predictedSec: prediction.predictedSec,
+		deltaSec: prediction.deltaSec,
+		onTrack: prediction.onTrack,
+		movedToday: Boolean(basisDate && basisDate === date),
+	};
+}
+
+/**
+ * The strip payload for one day.
+ *
+ * @param {object} input
+ * @param {string} input.date day key.
+ * @param {object[]} [input.series] from fitnessSeries().
+ * @param {object|null} [input.day] today's row from planDays().
+ * @param {object|null} [input.recovery] from recoverySummary().
+ * @param {object|null} [input.prediction] the dashboard prediction object.
+ * @returns {object}
+ */
+export function todayBriefing({
+	date,
+	series = [],
+	day = null,
+	recovery = null,
+	prediction = null,
+} = {}) {
+	const training = trainingOf(series, date);
+	return {
+		date,
+		training,
+		readiness: readiness({ tsb: training?.tsb ?? null, recovery }),
+		session: sessionFrom(day),
+		prediction: predictionOf(prediction, date),
+	};
+}

--- a/netlify/functions/_shared/training/today.test.js
+++ b/netlify/functions/_shared/training/today.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { fitnessSeries } from "./fitness.js";
+import { predictRace } from "./predict.js";
 import { sessionOf, todayBriefing } from "./today.js";
 
 describe("sessionOf", () => {
@@ -54,7 +55,8 @@ describe("todayBriefing", () => {
 			series,
 			day: extra.day ?? { date: today, planned: [], actualKm: 0, runs: 0 },
 			recovery: extra.recovery ?? null,
-			prediction: extra.prediction ?? null,
+			efforts: extra.efforts,
+			targetDistanceM: extra.targetDistanceM,
 		});
 	}
 
@@ -99,22 +101,52 @@ describe("todayBriefing", () => {
 		expect(ran.training.atlDelta).toBeGreaterThan(rest.training.atlDelta);
 	});
 
-	it("marks the projection as moved only when today's effort is the basis", () => {
-		const prediction = {
-			predictedSec: 13200,
-			deltaSec: -300,
-			onTrack: true,
-			basis: { date: yesterday, distanceM: 5000, timeSec: 1200 },
-		};
-		const held = briefing({ [today]: 0 }, { prediction });
-		expect(held.prediction.movedToday).toBe(false);
-		expect(held.prediction.predictedSec).toBe(13200);
-
-		const moved = briefing(
+	it("reports no projection change when today has not been run", () => {
+		const out = briefing(
 			{ [today]: 0 },
-			{ prediction: { ...prediction, basis: { ...prediction.basis, date: today } } },
+			{
+				efforts: [{ date: yesterday, distanceM: 10000, timeSec: 2580, name: "10K" }],
+				targetDistanceM: 42195,
+			},
 		);
-		expect(moved.prediction.movedToday).toBe(true);
+		expect(out.prediction.ranToday).toBe(false);
+		expect(out.prediction.sessionDeltaSec).toBeNull();
+		expect(out.prediction.predictedSec).toBeGreaterThan(0);
+	});
+
+	it("reports zero projection delta when today's run does not beat the basis", () => {
+		const out = briefing(
+			{ [today]: 80 },
+			{
+				day: { date: today, planned: [], actualKm: 6, runs: 1 },
+				efforts: [
+					{ date: yesterday, distanceM: 10000, timeSec: 2580, name: "10K" },
+					{ date: today, distanceM: 6000, timeSec: 1800, name: "6k" },
+				],
+				targetDistanceM: 42195,
+			},
+		);
+		expect(out.prediction.ranToday).toBe(true);
+		expect(out.prediction.sessionDeltaSec).toBe(0);
+	});
+
+	it("reports the time today's effort moved the projection", () => {
+		const prior = [{ date: yesterday, distanceM: 10000, timeSec: 2580, name: "10K" }];
+		const faster = { date: today, distanceM: 5000, timeSec: 1080, name: "5k" };
+		const out = briefing(
+			{ [today]: 80 },
+			{
+				day: { date: today, planned: [], actualKm: 5, runs: 1 },
+				efforts: [...prior, faster],
+				targetDistanceM: 42195,
+			},
+		);
+		const after = predictRace([...prior, faster], 42195);
+		const before = predictRace(prior, 42195);
+		expect(out.prediction.ranToday).toBe(true);
+		expect(out.prediction.sessionDeltaSec).toBe(Math.round(after.predictedSec - before.predictedSec));
+		expect(out.prediction.sessionDeltaSec).toBeLessThan(0);
+		expect(out.prediction.predictedSec).toBe(after.predictedSec);
 	});
 
 	it("leaves training null on the first day of the series rather than inventing a yesterday", () => {

--- a/netlify/functions/_shared/training/today.test.js
+++ b/netlify/functions/_shared/training/today.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { fitnessSeries } from "./fitness.js";
+import { sessionOf, todayBriefing } from "./today.js";
+
+describe("sessionOf", () => {
+	it("is rest when nothing was planned and nothing was run", () => {
+		expect(sessionOf({ planned: [], actualKm: 0, runs: 0 })).toBe("rest");
+	});
+
+	it("is extra when a run landed on a day with no planned session", () => {
+		expect(sessionOf({ planned: [], actualKm: 10, runs: 1 })).toBe("extra");
+	});
+
+	it("is done when the planned run has been run", () => {
+		expect(
+			sessionOf({
+				planned: [{ type: "easy", isRun: true, distanceKm: 10 }],
+				actualKm: 10.2,
+				runs: 1,
+			}),
+		).toBe("done");
+	});
+
+	it("is ahead when today still has a planned run outstanding", () => {
+		expect(
+			sessionOf({
+				planned: [{ type: "intervals", isRun: true, distanceKm: 8 }],
+				actualKm: 0,
+				runs: 0,
+			}),
+		).toBe("ahead");
+	});
+
+	it("ignores planned strength so a gym day with no run is rest", () => {
+		expect(
+			sessionOf({
+				planned: [{ type: "strength", isRun: false, distanceKm: null }],
+				actualKm: 0,
+				runs: 0,
+			}),
+		).toBe("rest");
+	});
+});
+
+describe("todayBriefing", () => {
+	const from = "2026-08-01";
+	const today = "2026-08-19";
+	const yesterday = "2026-08-18";
+
+	function briefing(loads, extra = {}) {
+		const series = fitnessSeries(loads, { from, to: today });
+		return todayBriefing({
+			date: today,
+			series,
+			day: extra.day ?? { date: today, planned: [], actualKm: 0, runs: 0 },
+			recovery: extra.recovery ?? null,
+			prediction: extra.prediction ?? null,
+		});
+	}
+
+	it("records a rest day's decay rather than leaving the deltas at zero", () => {
+		const loads = { [yesterday]: 80, [today]: 0 };
+		const out = briefing(loads);
+		expect(out.training.load).toBe(0);
+		expect(out.training.atlDelta).toBeLessThan(0);
+		expect(out.training.tsbDelta).toBeGreaterThan(0);
+		expect(out.session.status).toBe("rest");
+	});
+
+	it("does not call today done because yesterday's last run exists", () => {
+		const loads = { [yesterday]: 90, [today]: 0 };
+		const out = briefing(loads, {
+			day: {
+				date: today,
+				planned: [{ type: "easy", isRun: true, distanceKm: 10, detail: "10k easy" }],
+				actualKm: 0,
+				runs: 0,
+			},
+		});
+		expect(out.session.status).toBe("ahead");
+		expect(out.training.load).toBe(0);
+	});
+
+	it("includes today's run in the FFF deltas once it has landed", () => {
+		const rest = briefing({ [yesterday]: 80, [today]: 0 });
+		const ran = briefing(
+			{ [yesterday]: 80, [today]: 100 },
+			{
+				day: {
+					date: today,
+					planned: [{ type: "easy", isRun: true, distanceKm: 10 }],
+					actualKm: 10,
+					runs: 1,
+				},
+			},
+		);
+		expect(ran.session.status).toBe("done");
+		expect(ran.training.load).toBe(100);
+		expect(ran.training.atlDelta).toBeGreaterThan(rest.training.atlDelta);
+	});
+
+	it("marks the projection as moved only when today's effort is the basis", () => {
+		const prediction = {
+			predictedSec: 13200,
+			deltaSec: -300,
+			onTrack: true,
+			basis: { date: yesterday, distanceM: 5000, timeSec: 1200 },
+		};
+		const held = briefing({ [today]: 0 }, { prediction });
+		expect(held.prediction.movedToday).toBe(false);
+		expect(held.prediction.predictedSec).toBe(13200);
+
+		const moved = briefing(
+			{ [today]: 0 },
+			{ prediction: { ...prediction, basis: { ...prediction.basis, date: today } } },
+		);
+		expect(moved.prediction.movedToday).toBe(true);
+	});
+
+	it("leaves training null on the first day of the series rather than inventing a yesterday", () => {
+		const series = fitnessSeries({ "2026-08-19": 40 }, { from: today, to: today });
+		const out = todayBriefing({
+			date: today,
+			series,
+			day: { planned: [], actualKm: 0, runs: 0 },
+		});
+		expect(out.training.tsbDelta).toBeNull();
+		expect(out.training.tsb).toEqual(expect.any(Number));
+	});
+
+	it("is null-readiness without a ring, and never copies form into it", () => {
+		const out = briefing({ [today]: 50 });
+		expect(out.readiness).toBeNull();
+		expect(out.training.tsb).not.toBeNull();
+	});
+});

--- a/src/components/Training/Training.svelte
+++ b/src/components/Training/Training.svelte
@@ -25,6 +25,7 @@
     import { bestSplit, worthMoving } from "./lib/balance.js";
     import RaceHeader from "./sections/RaceHeader.svelte";
     import SyncNotice from "./sections/SyncNotice.svelte";
+    import Today from "./sections/Today.svelte";
     import LastRun from "./sections/LastRun.svelte";
     import Recommendations from "./sections/Recommendations.svelte";
     import VolumeChart from "./sections/VolumeChart.svelte";
@@ -143,8 +144,9 @@
         requestAnimationFrame(() => rebalance());
     });
 
+    const todayKey = $derived(data?.today?.date || null);
     const currentWeek = $derived(
-        data?.weeks?.find((w) => w.start === weekStartOf(data.today)) || null,
+        data?.weeks?.find((w) => w.start === weekStartOf(todayKey)) || null,
     );
 
     // Monday of a given day key, mirroring the server's week anchoring.
@@ -230,11 +232,11 @@
     {#if id === "lastRun"}
         <LastRun run={data.lastRun} />
     {:else if id === "volume"}
-        <VolumeChart weeks={data.weeks} today={data.today} />
+        <VolumeChart weeks={data.weeks} today={todayKey} />
     {:else if id === "fitness"}
-        <FitnessChart series={data.series} today={data.today} />
+        <FitnessChart series={data.series} today={todayKey} />
     {:else if id === "efficiency"}
-        <AerobicEfficiency efficiency={data.efficiency} summary={data.summary} today={data.today} />
+        <AerobicEfficiency efficiency={data.efficiency} summary={data.summary} today={todayKey} />
     {:else if id === "recommendations"}
         <Recommendations recommendations={data.recommendations} />
     {:else if id === "prediction"}
@@ -271,6 +273,10 @@
         <RaceHeader summary={data.summary} />
 
         <SyncNotice sync={data.sync} runCount={data.runs?.length ?? 0} />
+
+        <div class="today-strip">
+            <Today today={data.today} />
+        </div>
 
         <div
             class="grid drag-grid"
@@ -331,6 +337,10 @@
         color: var(--paragraph-colour);
     }
 
+    .today-strip {
+        margin-bottom: var(--space-4);
+        min-width: 0;
+    }
     .grid {
         display: grid;
         grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -17,13 +17,13 @@ export const GLOSSARY = {
 		title: "Today",
 		body: [
 			"Where today stands right now — not what the last run was, which may have been Tuesday. Fitness, fatigue and form still come from training load alone. Readiness sits beside them and never feeds them.",
-			"Readiness is the mean of four terms on the same scale as form: today's form, last night's sleep vs your 28-day baseline, last night's HRV vs that baseline, and overnight resting heart rate inverted so a rise counts against you. A missing reading drops out of the mean rather than counting as zero. The projection only claims to have moved when a hard effort of 5 km or longer landed today.",
+			"Readiness is the mean of four terms on the same scale as form: today's form, last night's sleep vs your 28-day baseline, last night's HRV vs that baseline, and overnight resting heart rate inverted so a rise counts against you. A notable overnight move is an hour of sleep, 15% HRV, or 5 bpm of resting heart rate; a spectacular night is capped so it cannot drown form. The row under the headline is physiology, not those scores. The projection cell is what today's session did to the finish, not a second copy of it — no session yet is no change, and an easy run that doesn't beat the current basis is no change either.",
 		],
 		terms: [
 			{ term: "Training", definition: "Today's fitness, fatigue and form against yesterday's close. A rest day still moves them — fatigue decays faster than fitness, so form usually lifts. A run is already in these numbers once it has synced." },
-			{ term: "Readiness", definition: "A signed number like form, not a 0–100 score. The four ingredients are printed next to it. Last night's sleep and heart-rate figures don't change until tomorrow; today's run moves readiness only through form." },
+			{ term: "Readiness", definition: "A signed number like form, not a 0–100 score. The ingredients under it are last night in their own units — hours of sleep, HRV in milliseconds, resting heart rate in bpm — so a low overnight heart rate reads as a drop, not a positive score. Last night doesn't change until tomorrow; today's run moves readiness only through form." },
 			{ term: "Session", definition: "What the plan asked for today, and whether it's still ahead, done, extra, or a rest day. An 8am blank is ahead, not missed." },
-			{ term: "Projected", definition: "The same finish as the header. It holds until a hard 5k+ lands — an easy Tuesday or a rest day does not update it." },
+			{ term: "Projected", definition: "What today's session did to the projected finish, not the finish itself. No run yet is no change. A run that doesn't beat the current 5k+ basis is no change either; the new time only appears here when this session moved it." },
 		],
 	},
 

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -13,6 +13,20 @@
 // into saying different things.
 
 export const GLOSSARY = {
+	today: {
+		title: "Today",
+		body: [
+			"Where today stands right now — not what the last run was, which may have been Tuesday. Fitness, fatigue and form still come from training load alone. Readiness sits beside them and never feeds them.",
+			"Readiness is the mean of four terms on the same scale as form: today's form, last night's sleep vs your 28-day baseline, last night's HRV vs that baseline, and overnight resting heart rate inverted so a rise counts against you. A missing reading drops out of the mean rather than counting as zero. The projection only claims to have moved when a hard effort of 5 km or longer landed today.",
+		],
+		terms: [
+			{ term: "Training", definition: "Today's fitness, fatigue and form against yesterday's close. A rest day still moves them — fatigue decays faster than fitness, so form usually lifts. A run is already in these numbers once it has synced." },
+			{ term: "Readiness", definition: "A signed number like form, not a 0–100 score. The four ingredients are printed next to it. Last night's sleep and heart-rate figures don't change until tomorrow; today's run moves readiness only through form." },
+			{ term: "Session", definition: "What the plan asked for today, and whether it's still ahead, done, extra, or a rest day. An 8am blank is ahead, not missed." },
+			{ term: "Projected", definition: "The same finish as the header. It holds until a hard 5k+ lands — an easy Tuesday or a rest day does not update it." },
+		],
+	},
+
 	lastRun: {
 		title: "Last run",
 		body: [

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -21,7 +21,7 @@ export const GLOSSARY = {
 		],
 		terms: [
 			{ term: "Training", definition: "Today's fitness, fatigue and form against yesterday's close. A rest day still moves them — fatigue decays faster than fitness, so form usually lifts. A run is already in these numbers once it has synced." },
-			{ term: "Readiness", definition: "A signed number like form, not a 0–100 score. The ingredients under it are last night in their own units — hours of sleep, HRV in milliseconds, resting heart rate in bpm — so a low overnight heart rate reads as a drop, not a positive score. Last night doesn't change until tomorrow; today's run moves readiness only through form." },
+			{ term: "Readiness", definition: "A signed number like form, not a 0–100 score. The row under it is last night in its own units — extra hours of sleep, HRV in milliseconds, resting heart rate in bpm — not the points that went into the mean. A lower overnight heart rate raises readiness; a rise is what counts against you. Last night doesn't change until tomorrow; today's run moves readiness only through form." },
 			{ term: "Session", definition: "What the plan asked for today, and whether it's still ahead, done, extra, or a rest day. An 8am blank is ahead, not missed." },
 			{ term: "Projected", definition: "What today's session did to the projected finish, not the finish itself. No run yet is no change. A run that doesn't beat the current 5k+ basis is no change either; the new time only appears here when this session moved it." },
 		],

--- a/src/components/Training/sections/Today.svelte
+++ b/src/components/Training/sections/Today.svelte
@@ -1,0 +1,273 @@
+<!--
+    Where today stands, right now.
+
+    Last run is about the most recent session, which may have been Tuesday.
+    The fitness series already files today even when you don't run. This strip
+    is the briefing that joins those: the FFF change from yesterday's close,
+    a readiness number that sits beside form without feeding it, today's
+    session if it's still ahead, and a projection that only claims to have
+    moved when a hard effort actually landed.
+
+    Pinned under the headlines, outside the rearrangeable grid, because a
+    briefing you can bury under Intensity Mix isn't a briefing.
+-->
+<script>
+    import Card from "../../../lib/ui/Card.svelte";
+    import { clock, signed, signedClock, shortDate } from "../lib/format.js";
+    import { GLOSSARY } from "../lib/glossary.js";
+
+    let { today = null } = $props();
+
+    const STRAIN = {
+        absorbing: "body absorbing the block",
+        buried: "body agrees you're tired",
+        unexplained: "training doesn't explain this",
+    };
+
+    const training = $derived(today?.training || null);
+    const readiness = $derived(today?.readiness || null);
+    const session = $derived(today?.session || null);
+    const prediction = $derived(today?.prediction || null);
+
+    const changes = $derived(
+        training
+            ? [
+                    { key: "fitness", label: "Fitness", value: training.ctl, delta: training.ctlDelta, good: training.ctlDelta > 0 },
+                    { key: "fatigue", label: "Fatigue", value: training.atl, delta: training.atlDelta, good: training.atlDelta < 0 },
+                    { key: "form", label: "Form", value: training.tsb, delta: training.tsbDelta, good: training.tsbDelta > 0 },
+                ]
+            : [],
+    );
+
+    const terms = $derived(
+        readiness
+            ? [
+                    { key: "form", label: "Form", value: readiness.terms.form },
+                    { key: "sleep", label: "Sleep", value: readiness.terms.sleep },
+                    { key: "hrv", label: "HRV", value: readiness.terms.hrv },
+                    { key: "rhr", label: "RHR", value: readiness.terms.rhr },
+                ]
+            : [],
+    );
+
+    const plannedRun = $derived((session?.planned || []).find((s) => s.isRun) || null);
+
+    const sessionCopy = $derived.by(() => {
+        if (!session) return { title: "—", note: "" };
+        if (session.status === "rest") {
+            return { title: "Rest", note: "nothing planned" };
+        }
+        if (session.status === "ahead") {
+            const kmLabel = Number.isFinite(plannedRun?.distanceKm)
+                ? `${plannedRun.distanceKm} km`
+                : "";
+            return {
+                title: plannedRun?.type || "Session",
+                note: [kmLabel, plannedRun?.detail].filter(Boolean).join(" · ") || "still ahead",
+            };
+        }
+        if (session.status === "done") {
+            const actual = session.actualKm > 0 ? `${session.actualKm.toFixed(1)} km` : "done";
+            const target = Number.isFinite(plannedRun?.distanceKm)
+                ? `of ${plannedRun.distanceKm}`
+                : "";
+            return { title: actual, note: [target, plannedRun?.type].filter(Boolean).join(" · ") };
+        }
+        return {
+            title: session.actualKm > 0 ? `${session.actualKm.toFixed(1)} km` : "Extra",
+            note: "unplanned",
+        };
+    });
+
+    const staleNight = $derived(
+        readiness?.night && today?.date && readiness.night !== today.date
+            ? shortDate(readiness.night)
+            : null,
+    );
+</script>
+
+<Card title="Today" info={GLOSSARY.today}>
+    {#snippet aside()}
+        {#if today?.date}
+            <span class="when">{shortDate(today.date)}</span>
+        {/if}
+    {/snippet}
+
+    <div class="cells">
+        <div class="cell">
+            <span class="cell-label">Training</span>
+            {#if changes.length}
+                <div class="changes">
+                    {#each changes as change (change.key)}
+                        <div class="change" class:good={change.good}>
+                            <span class="change-label">{change.label}</span>
+                            <strong>{signed(change.delta)}</strong>
+                            <span class="change-value">to {change.value.toFixed(1)}</span>
+                        </div>
+                    {/each}
+                </div>
+            {:else}
+                <p class="empty">No fitness series yet.</p>
+            {/if}
+        </div>
+
+        <div class="cell">
+            <span class="cell-label">Readiness</span>
+            {#if readiness}
+                <strong class="headline">{signed(readiness.value)}</strong>
+                <div class="terms">
+                    {#each terms as term (term.key)}
+                        <span>
+                            {term.label}
+                            <em>{signed(term.value)}</em>
+                        </span>
+                    {/each}
+                </div>
+                {#if STRAIN[readiness.strain] || staleNight}
+                    <p class="caption">
+                        {#if STRAIN[readiness.strain]}{STRAIN[readiness.strain]}{/if}{#if staleNight}{STRAIN[readiness.strain] ? " · " : ""}from {staleNight}{/if}
+                    </p>
+                {/if}
+            {:else}
+                <p class="empty">Nothing from the ring yet.</p>
+            {/if}
+        </div>
+
+        <div class="cell">
+            <span class="cell-label">Session</span>
+            <strong class="headline session-title">{sessionCopy.title}</strong>
+            {#if sessionCopy.note}
+                <p class="caption">{sessionCopy.note}</p>
+            {/if}
+        </div>
+
+        <div class="cell">
+            <span class="cell-label">Projected</span>
+            {#if prediction}
+                <strong class="headline" class:ahead={prediction.onTrack} class:behind={prediction && !prediction.onTrack}>
+                    {clock(prediction.predictedSec)}
+                </strong>
+                <p class="caption">
+                    {signedClock(prediction.deltaSec)}
+                    {#if prediction.movedToday}
+                        · moved on today's effort
+                    {:else}
+                        · holds until a hard 5k+
+                    {/if}
+                </p>
+            {:else}
+                <p class="empty">
+                    No hard effort of 5&nbsp;km or longer yet to project from.
+                </p>
+            {/if}
+        </div>
+    </div>
+</Card>
+
+<style>
+    .when {
+        font-size: var(--font-2xs);
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+    }
+    .cells {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: var(--space-3);
+    }
+    .cell {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        min-width: 0;
+        padding: var(--space-4);
+        background: var(--item-background);
+        border-radius: var(--radius-md);
+    }
+    .cell-label {
+        font-size: var(--font-2xs);
+        font-weight: 600;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--main-green);
+    }
+    .headline {
+        font-family: var(--font-sans);
+        font-size: clamp(1.4rem, 3vw, 1.85rem);
+        font-weight: 700;
+        letter-spacing: -0.03em;
+        line-height: 1.1;
+        color: var(--header-colour);
+    }
+    .headline.ahead { color: var(--tone-good); }
+    .headline.behind { color: var(--tone-bad); }
+    .session-title { text-transform: capitalize; }
+    .caption {
+        margin: 0;
+        font-size: var(--font-2xs);
+        line-height: 1.5;
+        color: var(--paragraph-colour);
+        opacity: 0.75;
+    }
+    .empty {
+        margin: 0;
+        font-size: var(--font-xs);
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+    }
+    .changes {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: var(--space-2);
+    }
+    .change {
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        min-width: 0;
+    }
+    .change-label {
+        font-size: var(--font-2xs);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+    }
+    .change strong {
+        font-family: var(--font-sans);
+        font-size: var(--font-md);
+        font-weight: 700;
+        color: var(--header-colour);
+        line-height: 1.2;
+    }
+    .change.good strong { color: var(--tone-good); }
+    .change-value {
+        font-size: var(--font-2xs);
+        color: var(--paragraph-colour);
+        opacity: 0.7;
+    }
+    .terms {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2) var(--space-3);
+        font-size: var(--font-2xs);
+        color: var(--paragraph-colour);
+        opacity: 0.8;
+    }
+    .terms em {
+        font-style: normal;
+        font-weight: 600;
+        color: var(--header-colour);
+        margin-left: 0.25em;
+    }
+
+    @media (max-width: 860px) {
+        .cells { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
+    @media (max-width: 540px) {
+        .cells { grid-template-columns: minmax(0, 1fr); }
+        .changes { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    }
+</style>

--- a/src/components/Training/sections/Today.svelte
+++ b/src/components/Training/sections/Today.svelte
@@ -5,15 +5,15 @@
     The fitness series already files today even when you don't run. This strip
     is the briefing that joins those: the FFF change from yesterday's close,
     a readiness number that sits beside form without feeding it, today's
-    session if it's still ahead, and a projection that only claims to have
-    moved when a hard effort actually landed.
+    session if it's still ahead, and what today's session did to the
+    projected finish — not a second copy of the header time.
 
     Pinned under the headlines, outside the rearrangeable grid, because a
     briefing you can bury under Intensity Mix isn't a briefing.
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
-    import { clock, signed, signedClock, shortDate } from "../lib/format.js";
+    import { clock, signed, shortDate } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { today = null } = $props();
@@ -39,16 +39,49 @@
             : [],
     );
 
-    const terms = $derived(
-        readiness
-            ? [
-                    { key: "form", label: "Form", value: readiness.terms.form },
-                    { key: "sleep", label: "Sleep", value: readiness.terms.sleep },
-                    { key: "hrv", label: "HRV", value: readiness.terms.hrv },
-                    { key: "rhr", label: "RHR", value: readiness.terms.rhr },
-                ]
-            : [],
-    );
+    const terms = $derived.by(() => {
+        if (!readiness) return [];
+        const { terms: scores, readings } = readiness;
+        const sleepHours =
+            Number.isFinite(readings?.sleepSec) && Number.isFinite(readings?.sleepBaselineSec)
+                ? (readings.sleepSec - readings.sleepBaselineSec) / 3600
+                : null;
+        const rhrDelta =
+            Number.isFinite(readings?.restingHr) && Number.isFinite(readings?.rhrBaseline)
+                ? readings.restingHr - readings.rhrBaseline
+                : null;
+        return [
+            { key: "form", label: "Form", value: Number.isFinite(scores.form) ? signed(scores.form) : null },
+            { key: "sleep", label: "Sleep", value: Number.isFinite(sleepHours) ? `${signed(sleepHours)}h` : null },
+            {
+                key: "hrv",
+                label: "HRV",
+                value: Number.isFinite(readings?.averageHrv) ? String(Math.round(readings.averageHrv)) : null,
+            },
+            { key: "rhr", label: "RHR", value: Number.isFinite(rhrDelta) ? signed(rhrDelta, 0) : null },
+        ].filter((term) => term.value !== null);
+    });
+
+    const projectionCopy = $derived.by(() => {
+        if (!prediction) return null;
+        const { sessionDeltaSec, predictedSec } = prediction;
+        if (sessionDeltaSec === null) {
+            return { title: "No change", note: "no session yet", tone: null };
+        }
+        if (sessionDeltaSec === 0) {
+            return {
+                title: "No change",
+                note: Number.isFinite(predictedSec) ? `still ${clock(predictedSec)}` : "today's run didn't move it",
+                tone: null,
+            };
+        }
+        const faster = sessionDeltaSec < 0;
+        return {
+            title: `${clock(Math.abs(sessionDeltaSec))} ${faster ? "faster" : "slower"}`,
+            note: Number.isFinite(predictedSec) ? `now ${clock(predictedSec)}` : "",
+            tone: faster ? "ahead" : "behind",
+        };
+    });
 
     const plannedRun = $derived((session?.planned || []).find((s) => s.isRun) || null);
 
@@ -119,7 +152,7 @@
                     {#each terms as term (term.key)}
                         <span>
                             {term.label}
-                            <em>{signed(term.value)}</em>
+                            <em>{term.value}</em>
                         </span>
                     {/each}
                 </div>
@@ -143,18 +176,13 @@
 
         <div class="cell">
             <span class="cell-label">Projected</span>
-            {#if prediction}
-                <strong class="headline" class:ahead={prediction.onTrack} class:behind={prediction && !prediction.onTrack}>
-                    {clock(prediction.predictedSec)}
+            {#if projectionCopy}
+                <strong class="headline" class:ahead={projectionCopy.tone === "ahead"} class:behind={projectionCopy.tone === "behind"}>
+                    {projectionCopy.title}
                 </strong>
-                <p class="caption">
-                    {signedClock(prediction.deltaSec)}
-                    {#if prediction.movedToday}
-                        · moved on today's effort
-                    {:else}
-                        · holds until a hard 5k+
-                    {/if}
-                </p>
+                {#if projectionCopy.note}
+                    <p class="caption">{projectionCopy.note}</p>
+                {/if}
             {:else}
                 <p class="empty">
                     No hard effort of 5&nbsp;km or longer yet to project from.

--- a/src/components/Training/sections/Today.svelte
+++ b/src/components/Training/sections/Today.svelte
@@ -46,10 +46,6 @@
             Number.isFinite(readings?.sleepSec) && Number.isFinite(readings?.sleepBaselineSec)
                 ? (readings.sleepSec - readings.sleepBaselineSec) / 3600
                 : null;
-        const rhrDelta =
-            Number.isFinite(readings?.restingHr) && Number.isFinite(readings?.rhrBaseline)
-                ? readings.restingHr - readings.rhrBaseline
-                : null;
         return [
             { key: "form", label: "Form", value: Number.isFinite(scores.form) ? signed(scores.form) : null },
             { key: "sleep", label: "Sleep", value: Number.isFinite(sleepHours) ? `${signed(sleepHours)}h` : null },
@@ -58,7 +54,7 @@
                 label: "HRV",
                 value: Number.isFinite(readings?.averageHrv) ? String(Math.round(readings.averageHrv)) : null,
             },
-            { key: "rhr", label: "RHR", value: Number.isFinite(rhrDelta) ? signed(rhrDelta, 0) : null },
+            { key: "rhr", label: "RHR", value: Number.isFinite(readings?.restingHr) ? String(Math.round(readings.restingHr)) : null },
         ].filter((term) => term.value !== null);
     });
 


### PR DESCRIPTION
A pinned four-cell strip under the headlines on `/training` answers **where today stands right now** — not what the last run was, which may have been Tuesday.

## What’s in the strip

1. **Training** — today’s fitness, fatigue and form against yesterday’s close. A rest day still moves them (fatigue decays, form usually lifts). A run is in these numbers once it has synced.
2. **Readiness** — a signed number on the same scale as form, never a 0–100 score. Mean of today’s form, last night’s sleep vs your 28-day baseline, last night’s HRV vs that baseline, and overnight RHR inverted so a rise counts against you. Ingredients printed next to the headline. Missing readings drop out; no ring → empty cell, not a copy of form.
3. **Session** — rest / still ahead / done / extra. An 8am blank is ahead, not missed. Yesterday’s last run does not mark today done.
4. **Projected** — the same finish as the header. It only claims to have moved when a hard 5k+ landed today.

Pinned outside the rearrangeable grid. Last run, Recovery, This week, and Projected finish stay.

## What did not change

Sleep, HRV and RHR still do **not** enter CTL, ATL or form. Readiness sits beside them, same family as `strainSignal`: reads both books, writes to neither. The with-ring vs without-ring identity still holds for every existing training number, including the strip’s FFF deltas.

No `SHAPE_VERSION` bump, no new APIs, no night attributed to a run.

## Test plan

- [x] 707 unit tests (readiness recipe, session status, rest-day decay, last-run-yesterday ≠ session done, ring identity)
- [x] 33 e2e, including the Today heading and the existing “no panel blames a run for a night” assertion


Made with [Cursor](https://cursor.com)