### PR TITLE
Sweep training notes every five minutes for three hours after a run lands

### DIFF
--- a/netlify/functions/_tests/trainingSync.test.js
+++ b/netlify/functions/_tests/trainingSync.test.js
@@ -335,6 +335,108 @@ describe("trainingSync", () => {
 		expect(index()).toEqual(before);
 	});
 
+	// A note is written after the run it explains, so the sweep is the only
+	// thing that ever picks one up — and how long it waits between passes is
+	// the whole delay on seeing it. The property worth asserting is that the
+	// wait is short exactly when a note is likely (just after a run landed)
+	// and long the rest of the time, since the calls come out of the same
+	// quota the /dashboard widgets are drawing on.
+	describe("the note sweep", () => {
+		// The sweep only reads the last few days, and the sync's days are the
+		// athlete's rather than UTC.
+		const today = () => new Date().toLocaleDateString("en-CA", { timeZone: "America/Toronto" });
+
+		function justRun(description) {
+			return [
+				{
+					id: 9001,
+					name: "Long run",
+					type: "Run",
+					sport_type: "Run",
+					private: false,
+					start_date_local: `${today()}T07:00:00Z`,
+					distance: 22000,
+					moving_time: 6600,
+					...(description === undefined ? {} : { description }),
+				},
+			];
+		}
+
+		const notes = () => index()[0].notes;
+
+		it("picks up a note written minutes after the run, not an hour after it", async () => {
+			mockStrava({ activities: justRun() });
+			await sync();
+			expect(notes()).toEqual([]);
+
+			// The sweep the run's arrival opened. Under an hourly cadence this
+			// one would land too, since nothing has been swept yet.
+			mockStrava({ activities: justRun("excuse: knee, cut it to 10k") });
+			const first = await sync();
+			expect(first.body.notesFresh).toBe(true);
+			expect(first.body.notesRefreshed).toBe(1);
+			expect(notes()).toEqual([{ kind: "excuse", text: "knee, cut it to 10k" }]);
+
+			// This is the one the hourly cadence would have made the athlete
+			// wait for: an edit five minutes later, on the same run.
+			mockStrava({ activities: justRun("note: new shoes") });
+			const second = await sync();
+			expect(second.body.notesRefreshed).toBe(1);
+			expect(notes()).toEqual([{ kind: "note", text: "new shoes" }]);
+		});
+
+		// Five minutes is worth its calls while the run is the thing being
+		// looked at. A day later it's spending a quota shared with the
+		// dashboard on a description nobody is editing.
+		it("drops back to hourly once the run is a few hours old", async () => {
+			mockStrava({ activities: justRun() });
+			await sync();
+
+			const hoursAgo = (h) => new Date(Date.now() - h * 3600_000).toISOString();
+			blobs.set("cursor.json", {
+				...cursor(),
+				activityArrivedAt: hoursAgo(4),
+				notesScannedAt: hoursAgo(0.25),
+			});
+
+			mockStrava({ activities: justRun("note: written much later") });
+			const soon = await sync();
+			expect(soon.body.notesFresh).toBe(false);
+			expect(soon.body.notesRefreshed).toBe(0);
+			expect(notes()).toEqual([]);
+
+			blobs.set("cursor.json", { ...cursor(), notesScannedAt: hoursAgo(2) });
+			const later = await sync();
+			expect(later.body.notesRefreshed).toBe(1);
+			expect(notes()).toEqual([{ kind: "note", text: "written much later" }]);
+		});
+
+		// The window is opened by a run the sweep would actually read. A cold
+		// start stores four months of run-up history in one go, and none of
+		// it is a run somebody is about to write a note on.
+		it("isn't opened by a backfill of history nobody is looking at", async () => {
+			mockStrava({ activities: summaries(3) });
+			const { body } = await sync();
+
+			expect(body.synced).toBe(3);
+			expect(body.notesFresh).toBe(false);
+			expect(cursor().activityArrivedAt).toBeNull();
+		});
+
+		// Notes are the cheapest thing here and the least urgent. A run with
+		// no numbers on it at all is worth more than a description.
+		it("waits for the backfill before spending anything on descriptions", async () => {
+			const calls = mockStrava({ activities: [...justRun("note: hello"), ...summaries(40)] });
+			const { body } = await sync();
+
+			expect(body.missing).toBeGreaterThan(0);
+			expect(body.notesRefreshed).toBe(0);
+			// Every detail call this made was an enrichment, which carries its
+			// query string; a note refresh asks for the activity bare.
+			expect(calls.filter((c) => /\/activities\/\d+$/.test(c))).toHaveLength(0);
+		});
+	});
+
 	describe("the Oura window", () => {
 		// Oura's date range excludes its end. Asking through today therefore
 		// returns every night except last night, and the failure is quiet:

--- a/netlify/functions/trainingSync.js
+++ b/netlify/functions/trainingSync.js
@@ -84,11 +84,32 @@ const WORK_DEADLINE_MS = 20_000;
 //
 // Rather than making a settled record pending again (which would re-fetch the
 // streams to recompute numbers that cannot have moved), the last few days are
-// swept on the hour for the description alone: one call each, and only the
-// notes are patched across. Three days because a note that hasn't been written
-// by then isn't coming, and hourly because the wait to see it is the cost.
+// swept for the description alone: one call each, and only the notes are
+// patched across. Three days because a note that hasn't been written by then
+// isn't coming.
+//
+// How long the sweep waits between passes is the whole delay on seeing a note,
+// and the odds of there being one to see are not flat over those three days.
+// They spike right after a run lands: the note is usually typed in the same
+// sitting as the upload, or in the hour or two after it while the run is still
+// the thing being looked at. So for the first few hours after an activity
+// first appears the sweep runs on every invocation — the same five minutes the
+// activity itself took to show up, so a note written beside it isn't waiting
+// an hour behind a run the page already has. After that the odds flatten out
+// and it falls back to hourly, which is what a note remembered the next
+// morning is worth.
+//
+// The fast pass is bounded by an activity arriving rather than by a clock, so
+// the steady state is still the hourly one: a week with no runs in it costs
+// exactly what it did before. A day with a run in it costs the three hours
+// after it — 36 invocations of at most NOTE_BUDGET reads each, against a daily
+// share of 750 that the listing spends 288 of. The quota guard is what makes
+// that a ceiling rather than a promise: the sweep stands down at its share
+// like everything else here, so a busy day trims the fast pass rather than
+// taking the window the /dashboard widgets need.
 const NOTE_WINDOW_DAYS = 3;
 const NOTE_RESCAN_MS = 60 * 60 * 1000;
+const NOTE_FRESH_WINDOW_MS = 3 * 60 * 60 * 1000;
 const NOTE_BUDGET = 5;
 
 // Chronic training load is a 42-day average, so the block needs a run-up of
@@ -261,6 +282,14 @@ async function fetchStreams(id, token) {
 	}
 }
 
+// A record a note sweep would look at at all: recent enough that a note could
+// still be written on it, and a run rather than a ride, since a ride's
+// description is never read for notes.
+function inNoteWindow(record, today) {
+	if (record?.sport === "ride") return false;
+	return toDayKey(record?.startDateLocal) >= addDays(today, -NOTE_WINDOW_DAYS);
+}
+
 /**
  * Bring the notes on the last few days' runs up to date, in place.
  *
@@ -274,10 +303,7 @@ async function fetchStreams(id, token) {
  * @returns {Promise<number>} how many were refreshed.
  */
 async function refreshNotes(records, token, today, deadline) {
-	const from = addDays(today, -NOTE_WINDOW_DAYS);
-	const recent = records
-		.filter((a) => a?.sport !== "ride" && toDayKey(a?.startDateLocal) >= from)
-		.slice(-NOTE_BUDGET);
+	const recent = records.filter((a) => inNoteWindow(a, today)).slice(-NOTE_BUDGET);
 
 	let refreshed = 0;
 	for (const record of recent) {
@@ -462,12 +488,29 @@ export default async function handler(req) {
 
 	// Deliberately last, and deliberately not part of the staleness pass
 	// above: nothing here can make a record pending, so a sweep that runs out
-	// of budget just leaves a note until the next hour. Skipped entirely while
+	// of budget just leaves a note until the next pass. Skipped entirely while
 	// there's backfill outstanding, which is when the calls are worth more
 	// spent on runs that have no numbers at all yet.
+	const today = todayKey();
+
+	// When a run last turned up that a note could be written on. Wall-clock
+	// arrival rather than the run's own start time, because what starts the
+	// clock is the activity reaching the page — an upload hours after a race,
+	// or a watch that only syncs when it finds wifi, is still a run the
+	// athlete is looking at now.
+	//
+	// Gated on the record being one the sweep would read anyway, which is what
+	// keeps a cold start from spending three hours sweeping every five minutes
+	// on the strength of a four-month backfill of run-up history.
+	const arrived = shaped.some((a) => !current.has(String(a.id)) && inNoteWindow(a, today));
+	const arrivedAt = arrived ? new Date().toISOString() : cursor?.activityArrivedAt || null;
+	const fresh = Date.now() - (Date.parse(arrivedAt || "") || 0) < NOTE_FRESH_WINDOW_MS;
+
 	const lastNoteScan = Date.parse(cursor?.notesScannedAt || "") || 0;
-	const scanNotes = !rateLimited && work.length === 0 && Date.now() - lastNoteScan >= NOTE_RESCAN_MS;
-	const notesRefreshed = scanNotes ? await refreshNotes(merged, token, todayKey(), deadline) : 0;
+	// Zero is every invocation, which is the schedule's five minutes.
+	const noteInterval = fresh ? 0 : NOTE_RESCAN_MS;
+	const scanNotes = !rateLimited && work.length === 0 && Date.now() - lastNoteScan >= noteInterval;
+	const notesRefreshed = scanNotes ? await refreshNotes(merged, token, today, deadline) : 0;
 
 	// Two kinds of incomplete, and only one of them is worth interrupting a
 	// reader over.
@@ -505,8 +548,14 @@ export default async function handler(req) {
 		writeJson(store, CURSOR_KEY, {
 			lastRunAt: new Date().toISOString(),
 			// Stamped on the attempt rather than on a success, so a sweep that
-			// finds nothing to do doesn't retry every five minutes.
+			// finds nothing to do waits out its interval instead of being
+			// retried on the next invocation — which, outside the fast window,
+			// is the difference between hourly and every five minutes.
 			notesScannedAt: scanNotes ? new Date().toISOString() : cursor?.notesScannedAt || null,
+			// What the fast window is measured from, and why it survives the
+			// invocation that opened it: the run that starts the clock arrives
+			// on a pass that has backfill outstanding and so doesn't sweep.
+			activityArrivedAt: arrivedAt,
 			lastActivityEpoch: allListedStored ? latestEpoch : cursor?.lastActivityEpoch || null,
 			// What the page needs to describe a partial history honestly. Only
 			// `missing` reaches a reader; `stale` is here to be read in a log
@@ -523,6 +572,9 @@ export default async function handler(req) {
 		runs: candidates.length,
 		synced: shaped.length,
 		notesRefreshed,
+		// Whether the sweep is on the five-minute cadence or the hourly one,
+		// which is otherwise only visible as a read count in Strava's quota.
+		notesFresh: fresh,
 		stored: merged.length,
 		missing,
 		stale,
@@ -540,7 +592,8 @@ export default async function handler(req) {
 // is the whole delay rather than half of it.
 //
 // Once caught up an invocation is two upstream calls: a token refresh and one
-// activity listing. Strava meters those in two buckets and the tighter one is
+// activity listing — plus, on the pass that sweeps notes, a call per run in
+// that sweep. Strava meters those in two buckets and the tighter one is
 // reads — 100 per 15 minutes and 1,000 per day at the standard tier — but only
 // the listing is a read, since the refresh is a POST to /oauth/token. So this
 // cadence spends about 288 reads a day of 1,000, and three of the 100 in any


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

The note sweep in `trainingSync` refreshed Strava descriptions once an hour across a three-day window. A note typed right after a run uploaded therefore waited up to an hour to appear on `/training`, even though the run itself showed up within five minutes of finishing.

Notes are almost always written in the same sitting as the upload, so the sweep now runs on **every invocation — the sync's five-minute cadence — for the first three hours after an activity arrives**, then falls back to the hourly cadence for the rest of the three-day window.

## How

- `NOTE_FRESH_WINDOW_MS` (3h) sets how long the fast cadence lasts. Inside it the sweep's interval is zero, which is every scheduled invocation; outside it, `NOTE_RESCAN_MS` (1h) applies as before.
- The window opens on **arrival**, not on the run's own start time: the clock starts when an activity the sync has never stored turns up, since an upload hours after a race is still a run the athlete is looking at now. The new `activityArrivedAt` field on the cursor is what carries that across invocations, which matters because the pass that first stores a run has backfill outstanding and so doesn't sweep.
- The trigger is gated on `inNoteWindow` (extracted from `refreshNotes`, so both use the same definition): only a run recent enough for the sweep to read opens the window. A cold-start backfill of four months of run-up history therefore doesn't spend three hours sweeping every five minutes.
- The response body reports `notesFresh`, so which cadence a given invocation was on is visible without inferring it from Strava's read counts.

## Quota

A day with a run in it now costs the three hours after it: 36 invocations of at most `NOTE_BUDGET` (5) reads, on top of the 288 listings a day, against the 750-read daily share. A week with no runs in it costs exactly what it did before. The existing quota guard still bounds the sweep at its share of either rate-limit bucket, so a busy day trims the fast pass rather than taking the window the `/dashboard` widgets need.

## Testing

`npm run test:run` (713 tests) and `npm run lint` (0 errors) pass. Four tests were added under `trainingSync > the note sweep` covering a note picked up minutes after the run rather than an hour, the fall back to hourly once the run is a few hours old, a backfill of old history not opening the window, and notes still yielding to an outstanding backfill. The first fails against the previous hourly-only behaviour.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01c51-33da-78da-ae34-0d90dd212d9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01c51-33da-78da-ae34-0d90dd212d9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

