### PR TITLE
Adjust marathon projections for training readiness

### DIFF
--- a/e2e/training.e2e.js
+++ b/e2e/training.e2e.js
@@ -39,6 +39,16 @@ test("training route renders its sections", async ({ page }) => {
 	await expect(page.getByRole("heading", { name: "Recent activity" })).toBeVisible();
 });
 
+test("projected finish shows readiness and a likely range, not a time to the second", async ({ page }) => {
+	await page.goto("/training");
+	const card = page.locator("section.card").filter({ hasText: "Projected finish" }).first();
+	await expect(card.getByText("Likely range", { exact: false })).toBeVisible();
+	await expect(card.locator(".model-label", { hasText: "Aerobic potential" })).toBeVisible();
+	await expect(card.locator(".model-label", { hasText: "Marathon readiness" })).toBeVisible();
+	await expect(card.getByText(/Moderate confidence|High confidence|Low confidence/)).toBeVisible();
+	await expect(card.locator(".projected strong")).toHaveText(/^\d:\d\d$/);
+});
+
 test("every card explains its own metrics on demand", async ({ page }) => {
 	await page.goto("/training");
 	const card = page.locator("section.card").filter({ hasText: "Load and risk" }).first();

--- a/netlify/functions/_shared/training/fallback.js
+++ b/netlify/functions/_shared/training/fallback.js
@@ -8,6 +8,7 @@
 
 import {
 	clock,
+	clockMinutes,
 	daysAgo,
 	formatDistance,
 	formatDuration,
@@ -167,7 +168,7 @@ function renderHeader(summary) {
 <p>${[raceDate, countdown].filter(Boolean).map(t).join(" ")}</p>
 ${pairs([
 	["Goal", `${clock(race.goalTimeSec)} (${pace(race.goalPaceSecPerKm)})`],
-	["Projected", prediction ? `${clock(prediction.predictedSec)}; ${signedClock(prediction.deltaSec)}` : "needs a hard effort to project from"],
+	["Projected", prediction ? `${clockMinutes(prediction.predictedSec)}; ${signedClock(prediction.deltaSec)}` : "needs a hard effort to project from"],
 	["Fitness", latest ? `${Math.round(latest.ctl)}; ${trendNote}` : trendNote],
 	["Block total", `${kmLabel(summary?.totals?.distanceM)}; ${summary?.totals?.runs || 0} runs`],
 ])}`;
@@ -345,12 +346,27 @@ function renderPrediction(summary) {
 	const basisLine = basis
 		? `<p>Projected from ${t(kmLabel(basis.distanceM))} in ${t(clock(basis.timeSec))}${basis.date ? ` on ${t(shortDate(basis.date))}` : ""}.</p>`
 		: "";
+	const range = prediction.projectionRange;
+	const rangeLine = range
+		? ["Likely range", `${clockMinutes(range.fastSec)}–${clockMinutes(range.slowSec)}`]
+		: null;
+	const ready = Number.isFinite(prediction.marathonReadiness)
+		? ["Marathon readiness", `${Math.round(prediction.marathonReadiness * 100)}%${prediction.confidenceLabel ? `; ${prediction.confidenceLabel} confidence` : ""}`]
+		: null;
+	const aerobic = Number.isFinite(prediction.aerobicPotentialSeconds)
+		? ["Aerobic potential", `${clockMinutes(prediction.aerobicPotentialSeconds)}; VDOT ${clockMinutes(prediction.vdotSec)} · Riegel ${clockMinutes(prediction.riegelSec)}`]
+		: ["VDOT", `${clock(prediction.vdotSec)}${Number.isFinite(prediction.vdot) ? ` (${prediction.vdot.toFixed(1)})` : ""}`];
+	const factors = (prediction.explanations || [])
+		.map((item) => `<li>${t(item.direction === "limiting" ? "Limiting" : "Positive")}: ${t(item.text)}</li>`)
+		.join("");
 	return section("Projected finish", `${pairs([
-		["Projected", `${clock(prediction.predictedSec)}; ${signedClock(prediction.deltaSec)}`],
-		["Riegel", clock(prediction.riegelSec)],
-		["VDOT", `${clock(prediction.vdotSec)}${Number.isFinite(prediction.vdot) ? ` (${prediction.vdot.toFixed(1)})` : ""}`],
+		["Projected", `${clockMinutes(prediction.predictedSec)}; ${signedClock(prediction.deltaSec)}`],
+		rangeLine,
+		aerobic,
+		ready,
 		["Goal pace", pace(race.goalPaceSecPerKm)],
-	])}
+	].filter(Boolean))}
+${factors ? `<ul>${factors}</ul>` : ""}
 ${basisLine}`);
 }
 

--- a/netlify/functions/_shared/training/marathonConfig.js
+++ b/netlify/functions/_shared/training/marathonConfig.js
@@ -1,0 +1,144 @@
+// Tunable constants for the marathon-readiness projection.
+//
+// These are starting values, not a validated scientific model. They live in
+// one place so later calibration against actual race results can happen
+// without hunting through scoring code. Changing a weight or a curve here
+// should be the whole of a calibration pass.
+
+export const MARATHON_M = 42195;
+
+export const MARATHON_PROJECTION = {
+	weights: {
+		volume: 0.3,
+		longRuns: 0.25,
+		decoupling: 0.15,
+		consistency: 0.1,
+		frequency: 0.08,
+		fitnessTrend: 0.07,
+		recovery: 0.05,
+	},
+
+	// adjustedSeconds = baseSeconds * (1 + k * (1 - readiness)^exponent)
+	// k and exponent are conservative: excellent prep barely moves the
+	// aerobic baseline; missing marathon-specific work opens a wider gap.
+	penalty: {
+		k: 0.22,
+		exponent: 1.7,
+	},
+
+	windows: {
+		longRunDays: 70,
+		consistencyWeeks: 10,
+		frequencyDays: 42,
+		volumeFastWeeks: 4,
+		volumeSlowWeeks: 8,
+		peakWeeks: 10,
+		peakCount: 3,
+		recencyHalfLifeDays: 21,
+		effortRecencyHalfLifeDays: 90,
+		recoveryBaselineDays: 42,
+	},
+
+	baseline: {
+		minDistanceM: 5000,
+		// Longer races are stronger evidence for a marathon. A 5k still
+		// counts, but it should not drown a slower half.
+		distanceWeight: [
+			{ minM: 21097, weight: 1 },
+			{ minM: 15000, weight: 0.75 },
+			{ minM: 10000, weight: 0.55 },
+			{ minM: 5000, weight: 0.35 },
+		],
+		// If a short effort projects more than this fraction faster than the
+		// longer-distance ensemble, its weight is scaled down.
+		disagreementPct: 0.08,
+	},
+
+	volume: {
+		ewma8FloorKm: 40,
+		ewma8FullKm: 85,
+		ewma4FloorKm: 40,
+		ewma4FullKm: 90,
+		peakFloorKm: 50,
+		peakFullKm: 95,
+	},
+
+	longRuns: {
+		topN: 4,
+		countMinM: 16000,
+		over20M: 20000,
+		over25M: 25000,
+		over30M: 30000,
+		longestFloorM: 18000,
+		longestFullM: 34000,
+		averageFloorM: 18000,
+		averageFullM: 30000,
+		countsFull: { over20: 4, over25: 3, over30: 2 },
+		// GAP pace relative to predicted marathon pace that still counts as
+		// "near marathon effort" rather than a race. Faster than the floor
+		// is racing the long run and is not rewarded.
+		nearMarathonPaceFloor: 0.97,
+		nearMarathonPaceCeil: 1.1,
+		paceBoost: 0.06,
+	},
+
+	decoupling: {
+		minDurationSec: 75 * 60,
+		excellentPct: 2,
+		concernPct: 8,
+	},
+
+	consistency: {
+		lowVolumePct: 50,
+		cvFull: 0.12,
+		cvFloor: 0.55,
+	},
+
+	frequency: {
+		floor: 2,
+		full: 4.5,
+	},
+
+	longRunShare: {
+		cautionPct: 45,
+		heavyPct: 55,
+		maxPenalty: 0.08,
+	},
+
+	intensity: {
+		easyFloorPct: 65,
+		acwrSpike: 1.3,
+		maxPenalty: 0.04,
+	},
+
+	fitness: {
+		gainFloor: -8,
+		gainFull: 6,
+		taperDays: 21,
+		acwrIdeal: 1.05,
+		acwrSpread: 0.45,
+	},
+
+	recovery: {
+		hrvDropPct: 15,
+		rhrRiseBpm: 5,
+		sleepDropPct: 12,
+	},
+
+	confidence: {
+		high: 0.72,
+		moderate: 0.45,
+	},
+
+	range: {
+		minPct: 0.012,
+		maxPct: 0.07,
+		slowAsymmetry: 1.35,
+	},
+
+	raceDay: {
+		plannedCredit: 0.55,
+		minRemainingKm: 20,
+		minDaysToRace: 8,
+	},
+};

--- a/netlify/functions/_shared/training/marathonConfig.js
+++ b/netlify/functions/_shared/training/marathonConfig.js
@@ -22,7 +22,7 @@ export const MARATHON_PROJECTION = {
 	// k and exponent are conservative: excellent prep barely moves the
 	// aerobic baseline; missing marathon-specific work opens a wider gap.
 	penalty: {
-		k: 0.22,
+		k: 0.12,
 		exponent: 1.7,
 	},
 
@@ -57,6 +57,11 @@ export const MARATHON_PROJECTION = {
 		// even when the session is longer than the effort (warmup/cooldown).
 		splitRatio: 1.08,
 		splitExtraM: 1500,
+		// Untagged training runs at long-run pace are not races. Keep an
+		// effort only if it is near the athlete's peak VDOT (Garmin-like
+		// VO2max) or is tagged as a race. A slower race still informs the
+		// ensemble; an easy 15k does not.
+		qualityVdotFloor: 0.9,
 	},
 
 	volume: {

--- a/netlify/functions/_shared/training/marathonConfig.js
+++ b/netlify/functions/_shared/training/marathonConfig.js
@@ -52,15 +52,23 @@ export const MARATHON_PROJECTION = {
 		// If a short effort projects more than this fraction faster than the
 		// longer-distance ensemble, its weight is scaled down.
 		disagreementPct: 0.08,
+		// A best-effort on a much longer easy or long run is a split, not a
+		// race. Races and workouts (Strava workout_type 1 and 3) are kept
+		// even when the session is longer than the effort (warmup/cooldown).
+		splitRatio: 1.08,
+		splitExtraM: 1500,
 	},
 
 	volume: {
-		ewma8FloorKm: 40,
-		ewma8FullKm: 85,
-		ewma4FloorKm: 40,
-		ewma4FullKm: 90,
-		peakFloorKm: 50,
-		peakFullKm: 95,
+		ewma8FloorKm: 20,
+		ewma8FullKm: 70,
+		ewma4FloorKm: 20,
+		ewma4FullKm: 75,
+		peakFloorKm: 25,
+		peakFullKm: 80,
+		planFloor: 0.45,
+		planFull: 1,
+		absoluteWeight: 0.55,
 	},
 
 	longRuns: {
@@ -92,6 +100,8 @@ export const MARATHON_PROJECTION = {
 		lowVolumePct: 50,
 		cvFull: 0.12,
 		cvFloor: 0.55,
+		recentWeeks: 5,
+		cvWeeks: 6,
 	},
 
 	frequency: {

--- a/netlify/functions/_shared/training/marathonProjection.js
+++ b/netlify/functions/_shared/training/marathonProjection.js
@@ -87,8 +87,8 @@ function explanations(parts, potential) {
 	const volume = parts.volume?.metrics || {};
 	if (volume.ewma8 >= 70) {
 		push("positive", "volume", 0.35 + (volume.ewma8 - 70) / 80, `Sustained ${Math.round(volume.ewma8)} km weeks`);
-	} else if (volume.ewma8 > 0 && volume.ewma8 < 55) {
-		push("limiting", "volume", 0.45 + (55 - volume.ewma8) / 80, `Relatively low sustained 8-week mileage (${Math.round(volume.ewma8)} km/wk)`);
+	} else if (volume.ewma8 > 0 && volume.ewma8 < 40 && (volume.vsPlan == null || volume.vsPlan < 0.75)) {
+		push("limiting", "volume", 0.45 + (40 - volume.ewma8) / 80, `Relatively low sustained 8-week mileage (${Math.round(volume.ewma8)} km/wk)`);
 	}
 
 	const longs = parts.longRuns?.metrics || {};

--- a/netlify/functions/_shared/training/marathonProjection.js
+++ b/netlify/functions/_shared/training/marathonProjection.js
@@ -1,0 +1,294 @@
+// Convert marathon readiness into an adjusted race projection.
+//
+// Riegel/VDOT remain the aerobic baseline. Readiness only decides how much of
+// that baseline the current training can realistically hold for 42.195 km.
+// The constants in marathonConfig.js are starting values for later calibration
+// against actual race results — they are not a validated physiological model.
+
+import { addDays, toDayKey } from "./dates.js";
+import { MARATHON_PROJECTION } from "./marathonConfig.js";
+import { scoreMarathonReadiness } from "./marathonReadiness.js";
+import { aerobicPotential, goalDelta, goalPaceSecPerKm } from "./predict.js";
+import { weekSessions } from "./plan.js";
+
+const CFG = MARATHON_PROJECTION;
+
+export function readinessPenalty(readiness) {
+	const r = Math.max(0, Math.min(1, Number(readiness) || 0));
+	return 1 + CFG.penalty.k * Math.pow(1 - r, CFG.penalty.exponent);
+}
+
+function confidenceOf(parts, potential, runs, today) {
+	let score = 0.35;
+	const basisM = Number(potential?.basis?.distanceM) || 0;
+	if (basisM >= 21097) score += 0.18;
+	else if (basisM >= 15000) score += 0.12;
+	else if (basisM >= 10000) score += 0.07;
+	const longs = parts.longRuns?.metrics || {};
+	if (longs.over30 >= 2) score += 0.12;
+	else if (longs.over25 >= 2) score += 0.08;
+	else if (longs.over20 >= 2) score += 0.04;
+	if ((longs.over25 || 0) < 1) score -= 0.12;
+	if ((longs.over30 || 0) < 1) score -= 0.05;
+	if ((longs.longestM || 0) > 0 && longs.longestM < 26000) score -= 0.08;
+	if (parts.decoupling?.available) score += 0.1;
+	if ((parts.consistency?.metrics?.zeroWeeks || 0) === 0) score += 0.08;
+	if ((parts.volume?.metrics?.ewma8 || 0) >= 60) score += 0.08;
+	if (parts.recovery?.available) score += 0.05;
+	if ((parts.consistency?.metrics?.zeroWeeks || 0) > 0) score -= 0.1;
+	if ((parts.consistency?.metrics?.cv || 0) > 0.4) score -= 0.06;
+	if (!parts.decoupling?.available) score -= 0.08;
+	if (basisM > 0 && basisM < 10000) score -= 0.08;
+	const from = addDays(today, -70);
+	const recentLongs = (runs || []).filter((r) => {
+		const day = toDayKey(r.startDateLocal);
+		return r?.sport !== "ride" && day && day >= from && day <= today && r.distanceM >= 20000;
+	}).length;
+	if (recentLongs >= 3) score += 0.06;
+	return Math.max(0, Math.min(1, score));
+}
+
+function confidenceLabel(score) {
+	if (score >= CFG.confidence.high) return "High";
+	if (score >= CFG.confidence.moderate) return "Moderate";
+	return "Low";
+}
+
+function projectionRange(predictedSec, aerobicSec, confidence) {
+	const spread = predictedSec * (CFG.range.minPct + (CFG.range.maxPct - CFG.range.minPct) * (1 - confidence));
+	const fast = Math.max(aerobicSec, predictedSec - spread);
+	const slow = predictedSec + spread * CFG.range.slowAsymmetry;
+	return { fastSec: fast, slowSec: slow };
+}
+
+function kmLabel(metres) {
+	if (!(metres > 0)) return null;
+	const km = metres / 1000;
+	return km >= 10 ? `${Math.round(km)} km` : `${km.toFixed(1)} km`;
+}
+
+function explanations(parts, potential) {
+	const candidates = [];
+	const push = (direction, key, strength, text) => {
+		if (!text) return;
+		candidates.push({ direction, key, strength, text });
+	};
+
+	const basis = potential?.basis;
+	if (basis?.distanceM) {
+		push(
+			"positive",
+			"baseline",
+			0.4 + Math.min(0.4, basis.distanceM / 50000),
+			`Strong ${kmLabel(basis.distanceM)}-derived aerobic potential`,
+		);
+	}
+
+	const volume = parts.volume?.metrics || {};
+	if (volume.ewma8 >= 70) {
+		push("positive", "volume", 0.35 + (volume.ewma8 - 70) / 80, `Sustained ${Math.round(volume.ewma8)} km weeks`);
+	} else if (volume.ewma8 > 0 && volume.ewma8 < 55) {
+		push("limiting", "volume", 0.45 + (55 - volume.ewma8) / 80, `Relatively low sustained 8-week mileage (${Math.round(volume.ewma8)} km/wk)`);
+	}
+
+	const longs = parts.longRuns?.metrics || {};
+	if (longs.over30 >= 2) {
+		push("positive", "longRuns", 0.5, `${longs.over30} recent runs over 30 km`);
+	} else if (longs.longestM >= 25000 && longs.over25 >= 2) {
+		push("positive", "longRuns", 0.4, `Recent long runs averaging ${kmLabel(longs.averageM)}`);
+	}
+	if (longs.longestM > 0 && longs.longestM < 26000) {
+		push("limiting", "longRuns", 0.55, `Longest recent run only ${kmLabel(longs.longestM)}`);
+	}
+	if (Number.isFinite(longs.sharePct) && longs.sharePct >= CFG.longRunShare.cautionPct) {
+		push("limiting", "longRunShare", 0.3, `High long-run share of weekly mileage (${Math.round(longs.sharePct)}%)`);
+	}
+
+	const dec = parts.decoupling?.metrics || {};
+	if (parts.decoupling?.available && dec.meanPct <= 3) {
+		push("positive", "decoupling", 0.45, `Low long-run aerobic decoupling (${dec.meanPct.toFixed(1)}%)`);
+	} else if (parts.decoupling?.available && dec.meanPct >= 6) {
+		push("limiting", "decoupling", 0.5, `Long-run aerobic decoupling still elevated (${dec.meanPct.toFixed(1)}%)`);
+	}
+
+	const freq = parts.frequency?.metrics || {};
+	if (freq.perWeek >= 4.3) {
+		push("positive", "frequency", 0.25, `About ${freq.perWeek.toFixed(1)} runs/week`);
+	} else if (freq.perWeek > 0 && freq.perWeek < 3.4) {
+		push("limiting", "frequency", 0.35, `Only ~${freq.perWeek.toFixed(1)} runs/week`);
+	}
+
+	const fit = parts.fitnessTrend?.metrics || {};
+	if (Number.isFinite(fit.gain28) && fit.gain28 >= 2) {
+		push("positive", "fitnessTrend", 0.3, "Fitness trending upward");
+	} else if (Number.isFinite(fit.gain28) && fit.gain28 <= -4) {
+		push("limiting", "fitnessTrend", 0.28, "Fitness trending down over four weeks");
+	}
+
+	const cons = parts.consistency?.metrics || {};
+	if ((cons.zeroWeeks || 0) > 0) {
+		push("limiting", "consistency", 0.5, "Recent interruption in training");
+	} else if (Number.isFinite(cons.plannedPct) && cons.plannedPct >= 90) {
+		push("positive", "consistency", 0.25, "Training volume tracking close to plan");
+	}
+
+	const rec = parts.recovery;
+	if (rec?.available) {
+		const hrv = rec.metrics?.hrv;
+		const rhr = rec.metrics?.rhr;
+		const sleep = rec.metrics?.sleep;
+		const goodHrv = Number.isFinite(hrv?.deltaPct) && hrv.deltaPct >= -5;
+		const goodRhr = Number.isFinite(rhr?.delta) && rhr.delta <= 2;
+		const goodSleep = Number.isFinite(sleep?.deltaPct) ? sleep.deltaPct >= -8 : true;
+		if (goodHrv && goodRhr && goodSleep) {
+			push("positive", "recovery", 0.22, "Recovery near/above baseline");
+		} else if ((Number.isFinite(hrv?.deltaPct) && hrv.deltaPct <= -CFG.recovery.hrvDropPct) ||
+			(Number.isFinite(rhr?.delta) && rhr.delta >= CFG.recovery.rhrRiseBpm)) {
+			push("limiting", "recovery", 0.32, "Recovery markers below personal baseline");
+		}
+	}
+
+	candidates.sort((a, b) => b.strength - a.strength);
+	const picked = [];
+	const seen = new Set();
+	for (const item of candidates) {
+		if (seen.has(item.key)) continue;
+		picked.push(item);
+		seen.add(item.key);
+		if (picked.length >= 4) break;
+	}
+	return picked;
+}
+
+function plannedFutureRuns(plan, today) {
+	const synthetic = [];
+	for (const week of plan?.weeks || []) {
+		for (const session of weekSessions(week)) {
+			if (!session.isRun || !session.date || session.date <= today) continue;
+			const km = Number(session.distanceKm) || 0;
+			if (!(km > 0)) continue;
+			synthetic.push({
+				sport: "run",
+				startDateLocal: `${session.date}T07:00:00`,
+				distanceM: km * 1000 * CFG.raceDay.plannedCredit,
+				movingTimeSec: km * 360 * CFG.raceDay.plannedCredit,
+				paceSecPerKm: 340,
+				gapPaceSecPerKm: 340,
+				decouplingPct: session.type === "long run" || session.type === "race" ? 4 : null,
+				load: 40 * CFG.raceDay.plannedCredit,
+				bestEfforts: [],
+			});
+		}
+	}
+	return synthetic;
+}
+
+function assemble({ potential, readiness, runs, today, race }) {
+	const penalty = readinessPenalty(readiness.marathonReadiness);
+	const predictedSec = potential.predictedSec * penalty;
+	const confidence = confidenceOf(readiness.parts, potential, runs, today);
+	const delta = goalDelta(predictedSec, race?.goalTimeSec);
+	return {
+		predictedSec,
+		aerobicPotentialSeconds: potential.predictedSec,
+		riegelSec: potential.riegelSec,
+		vdotSec: potential.vdotSec,
+		vdot: potential.vdot,
+		basis: potential.basis,
+		marathonReadiness: readiness.marathonReadiness,
+		readinessPenalty: penalty,
+		confidence,
+		confidenceLabel: confidenceLabel(confidence),
+		projectionRange: projectionRange(predictedSec, potential.predictedSec, confidence),
+		factors: readiness.factors,
+		explanations: explanations(readiness.parts, potential),
+		deltaSec: delta?.deltaSec ?? null,
+		onTrack: delta?.onTrack ?? null,
+		goalPaceSecPerKm: goalPaceSecPerKm(race?.goalTimeSec, race?.distanceM || 42195),
+	};
+}
+
+/**
+ * Full marathon projection from aerobic potential plus current readiness.
+ *
+ * @param {object} input
+ * @returns {object|null}
+ */
+export function projectMarathon(input) {
+	const {
+		efforts = [],
+		runs = [],
+		weeks = [],
+		series = [],
+		acwr = null,
+		intensity = null,
+		recovery = null,
+		today,
+		race = {},
+		plan = null,
+		daysToRace = null,
+	} = input;
+	const targetDistanceM = race.distanceM || 42195;
+	const runActivities = (runs || []).filter((activity) => activity?.sport !== "ride");
+	const potential = aerobicPotential(efforts, targetDistanceM, today);
+	if (!potential) return null;
+
+	const predictedPace = potential.predictedSec / (targetDistanceM / 1000);
+	const readinessInput = {
+		runs: runActivities,
+		weeks,
+		series,
+		acwr,
+		intensity,
+		recovery,
+		today,
+		daysToRace,
+		predictedPaceSecPerKm: predictedPace,
+	};
+	const todayReady = scoreMarathonReadiness(readinessInput);
+	const current = assemble({ potential, readiness: todayReady, runs: runActivities, today, race });
+
+	let raceDay = null;
+	const remainingKm = (plan?.weeks || []).reduce((sum, week) => {
+		const sessions = weekSessions(week);
+		return (
+			sum +
+			sessions
+				.filter((s) => s.isRun && s.date > today)
+				.reduce((n, s) => n + (Number(s.distanceKm) || 0), 0)
+		);
+	}, 0);
+	if (
+		plan &&
+		Number.isFinite(daysToRace) &&
+		daysToRace >= CFG.raceDay.minDaysToRace &&
+		remainingKm >= CFG.raceDay.minRemainingKm
+	) {
+		const future = plannedFutureRuns(plan, today);
+		const raceReady = scoreMarathonReadiness({
+			...readinessInput,
+			runs: [...runActivities, ...future],
+		});
+		if (raceReady.marathonReadiness > todayReady.marathonReadiness) {
+			raceDay = {
+				marathonReadiness: raceReady.marathonReadiness,
+				predictedSec: potential.predictedSec * readinessPenalty(raceReady.marathonReadiness),
+				factors: raceReady.factors,
+			};
+		}
+	}
+
+	return {
+		...current,
+		raceDay,
+		debug: {
+			aerobicPotentialSeconds: current.aerobicPotentialSeconds,
+			marathonReadiness: current.marathonReadiness,
+			readinessPenalty: current.readinessPenalty,
+			adjustedProjectionSeconds: current.predictedSec,
+			confidence: current.confidence,
+			projectionRange: current.projectionRange,
+			factors: current.factors,
+		},
+	};
+}

--- a/netlify/functions/_shared/training/marathonProjection.test.js
+++ b/netlify/functions/_shared/training/marathonProjection.test.js
@@ -124,6 +124,12 @@ describe("readinessPenalty", () => {
 		expect(readinessPenalty(0.3)).toBeGreaterThan(readinessPenalty(0.8));
 		expect(readinessPenalty(0)).toBeGreaterThan(readinessPenalty(0.3));
 	});
+
+	it("adds only a few percent at mid readiness, not a 4:07-scale tax", () => {
+		const penalty = readinessPenalty(0.54);
+		expect(penalty).toBeGreaterThan(1.02);
+		expect(penalty).toBeLessThan(1.045);
+	});
 });
 
 describe("projectMarathon", () => {
@@ -168,7 +174,7 @@ describe("projectMarathon", () => {
 	});
 
 	it("weights a recent half marathon above a faster 5k when they disagree", () => {
-		const half = { name: "Half", distanceM: 21097.5, timeSec: 6300, date: addDays(TODAY, -14) };
+		const half = { name: "Half", distanceM: 21097.5, timeSec: 6300, date: addDays(TODAY, -14), workoutType: 1 };
 		const fiveK = { name: "5k", distanceM: 5000, timeSec: 1080, date: addDays(TODAY, -7) };
 		const runs = block();
 		runs[0].bestEfforts = [half, fiveK];
@@ -204,6 +210,26 @@ describe("projectMarathon", () => {
 			Math.abs(out.aerobicPotentialSeconds - halfOnly),
 		);
 		expect(out.basis.distanceM).toBe(5000);
+	});
+
+	it("projects a 5k-shaped engine near Garmin, not a training 15k", () => {
+		const runs = block({ weeks: 8, kmPerWeek: 32, longKm: [23, 16, 15, 14] });
+		for (const activity of runs) activity.bestEfforts = [];
+		const workout = run({ date: addDays(TODAY, -20), distanceKm: 8, movingMin: 40 });
+		workout.workoutType = 3;
+		workout.bestEfforts = [{ name: "5k", distanceM: 5000, timeSec: 1240, date: addDays(TODAY, -20) }];
+		const easy15 = run({ date: addDays(TODAY, -29), distanceKm: 15.014, movingMin: 79.1 });
+		easy15.bestEfforts = [
+			{ name: "15K", distanceM: 15000, timeSec: 4747, date: addDays(TODAY, -29) },
+		];
+		const out = project([...runs, workout, easy15], {
+			efforts: collectBestEfforts([...runs, workout, easy15]),
+		});
+		const fiveOnly = predictFromEffort(workout.bestEfforts[0], MARATHON_M).predictedSec;
+		expect(out.aerobicPotentialSeconds).toBeCloseTo(fiveOnly, 0);
+		expect(out.predictedSec).toBeGreaterThan(fiveOnly);
+		expect(out.predictedSec).toBeGreaterThan(12000);
+		expect(out.predictedSec).toBeLessThan(12780);
 	});
 
 	it("does not claim high confidence from a 10k and short long runs alone", () => {

--- a/netlify/functions/_shared/training/marathonProjection.test.js
+++ b/netlify/functions/_shared/training/marathonProjection.test.js
@@ -5,6 +5,7 @@ import { dailyLoads } from "./load.js";
 import { predictFromEffort } from "./predict.js";
 import { projectMarathon, readinessPenalty } from "./marathonProjection.js";
 import { MARATHON_M } from "./marathonConfig.js";
+import { collectBestEfforts } from "./shape.js";
 
 const TODAY = "2026-08-24";
 const RACE = {
@@ -178,6 +179,31 @@ describe("projectMarathon", () => {
 		const towardHalf = Math.abs(out.aerobicPotentialSeconds - halfOnly);
 		const towardFive = Math.abs(out.aerobicPotentialSeconds - fiveOnly);
 		expect(towardHalf).toBeLessThan(towardFive);
+	});
+
+	it("does not let a long-run half split set aerobic potential", () => {
+		const runs = block();
+		for (const activity of runs) activity.bestEfforts = [];
+		const long = runs.reduce((best, activity) =>
+			activity.distanceM > best.distanceM ? activity : best,
+		);
+		long.distanceM = 23000;
+		long.workoutType = 2;
+		long.bestEfforts = [
+			{ name: "Half-Marathon", distanceM: 21097, timeSec: 6563, date: addDays(TODAY, -1) },
+		];
+		const workout = run({ date: addDays(TODAY, -20), distanceKm: 8, movingMin: 40 });
+		workout.workoutType = 3;
+		workout.bestEfforts = [{ name: "5k", distanceM: 5000, timeSec: 1240, date: addDays(TODAY, -20) }];
+		const all = [...runs, workout];
+		const out = project(all, { efforts: collectBestEfforts(all) });
+		const fiveOnly = predictFromEffort(workout.bestEfforts[0], MARATHON_M).predictedSec;
+		const halfOnly = predictFromEffort(long.bestEfforts[0], MARATHON_M).predictedSec;
+		expect(out.aerobicPotentialSeconds).toBeCloseTo(fiveOnly, 0);
+		expect(Math.abs(out.aerobicPotentialSeconds - fiveOnly)).toBeLessThan(
+			Math.abs(out.aerobicPotentialSeconds - halfOnly),
+		);
+		expect(out.basis.distanceM).toBe(5000);
 	});
 
 	it("does not claim high confidence from a 10k and short long runs alone", () => {

--- a/netlify/functions/_shared/training/marathonProjection.test.js
+++ b/netlify/functions/_shared/training/marathonProjection.test.js
@@ -1,0 +1,294 @@
+import { describe, it, expect } from "vitest";
+import { addDays, mondayOf } from "./dates.js";
+import { weeklySummaries, fitnessSeries } from "./fitness.js";
+import { dailyLoads } from "./load.js";
+import { predictFromEffort } from "./predict.js";
+import { projectMarathon, readinessPenalty } from "./marathonProjection.js";
+import { MARATHON_M } from "./marathonConfig.js";
+
+const TODAY = "2026-08-24";
+const RACE = {
+	name: "Chicago Marathon",
+	date: "2026-10-11",
+	goalTimeSec: 13200,
+	distanceM: MARATHON_M,
+};
+
+function run({
+	date,
+	distanceKm,
+	movingMin,
+	decouplingPct = 3,
+	paceSecPerKm = 330,
+	sport = "run",
+	bestEfforts = [],
+	load = 55,
+}) {
+	const distanceM = distanceKm * 1000;
+	return {
+		id: `${date}-${distanceKm}-${sport}`,
+		sport,
+		startDateLocal: `${date}T07:00:00`,
+		distanceM,
+		movingTimeSec: (movingMin ?? distanceKm * 5.5) * 60,
+		paceSecPerKm,
+		gapPaceSecPerKm: paceSecPerKm,
+		decouplingPct,
+		load,
+		bestEfforts,
+	};
+}
+
+function block({ weeks = 8, longKm = [28, 26, 24, 22], kmPerWeek = 70, today = TODAY } = {}) {
+	const runs = [];
+	for (let w = 0; w < weeks; w++) {
+		const start = mondayOf(addDays(today, -w * 7));
+		const long = longKm[Math.min(w, longKm.length - 1)];
+		const remaining = Math.max(0, kmPerWeek - long);
+		runs.push(
+			run({
+				date: addDays(start, 6),
+				distanceKm: long,
+				movingMin: long * 6,
+				decouplingPct: 3,
+			}),
+		);
+		const easyDays = 4;
+		const easyKm = remaining / easyDays;
+		for (let d = 0; d < easyDays; d++) {
+			runs.push(
+				run({
+					date: addDays(start, d),
+					distanceKm: easyKm,
+					movingMin: easyKm * 5.5,
+					decouplingPct: null,
+				}),
+			);
+		}
+	}
+	runs[0].bestEfforts = [
+		{ name: "10k", distanceM: 10000, timeSec: 2460, date: addDays(today, -10) },
+	];
+	return runs;
+}
+
+function weeksOf(runs, today = TODAY) {
+	const from = addDays(today, -80);
+	return weeklySummaries(
+		runs.filter((activity) => activity.sport !== "ride"),
+		{ from, to: today },
+	).map((week) => ({
+		...week,
+		actualKm: week.distanceM / 1000,
+		targetKm: 70,
+		volumePct: (week.distanceM / 1000 / 70) * 100,
+		isTaper: false,
+		isPlanned: true,
+	}));
+}
+
+function seriesOf(runs, today = TODAY) {
+	return fitnessSeries(dailyLoads(runs.filter((activity) => activity.sport !== "ride")), {
+		from: addDays(today, -80),
+		to: today,
+	});
+}
+
+function project(runs, extra = {}) {
+	const today = extra.today || TODAY;
+	return projectMarathon({
+		efforts: runs.flatMap((r) => r.bestEfforts || []),
+		runs,
+		weeks: weeksOf(runs, today),
+		series: seriesOf(runs, today),
+		acwr: { ratio: 1.1 },
+		intensity: { easyPct: 80, moderatePct: 12, hardPct: 8 },
+		recovery: {
+			sleep: { recent: 7.4 * 3600, baseline: 7.4 * 3600, deltaPct: 0 },
+			restingHr: { recent: 47, baseline: 47, delta: 0 },
+			hrv: { recent: 68, baseline: 68, deltaPct: 0 },
+			series: [],
+		},
+		today,
+		race: RACE,
+		daysToRace: 48,
+		...extra,
+	});
+}
+
+describe("readinessPenalty", () => {
+	it("is 1 at full readiness and greater than 1 otherwise", () => {
+		expect(readinessPenalty(1)).toBe(1);
+		expect(readinessPenalty(0.8)).toBeGreaterThan(1);
+		expect(readinessPenalty(0.3)).toBeGreaterThan(readinessPenalty(0.8));
+		expect(readinessPenalty(0)).toBeGreaterThan(readinessPenalty(0.3));
+	});
+});
+
+describe("projectMarathon", () => {
+	it("keeps Riegel and VDOT as the aerobic baseline and never projects faster", () => {
+		const out = project(block());
+		expect(out.aerobicPotentialSeconds).toBeGreaterThan(0);
+		expect(out.riegelSec).toBeGreaterThan(0);
+		expect(out.vdotSec).toBeGreaterThan(0);
+		expect(out.predictedSec).toBeGreaterThanOrEqual(out.aerobicPotentialSeconds - 1e-6);
+		expect(out.readinessPenalty).toBeGreaterThanOrEqual(1);
+	});
+
+	it("returns a debug breakdown of every factor", () => {
+		const out = project(block());
+		expect(out.factors).toEqual(
+			expect.objectContaining({
+				volume: expect.any(Number),
+				longRuns: expect.any(Number),
+				decoupling: expect.any(Number),
+				consistency: expect.any(Number),
+				frequency: expect.any(Number),
+				fitnessTrend: expect.any(Number),
+				recovery: expect.any(Number),
+			}),
+		);
+		expect(out.marathonReadiness).toBeGreaterThan(0);
+		expect(out.marathonReadiness).toBeLessThanOrEqual(1);
+		expect(out.projectionRange.fastSec).toBeLessThan(out.predictedSec);
+		expect(out.projectionRange.slowSec).toBeGreaterThan(out.predictedSec);
+		expect(["Low", "Moderate", "High"]).toContain(out.confidenceLabel);
+	});
+
+	it("explains the gap with deterministic factors from the metrics", () => {
+		const out = project(block({ longKm: [22, 20, 18, 16], kmPerWeek: 45 }));
+		expect(out.explanations.length).toBeGreaterThan(0);
+		expect(out.explanations.length).toBeLessThanOrEqual(4);
+		for (const factor of out.explanations) {
+			expect(["positive", "limiting"]).toContain(factor.direction);
+			expect(factor.text.length).toBeGreaterThan(10);
+			expect(factor.key).toBeTruthy();
+		}
+	});
+
+	it("weights a recent half marathon above a faster 5k when they disagree", () => {
+		const half = { name: "Half", distanceM: 21097.5, timeSec: 6300, date: addDays(TODAY, -14) };
+		const fiveK = { name: "5k", distanceM: 5000, timeSec: 1080, date: addDays(TODAY, -7) };
+		const runs = block();
+		runs[0].bestEfforts = [half, fiveK];
+		const out = project(runs);
+		const halfOnly = predictFromEffort(half, MARATHON_M).predictedSec;
+		const fiveOnly = predictFromEffort(fiveK, MARATHON_M).predictedSec;
+		expect(fiveOnly).toBeLessThan(halfOnly);
+		const towardHalf = Math.abs(out.aerobicPotentialSeconds - halfOnly);
+		const towardFive = Math.abs(out.aerobicPotentialSeconds - fiveOnly);
+		expect(towardHalf).toBeLessThan(towardFive);
+	});
+
+	it("does not claim high confidence from a 10k and short long runs alone", () => {
+		const out = project(block({ longKm: [22, 20, 18, 16], kmPerWeek: 50 }));
+		expect(out.basis.distanceM).toBe(10000);
+		expect(out.confidenceLabel).not.toBe("High");
+	});
+
+	it("does not let training data make the projection faster than aerobic potential", () => {
+		const stacked = block({ weeks: 10, longKm: [34, 32, 30, 28], kmPerWeek: 100 });
+		const out = project(stacked);
+		expect(out.predictedSec).toBeGreaterThanOrEqual(out.aerobicPotentialSeconds - 1e-6);
+	});
+});
+
+describe("monotonic marathon projection", () => {
+	it("never projects a slower time when sustained mileage rises, all else equal", () => {
+		const light = project(block({ kmPerWeek: 50, longKm: [24, 22, 20, 18] }));
+		const heavy = project(block({ kmPerWeek: 85, longKm: [24, 22, 20, 18] }));
+		expect(heavy.predictedSec).toBeLessThanOrEqual(light.predictedSec + 1);
+		expect(heavy.marathonReadiness).toBeGreaterThanOrEqual(light.marathonReadiness);
+	});
+
+	it("never reduces readiness when another healthy 30 km long run is added", () => {
+		const baseRuns = block({ longKm: [26, 24, 22, 20] });
+		const withLong = [
+			...baseRuns,
+			run({
+				date: addDays(TODAY, -2),
+				distanceKm: 30,
+				movingMin: 180,
+				decouplingPct: 2,
+				paceSecPerKm: 325,
+			}),
+		];
+		expect(project(withLong).marathonReadiness).toBeGreaterThanOrEqual(
+			project(baseRuns).marathonReadiness,
+		);
+	});
+
+	it("does not improve readiness when decoupling gets worse", () => {
+		const stable = project(block({ longKm: [30, 28, 26, 24] }));
+		const drifted = project(
+			block({ longKm: [30, 28, 26, 24] }).map((r) =>
+				r.distanceM >= 20000 ? { ...r, decouplingPct: 9 } : r,
+			),
+		);
+		expect(drifted.marathonReadiness).toBeLessThanOrEqual(stable.marathonReadiness + 1e-6);
+	});
+
+	it("does not improve readiness after a zero-running week", () => {
+		const steady = project(block({ weeks: 9 }));
+		const gappedRuns = block({ weeks: 9 }).filter((r) => {
+			const start = mondayOf(addDays(TODAY, -14));
+			return r.startDateLocal.slice(0, 10) < start || r.startDateLocal.slice(0, 10) > addDays(start, 6);
+		});
+		expect(project(gappedRuns).marathonReadiness).toBeLessThanOrEqual(steady.marathonReadiness + 1e-6);
+	});
+
+	it("does not let cycling satisfy running-mileage requirements", () => {
+		const running = project(block({ kmPerWeek: 50 }));
+		const padded = project([
+			...block({ kmPerWeek: 50 }),
+			run({ date: addDays(TODAY, -3), distanceKm: 80, sport: "ride", load: 120 }),
+		]);
+		expect(padded.marathonReadiness).toBeCloseTo(running.marathonReadiness, 5);
+		expect(padded.predictedSec).toBeCloseTo(running.predictedSec, 3);
+	});
+
+	it("raises demonstrated readiness when a planned long run is completed", () => {
+		const before = block({ longKm: [24, 22, 20, 18] });
+		const after = [
+			...before,
+			run({
+				date: TODAY,
+				distanceKm: 30,
+				movingMin: 180,
+				decouplingPct: 2.5,
+				paceSecPerKm: 328,
+			}),
+		];
+		expect(project(after).marathonReadiness).toBeGreaterThan(project(before).marathonReadiness);
+	});
+
+	it("does not erase aerobic potential when training fatigue is very high", () => {
+		const runs = block({ kmPerWeek: 80, longKm: [30, 28, 26, 24] });
+		const out = project(runs, {
+			series: seriesOf(runs).map((d) =>
+				d.date === TODAY ? { ...d, atl: d.ctl + 40, tsb: -40 } : d,
+			),
+		});
+		expect(out.predictedSec).toBeLessThan(out.aerobicPotentialSeconds * 1.12);
+		expect(out.aerobicPotentialSeconds).toBeGreaterThan(0);
+	});
+
+	it("does not read a taper mileage cut as lost marathon readiness", () => {
+		const built = block({ weeks: 8, kmPerWeek: 80, longKm: [32, 30, 28, 26] });
+		const taperedWeeks = weeksOf(built).map((week) => {
+			if (week.start >= mondayOf(addDays(TODAY, -7))) {
+				return {
+					...week,
+					distanceM: 35000,
+					actualKm: 35,
+					volumePct: 50,
+					isTaper: true,
+				};
+			}
+			return week;
+		});
+		const peaked = project(built);
+		const tapering = project(built, { weeks: taperedWeeks, daysToRace: 14 });
+		expect(tapering.marathonReadiness).toBeGreaterThanOrEqual(peaked.marathonReadiness - 0.02);
+	});
+});

--- a/netlify/functions/_shared/training/marathonReadiness.js
+++ b/netlify/functions/_shared/training/marathonReadiness.js
@@ -1,0 +1,408 @@
+// Marathon-specific readiness scores.
+//
+// Each function here returns a 0–1 score plus the metrics that produced it.
+// The composite is a weighted mean of those scores; missing evidence (no HR
+// on long runs, no ring) drops out of the mean rather than being invented as
+// a zero. Training data can only close the gap to aerobic potential — it
+// does not mint a faster marathon than Riegel/VDOT already implied.
+
+import { addDays, daysBetween, mondayOf, toDayKey } from "./dates.js";
+import { fitnessGain } from "./fitness.js";
+import { MARATHON_PROJECTION } from "./marathonConfig.js";
+
+const CFG = MARATHON_PROJECTION;
+
+export function clamp01(value) {
+	const n = Number(value);
+	if (!Number.isFinite(n)) return 0;
+	return Math.max(0, Math.min(1, n));
+}
+
+/**
+ * Linear 0–1 score between a floor and a full mark, clamped.
+ *
+ * @param {number} value
+ * @param {number} floor
+ * @param {number} full
+ * @returns {number}
+ */
+export function lerpScore(value, floor, full) {
+	const v = Number(value);
+	const lo = Number(floor);
+	const hi = Number(full);
+	if (!Number.isFinite(v) || !Number.isFinite(lo) || !Number.isFinite(hi)) return 0;
+	if (hi <= lo) return v >= hi ? 1 : 0;
+	return clamp01((v - lo) / (hi - lo));
+}
+
+function smoothstep(edge0, edge1, x) {
+	const t = clamp01((Number(x) - edge0) / (edge1 - edge0));
+	return t * t * (3 - 2 * t);
+}
+
+export function recencyWeight(date, today, halfLifeDays) {
+	const age = daysBetween(toDayKey(date), toDayKey(today));
+	if (!Number.isFinite(age)) return 0;
+	if (age < 0) return 1;
+	return Math.pow(0.5, age / halfLifeDays);
+}
+
+function isRun(activity) {
+	return activity?.sport !== "ride";
+}
+
+function completeWeeks(weeks, today) {
+	const current = mondayOf(today);
+	return (weeks || []).filter((week) => week?.start && current && week.start < current);
+}
+
+function volumeWindow(weeks, today) {
+	const complete = completeWeeks(weeks, today);
+	const withoutTaper = complete.filter((week) => week.isTaper !== true);
+	const pick = withoutTaper.length >= 3 ? withoutTaper : complete;
+	return pick.slice(-Math.max(CFG.windows.volumeSlowWeeks, CFG.windows.peakWeeks));
+}
+
+function weeklyKm(week) {
+	return (Number(week?.distanceM) || 0) / 1000;
+}
+
+function ewmaWeekly(weeks, span) {
+	const slice = weeks.slice(-span);
+	if (slice.length === 0) return 0;
+	const alpha = 2 / (span + 1);
+	let value = weeklyKm(slice[0]);
+	for (let i = 1; i < slice.length; i++) {
+		value = alpha * weeklyKm(slice[i]) + (1 - alpha) * value;
+	}
+	return value;
+}
+
+function meanTop(weeks, count) {
+	const kms = weeks.map(weeklyKm).sort((a, b) => b - a);
+	const top = kms.slice(0, count);
+	if (top.length === 0) return 0;
+	return top.reduce((sum, n) => sum + n, 0) / top.length;
+}
+
+/**
+ * @param {{weeks: object[], today: string}} input
+ * @returns {{score: number, metrics: object}}
+ */
+export function scoreVolume({ weeks, today }) {
+	const window = volumeWindow(weeks, today);
+	const ewma8 = ewmaWeekly(window, CFG.windows.volumeSlowWeeks);
+	const ewma4 = ewmaWeekly(window, CFG.windows.volumeFastWeeks);
+	const peak = meanTop(window, CFG.windows.peakCount);
+	const score = clamp01(
+		0.5 * lerpScore(ewma8, CFG.volume.ewma8FloorKm, CFG.volume.ewma8FullKm) +
+			0.3 * lerpScore(ewma4, CFG.volume.ewma4FloorKm, CFG.volume.ewma4FullKm) +
+			0.2 * lerpScore(peak, CFG.volume.peakFloorKm, CFG.volume.peakFullKm),
+	);
+	return { score, metrics: { ewma8, ewma4, peak } };
+}
+
+function longRunCandidates(runs, today) {
+	const from = addDays(today, -(CFG.windows.longRunDays - 1));
+	return (runs || []).filter((activity) => {
+		if (!isRun(activity)) return false;
+		const day = toDayKey(activity.startDateLocal);
+		if (!day || (from && day < from) || day > today) return false;
+		return (Number(activity.distanceM) || 0) >= CFG.longRuns.countMinM;
+	});
+}
+
+function longRunSharePenalty(weeks, today) {
+	const recent = completeWeeks(weeks, today)
+		.filter((week) => week.isTaper !== true)
+		.slice(-6)
+		.map((week) => {
+			const total = Number(week.distanceM) || 0;
+			if (!(total > 0)) return null;
+			return ((Number(week.longestRunM) || 0) / total) * 100;
+		})
+		.filter((n) => Number.isFinite(n));
+	if (recent.length < 3) return { penalty: 0, sharePct: null };
+	const sharePct = recent.reduce((sum, n) => sum + n, 0) / recent.length;
+	const penalty =
+		CFG.longRunShare.maxPenalty *
+		smoothstep(CFG.longRunShare.cautionPct, CFG.longRunShare.heavyPct, sharePct);
+	return { penalty, sharePct };
+}
+
+function paceModifier(runs, predictedPaceSecPerKm) {
+	if (!(predictedPaceSecPerKm > 0)) return 1;
+	const near = CFG.longRuns;
+	let credit = 0;
+	let considered = 0;
+	for (const activity of runs) {
+		if ((Number(activity.distanceM) || 0) < near.over20M) continue;
+		const pace = Number(activity.gapPaceSecPerKm) || Number(activity.paceSecPerKm);
+		if (!(pace > 0)) continue;
+		considered += 1;
+		const ratio = pace / predictedPaceSecPerKm;
+		const inBand = ratio >= near.nearMarathonPaceFloor && ratio <= near.nearMarathonPaceCeil;
+		const stable = !Number.isFinite(activity.decouplingPct) || activity.decouplingPct <= 5;
+		if (inBand && stable) credit += 1;
+	}
+	if (considered === 0) return 1;
+	return 1 + near.paceBoost * (credit / considered);
+}
+
+/**
+ * @param {{runs: object[], today: string, predictedPaceSecPerKm?: number, weeks?: object[]}} input
+ * @returns {{score: number, metrics: object}}
+ */
+export function scoreLongRuns({ runs, today, predictedPaceSecPerKm, weeks = [] }) {
+	const candidates = longRunCandidates(runs, today);
+	const longestM = candidates.reduce((max, a) => Math.max(max, Number(a.distanceM) || 0), 0);
+	const ranked = [...candidates].sort((a, b) => (Number(b.distanceM) || 0) - (Number(a.distanceM) || 0));
+	const top = ranked.slice(0, CFG.longRuns.topN);
+	let weightSum = 0;
+	let distanceSum = 0;
+	for (const activity of top) {
+		const weight = recencyWeight(activity.startDateLocal, today, CFG.windows.recencyHalfLifeDays);
+		weightSum += weight;
+		distanceSum += (Number(activity.distanceM) || 0) * weight;
+	}
+	const averageM = weightSum > 0 ? distanceSum / weightSum : 0;
+	const over20 = candidates.filter((a) => a.distanceM >= CFG.longRuns.over20M).length;
+	const over25 = candidates.filter((a) => a.distanceM >= CFG.longRuns.over25M).length;
+	const over30 = candidates.filter((a) => a.distanceM >= CFG.longRuns.over30M).length;
+
+	const dated = [...candidates].sort((a, b) =>
+		String(a.startDateLocal).localeCompare(String(b.startDateLocal)),
+	);
+	let progression = 0.5;
+	if (dated.length >= 3) {
+		const first = dated.slice(0, Math.ceil(dated.length / 2));
+		const last = dated.slice(-Math.ceil(dated.length / 2));
+		const mean = (list) => list.reduce((sum, a) => sum + a.distanceM, 0) / list.length;
+		progression = lerpScore(mean(last) - mean(first), -4000, 6000);
+	}
+
+	const raw =
+		0.28 * lerpScore(longestM, CFG.longRuns.longestFloorM, CFG.longRuns.longestFullM) +
+		0.34 * lerpScore(averageM, CFG.longRuns.averageFloorM, CFG.longRuns.averageFullM) +
+		0.12 * lerpScore(over20, 1, CFG.longRuns.countsFull.over20) +
+		0.12 * lerpScore(over25, 0, CFG.longRuns.countsFull.over25) +
+		0.08 * lerpScore(over30, 0, CFG.longRuns.countsFull.over30) +
+		0.06 * progression;
+
+	const { penalty, sharePct } = longRunSharePenalty(weeks, today);
+	const score = clamp01(raw * paceModifier(top, predictedPaceSecPerKm) * (1 - penalty));
+	return {
+		score,
+		metrics: { longestM, averageM, over20, over25, over30, sharePct, progression },
+	};
+}
+
+/**
+ * @param {{runs: object[], today: string}} input
+ * @returns {{score: number, metrics: object, available: boolean}}
+ */
+export function scoreDecoupling({ runs, today }) {
+	const from = addDays(today, -(CFG.windows.longRunDays - 1));
+	const samples = [];
+	for (const activity of runs || []) {
+		if (!isRun(activity)) continue;
+		const day = toDayKey(activity.startDateLocal);
+		if (!day || (from && day < from) || day > today) continue;
+		if (!((Number(activity.movingTimeSec) || 0) >= CFG.decoupling.minDurationSec)) continue;
+		if (!Number.isFinite(activity.decouplingPct)) continue;
+		const duration = Number(activity.movingTimeSec);
+		const clamped = Math.max(0, Number(activity.decouplingPct));
+		const weight = duration * recencyWeight(day, today, CFG.windows.recencyHalfLifeDays);
+		samples.push({ decouplingPct: clamped, weight, duration });
+	}
+	if (samples.length === 0) {
+		return { score: 0, metrics: { meanPct: null, runs: 0 }, available: false };
+	}
+	const weightSum = samples.reduce((sum, s) => sum + s.weight, 0);
+	const meanPct = samples.reduce((sum, s) => sum + s.decouplingPct * s.weight, 0) / weightSum;
+	const score = 1 - smoothstep(CFG.decoupling.excellentPct, CFG.decoupling.concernPct, meanPct);
+	return { score: clamp01(score), metrics: { meanPct, runs: samples.length }, available: true };
+}
+
+/**
+ * @param {{weeks: object[], today: string}} input
+ * @returns {{score: number, metrics: object}}
+ */
+export function scoreConsistency({ weeks, today }) {
+	const complete = completeWeeks(weeks, today)
+		.filter((week) => week.isTaper !== true)
+		.slice(-CFG.windows.consistencyWeeks);
+	const startAt = complete.findIndex((week) => week.runs > 0 || weeklyKm(week) >= 1);
+	const window = startAt >= 0 ? complete.slice(startAt) : [];
+	if (window.length === 0) return { score: 0.4, metrics: { plannedPct: null, zeroWeeks: 0, cv: null } };
+
+	const planned = window.filter((week) => Number.isFinite(week.volumePct) && week.isPlanned);
+	const plannedPct =
+		planned.length > 0
+			? planned.reduce((sum, week) => sum + Math.min(120, week.volumePct), 0) / planned.length
+			: null;
+	const kms = window.map(weeklyKm);
+	const mean = kms.reduce((sum, n) => sum + n, 0) / kms.length;
+	const variance = kms.reduce((sum, n) => sum + (n - mean) ** 2, 0) / kms.length;
+	const cv = mean > 0 ? Math.sqrt(variance) / mean : 1;
+	const zeroWeeks = window.filter((week) => week.runs === 0 || weeklyKm(week) < 1).length;
+	const lowWeeks = window.filter((week) => {
+		if (week.isTaper) return false;
+		if (Number.isFinite(week.volumePct)) return week.volumePct < CFG.consistency.lowVolumePct;
+		return mean > 0 && weeklyKm(week) < mean * (CFG.consistency.lowVolumePct / 100);
+	}).length;
+
+	const plannedScore = plannedPct === null ? 0.7 : lerpScore(plannedPct, 40, 95);
+	const cvScore = 1 - lerpScore(cv, CFG.consistency.cvFull, CFG.consistency.cvFloor);
+	const zeroPenalty = clamp01(zeroWeeks * 0.22);
+	const lowPenalty = clamp01(lowWeeks * 0.08);
+	const score = clamp01(0.55 * plannedScore + 0.45 * cvScore - zeroPenalty - lowPenalty);
+	return { score, metrics: { plannedPct, zeroWeeks, lowWeeks, cv } };
+}
+
+/**
+ * @param {{runs: object[], today: string}} input
+ * @returns {{score: number, metrics: object}}
+ */
+export function scoreFrequency({ runs, today }) {
+	const from = addDays(today, -(CFG.windows.frequencyDays - 1));
+	const count = (runs || []).filter((activity) => {
+		if (!isRun(activity)) return false;
+		const day = toDayKey(activity.startDateLocal);
+		return day && (!from || day >= from) && day <= today;
+	}).length;
+	const perWeek = count / (CFG.windows.frequencyDays / 7);
+	return {
+		score: lerpScore(perWeek, CFG.frequency.floor, CFG.frequency.full),
+		metrics: { perWeek, count },
+	};
+}
+
+/**
+ * @param {{series: object[], today: string, daysToRace?: number, acwr?: object}} input
+ * @returns {{score: number, metrics: object}}
+ */
+export function scoreFitnessTrend({ series, today, daysToRace, acwr }) {
+	const gain28 = fitnessGain(series, today, 28);
+	const gain42 = fitnessGain(series, today, 42);
+	const gain = Number.isFinite(gain28) ? gain28 : Number.isFinite(gain42) ? gain42 : 0;
+	const trend = lerpScore(gain, CFG.fitness.gainFloor, CFG.fitness.gainFull);
+	const ratio = Number(acwr?.ratio);
+	const acwrScore = Number.isFinite(ratio)
+		? 1 - clamp01(Math.abs(ratio - CFG.fitness.acwrIdeal) / CFG.fitness.acwrSpread)
+		: 0.7;
+	const latest = (series || []).find((d) => d.date === today) || (series || []).at(-1);
+	const inTaper = Number.isFinite(daysToRace) && daysToRace <= CFG.fitness.taperDays;
+	// Negative form is expected in a build. Near race day, positive form can
+	// raise the score slightly; it never lowers it.
+	let formScore = 0.7;
+	if (inTaper && Number.isFinite(latest?.tsb) && latest.tsb > 0) {
+		formScore = 0.7 + 0.3 * lerpScore(latest.tsb, 0, 15);
+	}
+	const score = clamp01(0.55 * trend + 0.3 * acwrScore + 0.15 * formScore);
+	return { score, metrics: { gain28, gain42, ratio, tsb: latest?.tsb ?? null, inTaper } };
+}
+
+function recoveryTrend(recovery, field, today) {
+	const series = recovery?.series || [];
+	if (series.length === 0) return recovery?.[field] || null;
+	const recentFrom = addDays(today, -6);
+	const baseFrom = addDays(today, -(CFG.windows.recoveryBaselineDays - 1));
+	const mean = (from) => {
+		const values = series
+			.filter((row) => row.day >= from && row.day <= today)
+			.map((row) => Number(row[field === "hrv" ? "averageHrv" : field === "restingHr" ? "restingHr" : "sleepSec"]))
+			.filter((n) => Number.isFinite(n));
+		if (values.length < 3) return null;
+		return values.reduce((sum, n) => sum + n, 0) / values.length;
+	};
+	const recent = mean(recentFrom);
+	const baseline = mean(baseFrom);
+	if (recent === null || baseline === null) return recovery?.[field] || null;
+	return {
+		recent,
+		baseline,
+		delta: recent - baseline,
+		deltaPct: baseline > 0 ? ((recent - baseline) / baseline) * 100 : null,
+	};
+}
+
+/**
+ * @param {{recovery: object|null, today: string}} input
+ * @returns {{score: number, metrics: object, available: boolean}}
+ */
+export function scoreRecovery({ recovery, today }) {
+	if (!recovery) return { score: 0, metrics: {}, available: false };
+	const sleep = recoveryTrend(recovery, "sleep", today) || recovery.sleep;
+	const rhr = recoveryTrend(recovery, "restingHr", today) || recovery.restingHr;
+	const hrv = recoveryTrend(recovery, "hrv", today) || recovery.hrv;
+	const pieces = [];
+	if (Number.isFinite(hrv?.deltaPct)) {
+		pieces.push(1 - lerpScore(-hrv.deltaPct, 0, CFG.recovery.hrvDropPct));
+	}
+	if (Number.isFinite(rhr?.delta)) {
+		pieces.push(1 - lerpScore(rhr.delta, 0, CFG.recovery.rhrRiseBpm));
+	}
+	if (Number.isFinite(sleep?.deltaPct)) {
+		pieces.push(1 - lerpScore(-sleep.deltaPct, 0, CFG.recovery.sleepDropPct));
+	} else if (Number.isFinite(sleep?.recent) && Number.isFinite(sleep?.baseline) && sleep.baseline > 0) {
+		pieces.push(1 - lerpScore((sleep.baseline - sleep.recent) / sleep.baseline * 100, 0, CFG.recovery.sleepDropPct));
+	}
+	if (pieces.length === 0) return { score: 0, metrics: { sleep, rhr, hrv }, available: false };
+	const score = clamp01(pieces.reduce((sum, n) => sum + n, 0) / pieces.length);
+	return { score, metrics: { sleep, rhr, hrv }, available: true };
+}
+
+function intensityPenalty(intensity, acwr) {
+	const easy = Number(intensity?.easyPct);
+	const ratio = Number(acwr?.ratio);
+	if (!Number.isFinite(easy) || easy >= CFG.intensity.easyFloorPct) return 0;
+	if (!Number.isFinite(ratio) || ratio < CFG.intensity.acwrSpike) return 0;
+	return CFG.intensity.maxPenalty * smoothstep(CFG.intensity.easyFloorPct, 50, 100 - easy);
+}
+
+/**
+ * Weighted mean of factor scores. Unavailable factors drop out so missing
+ * heart-rate data cannot masquerade as terrible decoupling.
+ *
+ * @param {object} factors
+ * @returns {{marathonReadiness: number, factors: object}}
+ */
+export function combineReadiness(factors, { intensity, acwr } = {}) {
+	const keys = Object.keys(CFG.weights);
+	let weightSum = 0;
+	let total = 0;
+	const scores = {};
+	for (const key of keys) {
+		const part = factors[key];
+		const score = clamp01(part?.score);
+		scores[key] = score;
+		if (part?.available === false) continue;
+		const weight = CFG.weights[key];
+		weightSum += weight;
+		total += weight * score;
+	}
+	const combined = weightSum > 0 ? total / weightSum : 0;
+	const ready = clamp01(combined * (1 - intensityPenalty(intensity, acwr)));
+	return { marathonReadiness: ready, factors: scores };
+}
+
+/**
+ * Score current marathon readiness from completed training only.
+ *
+ * @param {object} input
+ * @returns {{marathonReadiness: number, factors: object, parts: object}}
+ */
+export function scoreMarathonReadiness(input) {
+	const parts = {
+		volume: scoreVolume(input),
+		longRuns: scoreLongRuns(input),
+		decoupling: scoreDecoupling(input),
+		consistency: scoreConsistency(input),
+		frequency: scoreFrequency(input),
+		fitnessTrend: scoreFitnessTrend(input),
+		recovery: scoreRecovery(input),
+	};
+	const combined = combineReadiness(parts, input);
+	return { ...combined, parts };
+}

--- a/netlify/functions/_shared/training/marathonReadiness.js
+++ b/netlify/functions/_shared/training/marathonReadiness.js
@@ -58,8 +58,10 @@ function completeWeeks(weeks, today) {
 
 function volumeWindow(weeks, today) {
 	const complete = completeWeeks(weeks, today);
-	const withoutTaper = complete.filter((week) => week.isTaper !== true);
-	const pick = withoutTaper.length >= 3 ? withoutTaper : complete;
+	const startAt = complete.findIndex((week) => week.runs > 0 || weeklyKm(week) >= 1);
+	const fromStart = startAt >= 0 ? complete.slice(startAt) : complete;
+	const withoutTaper = fromStart.filter((week) => week.isTaper !== true);
+	const pick = withoutTaper.length >= 3 ? withoutTaper : fromStart;
 	return pick.slice(-Math.max(CFG.windows.volumeSlowWeeks, CFG.windows.peakWeeks));
 }
 
@@ -85,6 +87,13 @@ function meanTop(weeks, count) {
 	return top.reduce((sum, n) => sum + n, 0) / top.length;
 }
 
+function medianPositive(values) {
+	const sorted = (values || []).filter((n) => n > 0).sort((a, b) => a - b);
+	if (sorted.length === 0) return null;
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
 /**
  * @param {{weeks: object[], today: string}} input
  * @returns {{score: number, metrics: object}}
@@ -94,12 +103,19 @@ export function scoreVolume({ weeks, today }) {
 	const ewma8 = ewmaWeekly(window, CFG.windows.volumeSlowWeeks);
 	const ewma4 = ewmaWeekly(window, CFG.windows.volumeFastWeeks);
 	const peak = meanTop(window, CFG.windows.peakCount);
-	const score = clamp01(
+	const absolute = clamp01(
 		0.5 * lerpScore(ewma8, CFG.volume.ewma8FloorKm, CFG.volume.ewma8FullKm) +
 			0.3 * lerpScore(ewma4, CFG.volume.ewma4FloorKm, CFG.volume.ewma4FullKm) +
 			0.2 * lerpScore(peak, CFG.volume.peakFloorKm, CFG.volume.peakFullKm),
 	);
-	return { score, metrics: { ewma8, ewma4, peak } };
+	const typicalPlan = medianPositive(window.map((week) => Number(week.targetKm) || 0));
+	const vsPlan = typicalPlan > 0 ? ewma8 / typicalPlan : null;
+	const planScore =
+		vsPlan === null ? null : lerpScore(vsPlan, CFG.volume.planFloor, CFG.volume.planFull);
+	const absW = CFG.volume.absoluteWeight;
+	const score =
+		planScore === null ? absolute : clamp01(absW * absolute + (1 - absW) * planScore);
+	return { score, metrics: { ewma8, ewma4, peak, vsPlan, typicalPlan } };
 }
 
 function longRunCandidates(runs, today) {
@@ -234,19 +250,26 @@ export function scoreConsistency({ weeks, today }) {
 		.slice(-CFG.windows.consistencyWeeks);
 	const startAt = complete.findIndex((week) => week.runs > 0 || weeklyKm(week) >= 1);
 	const window = startAt >= 0 ? complete.slice(startAt) : [];
-	if (window.length === 0) return { score: 0.4, metrics: { plannedPct: null, zeroWeeks: 0, cv: null } };
+	const cvWindow = window.slice(-CFG.consistency.cvWeeks);
+	const recent = window.slice(-CFG.consistency.recentWeeks);
+	if (cvWindow.length === 0) return { score: 0.4, metrics: { plannedPct: null, zeroWeeks: 0, cv: null } };
 
-	const planned = window.filter((week) => Number.isFinite(week.volumePct) && week.isPlanned);
+	const planned = cvWindow.filter(
+		(week) => Number.isFinite(week.volumePct) && week.isPlanned && week.isTaper !== true,
+	);
 	const plannedPct =
 		planned.length > 0
 			? planned.reduce((sum, week) => sum + Math.min(120, week.volumePct), 0) / planned.length
 			: null;
-	const kms = window.map(weeklyKm);
+	const kms = (cvWindow.some((week) => week.isTaper !== true)
+		? cvWindow.filter((week) => week.isTaper !== true)
+		: cvWindow
+	).map(weeklyKm);
 	const mean = kms.reduce((sum, n) => sum + n, 0) / kms.length;
 	const variance = kms.reduce((sum, n) => sum + (n - mean) ** 2, 0) / kms.length;
 	const cv = mean > 0 ? Math.sqrt(variance) / mean : 1;
-	const zeroWeeks = window.filter((week) => week.runs === 0 || weeklyKm(week) < 1).length;
-	const lowWeeks = window.filter((week) => {
+	const zeroWeeks = recent.filter((week) => week.runs === 0 || weeklyKm(week) < 1).length;
+	const lowWeeks = recent.filter((week) => {
 		if (week.isTaper) return false;
 		if (Number.isFinite(week.volumePct)) return week.volumePct < CFG.consistency.lowVolumePct;
 		return mean > 0 && weeklyKm(week) < mean * (CFG.consistency.lowVolumePct / 100);

--- a/netlify/functions/_shared/training/marathonReadiness.test.js
+++ b/netlify/functions/_shared/training/marathonReadiness.test.js
@@ -84,6 +84,18 @@ describe("scoreVolume", () => {
 		);
 	});
 
+	it("does not treat ~30 km weeks as zero volume when that is the plan", () => {
+		const planned = weeksFrom(
+			Array.from({ length: 32 }, (_, i) =>
+				run({ date: addDays(TODAY, -(i * 2 + 1)), distanceKm: 10 }),
+			),
+		).map((week) => ({ ...week, targetKm: 35, volumePct: (week.distanceM / 1000 / 35) * 100 }));
+		const out = scoreVolume({ weeks: planned, today: TODAY });
+		expect(out.score).toBeGreaterThan(0.25);
+		expect(out.metrics.ewma8).toBeGreaterThan(20);
+		expect(out.metrics.ewma8).toBeLessThan(45);
+	});
+
 	it("does not count cycling kilometres as running volume", () => {
 		const runs = Array.from({ length: 20 }, (_, i) =>
 			run({ date: addDays(TODAY, -(i * 2 + 1)), distanceKm: 10 }),
@@ -222,6 +234,22 @@ describe("scoreConsistency", () => {
 		expect(scoreConsistency({ weeks: gapped, today: TODAY }).score).toBeLessThan(
 			scoreConsistency({ weeks: weeksFrom(steadyRuns), today: TODAY }).score,
 		);
+	});
+
+	it("does not treat a zero week two months ago as a recent interruption", () => {
+		const steadyRuns = Array.from({ length: 40 }, (_, i) =>
+			run({ date: addDays(TODAY, -(i + 3)), distanceKm: 10 }),
+		);
+		const oldGap = weeksFrom(steadyRuns).map((week) => {
+			if (week.start === mondayOf(addDays(TODAY, -56))) {
+				return { ...week, distanceM: 0, actualKm: 0, runs: 0, volumePct: 0, longestRunM: 0 };
+			}
+			return week;
+		});
+		const steady = scoreConsistency({ weeks: weeksFrom(steadyRuns), today: TODAY }).score;
+		const gapped = scoreConsistency({ weeks: oldGap, today: TODAY }).score;
+		expect(gapped).toBeGreaterThan(steady - 0.12);
+		expect(gapped).toBeGreaterThan(0.5);
 	});
 
 	it("ignores intentional taper reductions", () => {

--- a/netlify/functions/_shared/training/marathonReadiness.test.js
+++ b/netlify/functions/_shared/training/marathonReadiness.test.js
@@ -1,0 +1,354 @@
+import { describe, it, expect } from "vitest";
+import { addDays, mondayOf } from "./dates.js";
+import { weeklySummaries } from "./fitness.js";
+import {
+	clamp01,
+	combineReadiness,
+	lerpScore,
+	recencyWeight,
+	scoreConsistency,
+	scoreDecoupling,
+	scoreFitnessTrend,
+	scoreFrequency,
+	scoreLongRuns,
+	scoreRecovery,
+	scoreVolume,
+} from "./marathonReadiness.js";
+import { MARATHON_PROJECTION } from "./marathonConfig.js";
+
+const TODAY = "2026-08-24";
+
+function run({ date, distanceKm, movingMin, decouplingPct, paceSecPerKm, sport = "run" }) {
+	const distanceM = distanceKm * 1000;
+	const movingTimeSec = (movingMin ?? distanceKm * 6) * 60;
+	return {
+		sport,
+		startDateLocal: `${date}T07:00:00`,
+		distanceM,
+		movingTimeSec,
+		paceSecPerKm: paceSecPerKm ?? 330,
+		gapPaceSecPerKm: paceSecPerKm ?? 330,
+		decouplingPct: decouplingPct ?? null,
+		load: 50,
+	};
+}
+
+function weeksFrom(runs, from = "2026-06-15", to = TODAY) {
+	return weeklySummaries(
+		runs.filter((activity) => activity.sport !== "ride"),
+		{ from, to },
+	).map((week) => ({
+		...week,
+		actualKm: week.distanceM / 1000,
+		targetKm: 70,
+		volumePct: (week.distanceM / 1000 / 70) * 100,
+		isTaper: false,
+		isPlanned: true,
+	}));
+}
+
+describe("lerpScore", () => {
+	it("is 0 at the floor and 1 at the full mark", () => {
+		expect(lerpScore(40, 40, 85)).toBe(0);
+		expect(lerpScore(85, 40, 85)).toBe(1);
+	});
+
+	it("moves smoothly between the ends and stays in 0–1", () => {
+		expect(lerpScore(62.5, 40, 85)).toBeCloseTo(0.5, 5);
+		expect(lerpScore(10, 40, 85)).toBe(0);
+		expect(lerpScore(200, 40, 85)).toBe(1);
+	});
+});
+
+describe("recencyWeight", () => {
+	it("is 1 today and halves after one half-life", () => {
+		expect(recencyWeight(TODAY, TODAY, 21)).toBeCloseTo(1, 5);
+		expect(recencyWeight(addDays(TODAY, -21), TODAY, 21)).toBeCloseTo(0.5, 5);
+	});
+});
+
+describe("scoreVolume", () => {
+	it("scores higher sustained mileage better", () => {
+		const light = weeksFrom(
+			Array.from({ length: 24 }, (_, i) =>
+				run({ date: addDays(TODAY, -(i * 2 + 1)), distanceKm: 8 }),
+			),
+		);
+		const heavy = weeksFrom(
+			Array.from({ length: 40 }, (_, i) =>
+				run({ date: addDays(TODAY, -(i * 1.5 + 1)), distanceKm: 14 }),
+			),
+		);
+		expect(scoreVolume({ weeks: heavy, today: TODAY }).score).toBeGreaterThan(
+			scoreVolume({ weeks: light, today: TODAY }).score,
+		);
+	});
+
+	it("does not count cycling kilometres as running volume", () => {
+		const runs = Array.from({ length: 20 }, (_, i) =>
+			run({ date: addDays(TODAY, -(i * 2 + 1)), distanceKm: 10 }),
+		);
+		const withRides = [
+			...runs,
+			run({ date: addDays(TODAY, -3), distanceKm: 80, sport: "ride" }),
+		];
+		expect(scoreVolume({ weeks: weeksFrom(withRides), today: TODAY }).score).toBeCloseTo(
+			scoreVolume({ weeks: weeksFrom(runs), today: TODAY }).score,
+			5,
+		);
+	});
+
+	it("does not treat a taper week as a loss of volume", () => {
+		const build = weeksFrom(
+			Array.from({ length: 32 }, (_, i) =>
+				run({ date: addDays(TODAY, -(i * 2 + 8)), distanceKm: 12 }),
+			),
+		);
+		const tapered = build.map((week) => {
+			if (week.start >= mondayOf(addDays(TODAY, -7))) {
+				return { ...week, distanceM: 25000, actualKm: 25, isTaper: true, volumePct: 50 };
+			}
+			return week;
+		});
+		expect(scoreVolume({ weeks: tapered, today: TODAY }).score).toBeGreaterThanOrEqual(
+			scoreVolume({ weeks: build, today: TODAY }).score - 0.001,
+		);
+	});
+});
+
+describe("scoreLongRuns", () => {
+	it("credits a cluster of long runs more than one heroic outing", () => {
+		const clustered = [
+			run({ date: addDays(TODAY, -7), distanceKm: 34 }),
+			run({ date: addDays(TODAY, -14), distanceKm: 30 }),
+			run({ date: addDays(TODAY, -21), distanceKm: 28 }),
+			run({ date: addDays(TODAY, -28), distanceKm: 24 }),
+		];
+		const heroic = [
+			run({ date: addDays(TODAY, -7), distanceKm: 34 }),
+			run({ date: addDays(TODAY, -14), distanceKm: 20 }),
+			run({ date: addDays(TODAY, -21), distanceKm: 18 }),
+			run({ date: addDays(TODAY, -28), distanceKm: 16 }),
+		];
+		expect(scoreLongRuns({ runs: clustered, today: TODAY }).score).toBeGreaterThan(
+			scoreLongRuns({ runs: heroic, today: TODAY }).score + 0.08,
+		);
+	});
+
+	it("does not treat cycling as a long run", () => {
+		const runs = [run({ date: addDays(TODAY, -7), distanceKm: 18 })];
+		const withRide = [...runs, run({ date: addDays(TODAY, -6), distanceKm: 40, sport: "ride" })];
+		expect(scoreLongRuns({ runs: withRide, today: TODAY }).metrics.longestM).toBe(
+			scoreLongRuns({ runs: runs, today: TODAY }).metrics.longestM,
+		);
+	});
+
+	it("gives a modest boost for a long run near marathon pace, not a race", () => {
+		const easy = [
+			run({ date: addDays(TODAY, -7), distanceKm: 28, paceSecPerKm: 360 }),
+			run({ date: addDays(TODAY, -14), distanceKm: 26, paceSecPerKm: 360 }),
+		];
+		const nearMp = [
+			run({ date: addDays(TODAY, -7), distanceKm: 28, paceSecPerKm: 318, decouplingPct: 2 }),
+			run({ date: addDays(TODAY, -14), distanceKm: 26, paceSecPerKm: 320, decouplingPct: 2 }),
+		];
+		const raced = [
+			run({ date: addDays(TODAY, -7), distanceKm: 28, paceSecPerKm: 280, decouplingPct: 7 }),
+			run({ date: addDays(TODAY, -14), distanceKm: 26, paceSecPerKm: 282, decouplingPct: 7 }),
+		];
+		const predictedPace = 313;
+		expect(
+			scoreLongRuns({ runs: nearMp, today: TODAY, predictedPaceSecPerKm: predictedPace }).score,
+		).toBeGreaterThan(
+			scoreLongRuns({ runs: easy, today: TODAY, predictedPaceSecPerKm: predictedPace }).score,
+		);
+		expect(
+			scoreLongRuns({ runs: raced, today: TODAY, predictedPaceSecPerKm: predictedPace }).score,
+		).toBeLessThanOrEqual(
+			scoreLongRuns({ runs: nearMp, today: TODAY, predictedPaceSecPerKm: predictedPace }).score,
+		);
+	});
+});
+
+describe("scoreDecoupling", () => {
+	it("treats lower decoupling as better, including negative as excellent", () => {
+		const long = (pct) => [
+			run({ date: addDays(TODAY, -7), distanceKm: 28, movingMin: 170, decouplingPct: pct }),
+			run({ date: addDays(TODAY, -14), distanceKm: 26, movingMin: 160, decouplingPct: pct }),
+		];
+		expect(scoreDecoupling({ runs: long(1), today: TODAY }).score).toBeGreaterThan(
+			scoreDecoupling({ runs: long(6), today: TODAY }).score,
+		);
+		expect(scoreDecoupling({ runs: long(-2), today: TODAY }).score).toBeGreaterThanOrEqual(
+			scoreDecoupling({ runs: long(0), today: TODAY }).score,
+		);
+		expect(scoreDecoupling({ runs: long(-2), today: TODAY }).score).toBeLessThanOrEqual(1);
+	});
+
+	it("ignores runs too short for decoupling to mean anything", () => {
+		const shorts = [
+			run({ date: addDays(TODAY, -7), distanceKm: 8, movingMin: 40, decouplingPct: 0 }),
+			run({ date: addDays(TODAY, -8), distanceKm: 8, movingMin: 40, decouplingPct: 0 }),
+		];
+		expect(scoreDecoupling({ runs: shorts, today: TODAY }).available).toBe(false);
+	});
+
+	it("weights longer runs more heavily", () => {
+		const longerStable = [
+			run({ date: addDays(TODAY, -7), distanceKm: 32, movingMin: 200, decouplingPct: 1 }),
+			run({ date: addDays(TODAY, -14), distanceKm: 18, movingMin: 80, decouplingPct: 9 }),
+		];
+		const shorterStable = [
+			run({ date: addDays(TODAY, -7), distanceKm: 18, movingMin: 80, decouplingPct: 1 }),
+			run({ date: addDays(TODAY, -14), distanceKm: 32, movingMin: 200, decouplingPct: 9 }),
+		];
+		expect(scoreDecoupling({ runs: longerStable, today: TODAY }).score).toBeGreaterThan(
+			scoreDecoupling({ runs: shorterStable, today: TODAY }).score,
+		);
+	});
+});
+
+describe("scoreConsistency", () => {
+	it("penalises a zero-running week", () => {
+		const steadyRuns = Array.from({ length: 40 }, (_, i) =>
+			run({ date: addDays(TODAY, -(i + 3)), distanceKm: 10 }),
+		);
+		const gapped = weeksFrom(steadyRuns).map((week) => {
+			if (week.start === mondayOf(addDays(TODAY, -14))) {
+				return { ...week, distanceM: 0, actualKm: 0, runs: 0, volumePct: 0, longestRunM: 0 };
+			}
+			return week;
+		});
+		expect(scoreConsistency({ weeks: gapped, today: TODAY }).score).toBeLessThan(
+			scoreConsistency({ weeks: weeksFrom(steadyRuns), today: TODAY }).score,
+		);
+	});
+
+	it("ignores intentional taper reductions", () => {
+		const steady = weeksFrom(
+			Array.from({ length: 40 }, (_, i) =>
+				run({ date: addDays(TODAY, -(i + 3)), distanceKm: 10 }),
+			),
+		);
+		const taper = steady.map((week) =>
+			week.start >= mondayOf(addDays(TODAY, -7))
+				? { ...week, distanceM: 20000, actualKm: 20, volumePct: 40, isTaper: true }
+				: week,
+		);
+		expect(scoreConsistency({ weeks: taper, today: TODAY }).score).toBeGreaterThan(
+			scoreConsistency({ weeks: steady, today: TODAY }).score - 0.05,
+		);
+	});
+});
+
+describe("scoreFrequency", () => {
+	it("scores four runs a week above three, then saturates", () => {
+		const three = Array.from({ length: 18 }, (_, i) =>
+			run({ date: addDays(TODAY, -1 - Math.floor(i * (7 / 3))), distanceKm: 10 }),
+		);
+		const five = Array.from({ length: 30 }, (_, i) =>
+			run({ date: addDays(TODAY, -1 - Math.floor(i * (7 / 5))), distanceKm: 8 }),
+		);
+		const seven = Array.from({ length: 42 }, (_, i) =>
+			run({ date: addDays(TODAY, -(i + 1)), distanceKm: 6 }),
+		);
+		const threeScore = scoreFrequency({ runs: three, today: TODAY }).score;
+		const fiveScore = scoreFrequency({ runs: five, today: TODAY }).score;
+		const sevenScore = scoreFrequency({ runs: seven, today: TODAY }).score;
+		expect(fiveScore).toBeGreaterThan(threeScore);
+		expect(sevenScore).toBeLessThanOrEqual(fiveScore + 0.02);
+	});
+});
+
+describe("scoreFitnessTrend", () => {
+	it("does not punish negative form in a normal training week", () => {
+		const building = {
+			series: [
+				{ date: addDays(TODAY, -42), ctl: 40, atl: 38, tsb: 2 },
+				{ date: addDays(TODAY, -28), ctl: 45, atl: 50, tsb: -5 },
+				{ date: TODAY, ctl: 55, atl: 80, tsb: -25 },
+			],
+			today: TODAY,
+			daysToRace: 50,
+			acwr: { ratio: 1.1 },
+		};
+		const freshButFlat = {
+			series: [
+				{ date: addDays(TODAY, -42), ctl: 55, atl: 40, tsb: 15 },
+				{ date: addDays(TODAY, -28), ctl: 55, atl: 40, tsb: 15 },
+				{ date: TODAY, ctl: 54, atl: 40, tsb: 14 },
+			],
+			today: TODAY,
+			daysToRace: 50,
+			acwr: { ratio: 1.0 },
+		};
+		expect(scoreFitnessTrend(building).score).toBeGreaterThan(scoreFitnessTrend(freshButFlat).score);
+	});
+});
+
+describe("scoreRecovery", () => {
+	it("scores against the athlete's own baseline, not population cutoffs", () => {
+		const good = {
+			sleep: { recent: 7.5 * 3600, baseline: 7.4 * 3600, deltaPct: 1 },
+			restingHr: { recent: 47, baseline: 47, delta: 0 },
+			hrv: { recent: 70, baseline: 68, deltaPct: 3 },
+			series: [],
+		};
+		const poor = {
+			sleep: { recent: 6 * 3600, baseline: 7.4 * 3600, deltaPct: -19 },
+			restingHr: { recent: 54, baseline: 47, delta: 7 },
+			hrv: { recent: 50, baseline: 68, deltaPct: -26 },
+			series: [],
+		};
+		expect(scoreRecovery({ recovery: good, today: TODAY }).score).toBeGreaterThan(
+			scoreRecovery({ recovery: poor, today: TODAY }).score,
+		);
+	});
+
+	it("is unavailable rather than invented when there is no ring data", () => {
+		expect(scoreRecovery({ recovery: null, today: TODAY }).available).toBe(false);
+	});
+});
+
+describe("combineReadiness", () => {
+	it("weights the configured factors and stays in 0–1", () => {
+		const out = combineReadiness({
+			volume: { score: 1 },
+			longRuns: { score: 1 },
+			decoupling: { score: 1, available: true },
+			consistency: { score: 1 },
+			frequency: { score: 1 },
+			fitnessTrend: { score: 1 },
+			recovery: { score: 1, available: true },
+		});
+		expect(out.marathonReadiness).toBeCloseTo(1, 5);
+		expect(clamp01(out.marathonReadiness)).toBe(out.marathonReadiness);
+	});
+
+	it("redistributes weight when a factor is unavailable", () => {
+		const withDecoupling = combineReadiness({
+			volume: { score: 0.8 },
+			longRuns: { score: 0.8 },
+			decoupling: { score: 0.2, available: true },
+			consistency: { score: 0.8 },
+			frequency: { score: 0.8 },
+			fitnessTrend: { score: 0.8 },
+			recovery: { score: 0.8, available: false },
+		});
+		const withoutDecoupling = combineReadiness({
+			volume: { score: 0.8 },
+			longRuns: { score: 0.8 },
+			decoupling: { score: 0.2, available: false },
+			consistency: { score: 0.8 },
+			frequency: { score: 0.8 },
+			fitnessTrend: { score: 0.8 },
+			recovery: { score: 0.8, available: false },
+		});
+		expect(withoutDecoupling.marathonReadiness).toBeGreaterThan(withDecoupling.marathonReadiness);
+	});
+
+	it("keeps configured weights summing to 1", () => {
+		const total = Object.values(MARATHON_PROJECTION.weights).reduce((sum, n) => sum + n, 0);
+		expect(total).toBeCloseTo(1, 10);
+	});
+});

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -12,6 +12,7 @@ import { collectBestEfforts, publicRun } from "./shape.js";
 import { lastRunDetail } from "./lastRun.js";
 import { todayBriefing } from "./today.js";
 import { goalDelta, goalPaceSecPerKm, predictRace } from "./predict.js";
+import { projectMarathon } from "./marathonProjection.js";
 import {
 	blockRange,
 	comparePlan,
@@ -175,10 +176,33 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		? { strain: strainSignal({ tsb: latest?.tsb ?? null, recovery: recovered }) }
 		: null;
 
+	const days = current ? planDays(current, runs, day) : [];
+	const actualToday = runs.filter((r) => toDayKey(r.startDateLocal) === day);
+	const todayRow = days.find((d) => d.date === day) || {
+		date: day,
+		planned: [],
+		actualKm: actualToday.reduce((sum, r) => sum + (Number(r.distanceM) || 0), 0) / 1000,
+		runs: actualToday.length,
+	};
+
+	const remainingDays = daysToRace(plan, day);
 	const raceDistanceM = race.distanceM || 42195;
 	const efforts = collectBestEfforts(runs);
-	const prediction = predictRace(efforts, raceDistanceM);
 	const goalPace = goalPaceSecPerKm(race.goalTimeSec, raceDistanceM);
+	const projection = projectMarathon({
+		efforts,
+		runs,
+		weeks,
+		series,
+		acwr: ratio,
+		intensity,
+		recovery: recovered,
+		today: day,
+		race,
+		plan,
+		daysToRace: remainingDays,
+	});
+	const prediction = projection || predictRace(efforts, raceDistanceM);
 	const delta = prediction ? goalDelta(prediction.predictedSec, race.goalTimeSec) : null;
 
 	const lastLongRun = [...runs]
@@ -199,16 +223,6 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		today: day,
 	});
 
-	const days = current ? planDays(current, runs, day) : [];
-	const actualToday = runs.filter((r) => toDayKey(r.startDateLocal) === day);
-	const todayRow = days.find((d) => d.date === day) || {
-		date: day,
-		planned: [],
-		actualKm: actualToday.reduce((sum, r) => sum + (Number(r.distanceM) || 0), 0) / 1000,
-		runs: actualToday.length,
-	};
-
-	const remainingDays = daysToRace(plan, day);
 	const totals = runs.reduce(
 		(acc, a) => {
 			acc.distanceM += a.distanceM || 0;
@@ -259,8 +273,18 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 					vdotSec: prediction.vdotSec,
 					vdot: prediction.vdot,
 					basis: prediction.basis,
-					deltaSec: delta?.deltaSec ?? null,
-					onTrack: delta?.onTrack ?? null,
+					deltaSec: delta?.deltaSec ?? prediction.deltaSec ?? null,
+					onTrack: delta?.onTrack ?? prediction.onTrack ?? null,
+					aerobicPotentialSeconds: prediction.aerobicPotentialSeconds ?? prediction.predictedSec,
+					marathonReadiness: prediction.marathonReadiness ?? null,
+					readinessPenalty: prediction.readinessPenalty ?? null,
+					confidence: prediction.confidence ?? null,
+					confidenceLabel: prediction.confidenceLabel ?? null,
+					projectionRange: prediction.projectionRange ?? null,
+					factors: prediction.factors ?? null,
+					explanations: prediction.explanations ?? [],
+					raceDay: prediction.raceDay ?? null,
+					debug: prediction.debug ?? null,
 				}
 			: null,
 		longRun: lastLongRun

--- a/netlify/functions/_shared/training/metrics.js
+++ b/netlify/functions/_shared/training/metrics.js
@@ -345,6 +345,7 @@ export function buildDashboard({ activities = [], plan = {}, today, recovery = [
 		recovery: recovered,
 		efforts,
 		targetDistanceM: raceDistanceM,
+		projectedSec: prediction?.predictedSec,
 	});
 
 	return {

--- a/netlify/functions/_shared/training/metrics.test.js
+++ b/netlify/functions/_shared/training/metrics.test.js
@@ -350,6 +350,21 @@ describe("buildDashboard", () => {
 		expect(out.summary.prediction.predictedSec).toBeGreaterThan(0);
 		expect(out.summary.prediction.basis.distanceM).toBe(10000);
 		expect(typeof out.summary.prediction.onTrack).toBe("boolean");
+		expect(out.summary.prediction.aerobicPotentialSeconds).toBeGreaterThan(0);
+		expect(out.summary.prediction.predictedSec).toBeGreaterThanOrEqual(
+			out.summary.prediction.aerobicPotentialSeconds - 1,
+		);
+		expect(out.summary.prediction.marathonReadiness).toBeGreaterThanOrEqual(0);
+		expect(out.summary.prediction.marathonReadiness).toBeLessThanOrEqual(1);
+		expect(out.summary.prediction.projectionRange.slowSec).toBeGreaterThan(
+			out.summary.prediction.predictedSec,
+		);
+		expect(out.summary.prediction.debug.factors).toEqual(
+			expect.objectContaining({
+				volume: expect.any(Number),
+				longRuns: expect.any(Number),
+			}),
+		);
 	});
 });
 
@@ -682,7 +697,10 @@ describe("where the ring meets the training", () => {
 		const withRing = dashboard();
 		const without = buildDashboard({ activities: runs, plan: PLAN, today });
 		expect(withRing.series).toEqual(without.series);
-		expect(withRing.summary).toEqual(without.summary);
+		expect(withRing.summary.latest).toEqual(without.summary.latest);
+		expect(withRing.summary.acwr).toEqual(without.summary.acwr);
+		expect(withRing.summary.totals).toEqual(without.summary.totals);
+		expect(withRing.weeks).toEqual(without.weeks);
 		expect(withRing.lastRun.impact).toEqual(without.lastRun.impact);
 		expect(withRing.today.training).toEqual(without.today.training);
 		expect(without.today.readiness).toBeNull();

--- a/netlify/functions/_shared/training/predict.js
+++ b/netlify/functions/_shared/training/predict.js
@@ -184,13 +184,31 @@ function effortRecencyWeight(date, today) {
 }
 
 /**
+ * True when this best-effort is a split of a longer easy or long run, not a
+ * race or workout. A 23 km long run's "half marathon" is long-run pace.
+ *
+ * @param {{distanceM?: number, activityDistanceM?: number, workoutType?: number|null}} effort
+ */
+export function isContainedSplit(effort) {
+	const activityM = Number(effort?.activityDistanceM);
+	const effortM = Number(effort?.distanceM);
+	if (!(activityM > 0) || !(effortM > 0)) return false;
+	const type = effort.workoutType;
+	if (type === 1 || type === 3) return false;
+	const cfg = MARATHON_PROJECTION.baseline;
+	return activityM >= effortM * cfg.splitRatio && activityM - effortM >= cfg.splitExtraM;
+}
+
+/**
  * Ensemble aerobic potential from recent best efforts.
  *
- * Longer races count more, recent races count more, and a fast short effort
- * that disagrees with a slower longer race is down-weighted rather than
- * allowed to set the marathon time on its own.
+ * Easy-run and long-run *splits* are not races — averaging them in pulls a
+ * marathon projection toward long-run pace. Among the remaining efforts,
+ * longer races count more, recent races count more, and a fast short effort
+ * that disagrees with a slower longer race is down-weighted. If every effort
+ * is a split, fall back to the single best VDOT (the same pick as predictRace).
  *
- * @param {{timeSec: number, distanceM: number, name?: string, date?: string}[]} efforts
+ * @param {{timeSec: number, distanceM: number, name?: string, date?: string, activityDistanceM?: number, workoutType?: number|null}[]} efforts
  * @param {number} targetDistanceM
  * @param {string} [today]
  * @returns {object|null}
@@ -201,7 +219,7 @@ export function aerobicPotential(efforts, targetDistanceM, today) {
 	for (const effort of efforts || []) {
 		if (!(Number(effort?.distanceM) >= cfg.minDistanceM)) continue;
 		const projection = predictFromEffort(effort, targetDistanceM);
-		if (!projection) continue;
+		if (!projection || !(projection.vdot > 0)) continue;
 		candidates.push({
 			effort,
 			projection,
@@ -211,7 +229,18 @@ export function aerobicPotential(efforts, targetDistanceM, today) {
 	}
 	if (candidates.length === 0) return null;
 
-	const longer = candidates.filter((c) => c.effort.distanceM >= 10000);
+	const quality = candidates.filter((c) => !isContainedSplit(c.effort));
+	const poolSource = quality.length > 0 ? quality : [candidates.reduce((best, c) =>
+		c.projection.vdot > best.projection.vdot ? c : best,
+	)];
+	const pool = poolSource.reduce((bestByBand, c) => {
+		const prev = bestByBand.get(c.distanceW);
+		if (!prev || c.projection.vdot > prev.projection.vdot) bestByBand.set(c.distanceW, c);
+		return bestByBand;
+	}, new Map());
+	const selected = [...pool.values()];
+
+	const longer = selected.filter((c) => c.effort.distanceM >= 10000);
 	const longerMean =
 		longer.length > 0
 			? longer.reduce((sum, c) => sum + c.projection.predictedSec, 0) / longer.length
@@ -223,7 +252,7 @@ export function aerobicPotential(efforts, targetDistanceM, today) {
 	let vdotSec = 0;
 	let vdotSum = 0;
 	let best = null;
-	for (const c of candidates) {
+	for (const c of selected) {
 		let weight = c.distanceW * c.recencyW;
 		if (
 			longerMean > 0 &&

--- a/netlify/functions/_shared/training/predict.js
+++ b/netlify/functions/_shared/training/predict.js
@@ -202,11 +202,12 @@ export function isContainedSplit(effort) {
 /**
  * Ensemble aerobic potential from recent best efforts.
  *
- * Easy-run and long-run *splits* are not races — averaging them in pulls a
- * marathon projection toward long-run pace. Among the remaining efforts,
- * longer races count more, recent races count more, and a fast short effort
- * that disagrees with a slower longer race is down-weighted. If every effort
- * is a split, fall back to the single best VDOT (the same pick as predictRace).
+ * Easy-run splits and untagged training runs at long-run pace are not races.
+ * Keep efforts near the athlete's peak VDOT (the same fitness Garmin uses)
+ * plus tagged races, even if a race is slower than a 5k. Among those, longer
+ * races count more, recent races count more, and a fast short effort that
+ * disagrees with a slower *race* is down-weighted. If nothing quality remains,
+ * fall back to the single best VDOT.
  *
  * @param {{timeSec: number, distanceM: number, name?: string, date?: string, activityDistanceM?: number, workoutType?: number|null}[]} efforts
  * @param {number} targetDistanceM
@@ -229,7 +230,12 @@ export function aerobicPotential(efforts, targetDistanceM, today) {
 	}
 	if (candidates.length === 0) return null;
 
-	const quality = candidates.filter((c) => !isContainedSplit(c.effort));
+	const peakVdot = Math.max(...candidates.map((c) => c.projection.vdot));
+	const quality = candidates.filter((c) => {
+		if (isContainedSplit(c.effort)) return false;
+		if (c.projection.vdot >= peakVdot * cfg.qualityVdotFloor) return true;
+		return c.effort.workoutType === 1;
+	});
 	const poolSource = quality.length > 0 ? quality : [candidates.reduce((best, c) =>
 		c.projection.vdot > best.projection.vdot ? c : best,
 	)];
@@ -240,10 +246,12 @@ export function aerobicPotential(efforts, targetDistanceM, today) {
 	}, new Map());
 	const selected = [...pool.values()];
 
-	const longer = selected.filter((c) => c.effort.distanceM >= 10000);
+	const longerRaces = selected.filter(
+		(c) => c.effort.distanceM >= 10000 && c.effort.workoutType === 1,
+	);
 	const longerMean =
-		longer.length > 0
-			? longer.reduce((sum, c) => sum + c.projection.predictedSec, 0) / longer.length
+		longerRaces.length > 0
+			? longerRaces.reduce((sum, c) => sum + c.projection.predictedSec, 0) / longerRaces.length
 			: null;
 
 	let weightSum = 0;

--- a/netlify/functions/_shared/training/predict.js
+++ b/netlify/functions/_shared/training/predict.js
@@ -1,3 +1,6 @@
+import { daysBetween, toDayKey } from "./dates.js";
+import { MARATHON_PROJECTION } from "./marathonConfig.js";
+
 // Race-time prediction.
 //
 // Two independent models, deliberately kept separate rather than blended into
@@ -164,6 +167,89 @@ export function predictRace(efforts, targetDistanceM) {
 
 	const prediction = predictFromEffort(best.effort, targetDistanceM);
 	return prediction ? { ...prediction, basis: best.effort } : null;
+}
+
+function distanceWeight(distanceM) {
+	for (const band of MARATHON_PROJECTION.baseline.distanceWeight) {
+		if (distanceM >= band.minM) return band.weight;
+	}
+	return 0;
+}
+
+function effortRecencyWeight(date, today) {
+	const day = toDayKey(date);
+	const age = day && today ? daysBetween(day, today) : null;
+	if (!Number.isFinite(age) || age < 0) return 0.6;
+	return Math.pow(0.5, age / MARATHON_PROJECTION.windows.effortRecencyHalfLifeDays);
+}
+
+/**
+ * Ensemble aerobic potential from recent best efforts.
+ *
+ * Longer races count more, recent races count more, and a fast short effort
+ * that disagrees with a slower longer race is down-weighted rather than
+ * allowed to set the marathon time on its own.
+ *
+ * @param {{timeSec: number, distanceM: number, name?: string, date?: string}[]} efforts
+ * @param {number} targetDistanceM
+ * @param {string} [today]
+ * @returns {object|null}
+ */
+export function aerobicPotential(efforts, targetDistanceM, today) {
+	const cfg = MARATHON_PROJECTION.baseline;
+	const candidates = [];
+	for (const effort of efforts || []) {
+		if (!(Number(effort?.distanceM) >= cfg.minDistanceM)) continue;
+		const projection = predictFromEffort(effort, targetDistanceM);
+		if (!projection) continue;
+		candidates.push({
+			effort,
+			projection,
+			distanceW: distanceWeight(effort.distanceM),
+			recencyW: effortRecencyWeight(effort.date, today),
+		});
+	}
+	if (candidates.length === 0) return null;
+
+	const longer = candidates.filter((c) => c.effort.distanceM >= 10000);
+	const longerMean =
+		longer.length > 0
+			? longer.reduce((sum, c) => sum + c.projection.predictedSec, 0) / longer.length
+			: null;
+
+	let weightSum = 0;
+	let predicted = 0;
+	let riegel = 0;
+	let vdotSec = 0;
+	let vdotSum = 0;
+	let best = null;
+	for (const c of candidates) {
+		let weight = c.distanceW * c.recencyW;
+		if (
+			longerMean > 0 &&
+			c.effort.distanceM < 15000 &&
+			c.projection.predictedSec < longerMean * (1 - cfg.disagreementPct)
+		) {
+			const gap = (longerMean - c.projection.predictedSec) / longerMean;
+			weight *= Math.max(0.15, 1 - gap / cfg.disagreementPct);
+		}
+		if (!(weight > 0)) continue;
+		weightSum += weight;
+		predicted += c.projection.predictedSec * weight;
+		if (Number.isFinite(c.projection.riegelSec)) riegel += c.projection.riegelSec * weight;
+		if (Number.isFinite(c.projection.vdotSec)) vdotSec += c.projection.vdotSec * weight;
+		if (Number.isFinite(c.projection.vdot)) vdotSum += c.projection.vdot * weight;
+		if (!best || weight > best.weight) best = { ...c, weight };
+	}
+	if (!(weightSum > 0) || !best) return null;
+
+	return {
+		predictedSec: predicted / weightSum,
+		riegelSec: riegel / weightSum,
+		vdotSec: vdotSec / weightSum,
+		vdot: vdotSum / weightSum,
+		basis: best.effort,
+	};
 }
 
 /**

--- a/netlify/functions/_shared/training/predict.test.js
+++ b/netlify/functions/_shared/training/predict.test.js
@@ -124,7 +124,7 @@ describe("aerobicPotential", () => {
 	});
 
 	it("leans on the half when a 5k disagrees substantially", () => {
-		const half = { distanceM: 21097.5, timeSec: 6300, date: "2026-08-10" };
+		const half = { distanceM: 21097.5, timeSec: 6300, date: "2026-08-10", workoutType: 1 };
 		const five = { distanceM: 5000, timeSec: 1080, date: "2026-08-17" };
 		const out = aerobicPotential([half, five], MARATHON_M, "2026-08-24");
 		const halfSec = predictFromEffort(half, MARATHON_M).predictedSec;
@@ -161,6 +161,41 @@ describe("aerobicPotential", () => {
 		const out = aerobicPotential([fast5k, easyHalf], MARATHON_M, "2026-08-24");
 		expect(out.predictedSec).toBeCloseTo(predictFromEffort(fast5k, MARATHON_M).predictedSec, 0);
 		expect(out.basis.distanceM).toBe(5000);
+	});
+
+	it("does not let an untagged 15k at long-run pace set aerobic potential", () => {
+		const five = {
+			name: "5k",
+			distanceM: 5000,
+			timeSec: 1240,
+			date: "2026-07-20",
+			activityDistanceM: 8000,
+			workoutType: 3,
+		};
+		const easy15 = {
+			name: "15K",
+			distanceM: 15000,
+			timeSec: 4747,
+			date: "2026-07-26",
+			activityDistanceM: 15014,
+			workoutType: null,
+		};
+		const out = aerobicPotential([five, easy15], MARATHON_M, "2026-08-24");
+		const fiveSec = predictFromEffort(five, MARATHON_M).predictedSec;
+		const easySec = predictFromEffort(easy15, MARATHON_M).predictedSec;
+		expect(out.predictedSec).toBeCloseTo(fiveSec, 0);
+		expect(Math.abs(out.predictedSec - fiveSec)).toBeLessThan(Math.abs(out.predictedSec - easySec));
+		expect(out.basis.distanceM).toBe(5000);
+	});
+
+	it("does not let a tempo 10k a bit off peak VDOT drag a 5k toward long-run pace", () => {
+		const five = { name: "5k", distanceM: 5000, timeSec: 1240, date: "2026-07-20", workoutType: 3 };
+		const tempo10 = { name: "10k", distanceM: 10000, timeSec: 2850, date: "2026-07-29", workoutType: 3 };
+		const out = aerobicPotential([five, tempo10], MARATHON_M, "2026-08-24");
+		const fiveSec = predictFromEffort(five, MARATHON_M).predictedSec;
+		const tempoSec = predictFromEffort(tempo10, MARATHON_M).predictedSec;
+		expect(out.predictedSec).toBeCloseTo(fiveSec, 0);
+		expect(Math.abs(out.predictedSec - fiveSec)).toBeLessThan(Math.abs(out.predictedSec - tempoSec));
 	});
 });
 

--- a/netlify/functions/_shared/training/predict.test.js
+++ b/netlify/functions/_shared/training/predict.test.js
@@ -131,6 +131,37 @@ describe("aerobicPotential", () => {
 		const fiveSec = predictFromEffort(five, MARATHON_M).predictedSec;
 		expect(Math.abs(out.predictedSec - halfSec)).toBeLessThan(Math.abs(out.predictedSec - fiveSec));
 	});
+
+	it("ignores easy-run splits that are far slower than a genuine best effort", () => {
+		const race5k = { name: "5k", distanceM: 5000, timeSec: 1110, date: "2026-08-05", activityDistanceM: 5200, workoutType: 3 };
+		const easyHalf = { name: "Half-Marathon", distanceM: 21097, timeSec: 6563, date: "2026-08-23", activityDistanceM: 23000, workoutType: 2 };
+		const easy10ks = [
+			{ name: "10k", distanceM: 10000, timeSec: 3200, date: "2026-08-14", activityDistanceM: 12000 },
+			{ name: "10k", distanceM: 10000, timeSec: 3180, date: "2026-08-09", activityDistanceM: 11800 },
+			{ name: "10k", distanceM: 10000, timeSec: 3300, date: "2026-08-01", activityDistanceM: 12500 },
+		];
+		const out = aerobicPotential([race5k, easyHalf, ...easy10ks], MARATHON_M, "2026-08-24");
+		const raceSec = predictFromEffort(race5k, MARATHON_M).predictedSec;
+		const easySec = predictFromEffort(easyHalf, MARATHON_M).predictedSec;
+		expect(out.predictedSec).toBeCloseTo(raceSec, 0);
+		expect(Math.abs(out.predictedSec - raceSec)).toBeLessThan(Math.abs(out.predictedSec - easySec));
+		expect(out.basis.distanceM).toBe(5000);
+	});
+
+	it("still uses a workout 5k when the session includes warmup and cooldown", () => {
+		const workout = { name: "5k", distanceM: 5000, timeSec: 1110, date: "2026-08-05", activityDistanceM: 9000, workoutType: 3 };
+		const out = aerobicPotential([workout], MARATHON_M, "2026-08-24");
+		expect(out.basis.distanceM).toBe(5000);
+		expect(out.predictedSec).toBeCloseTo(predictFromEffort(workout, MARATHON_M).predictedSec, 0);
+	});
+
+	it("falls back to the fastest VDOT when every effort is a long-run split", () => {
+		const fast5k = { name: "5k", distanceM: 5000, timeSec: 1240, date: "2026-07-20", activityDistanceM: 8000 };
+		const easyHalf = { name: "Half-Marathon", distanceM: 21097, timeSec: 6563, date: "2026-08-23", activityDistanceM: 23000, workoutType: 2 };
+		const out = aerobicPotential([fast5k, easyHalf], MARATHON_M, "2026-08-24");
+		expect(out.predictedSec).toBeCloseTo(predictFromEffort(fast5k, MARATHON_M).predictedSec, 0);
+		expect(out.basis.distanceM).toBe(5000);
+	});
 });
 
 describe("goalDelta", () => {

--- a/netlify/functions/_shared/training/predict.test.js
+++ b/netlify/functions/_shared/training/predict.test.js
@@ -6,6 +6,7 @@ import {
 	vdotProjection,
 	predictFromEffort,
 	predictRace,
+	aerobicPotential,
 	goalDelta,
 	goalPaceSecPerKm,
 } from "./predict.js";
@@ -110,6 +111,25 @@ describe("predictRace", () => {
 	it("returns null when every effort is too short", () => {
 		expect(predictRace([{ distanceM: 1500, timeSec: 300 }], MARATHON_M)).toBeNull();
 		expect(predictRace([], MARATHON_M)).toBeNull();
+	});
+});
+
+describe("aerobicPotential", () => {
+	it("matches a single-effort projection", () => {
+		const effort = { distanceM: 10000, timeSec: 2400, date: "2026-08-01" };
+		const single = predictFromEffort(effort, MARATHON_M);
+		const out = aerobicPotential([effort], MARATHON_M, "2026-08-24");
+		expect(out.predictedSec).toBeCloseTo(single.predictedSec, 0);
+		expect(out.basis.distanceM).toBe(10000);
+	});
+
+	it("leans on the half when a 5k disagrees substantially", () => {
+		const half = { distanceM: 21097.5, timeSec: 6300, date: "2026-08-10" };
+		const five = { distanceM: 5000, timeSec: 1080, date: "2026-08-17" };
+		const out = aerobicPotential([half, five], MARATHON_M, "2026-08-24");
+		const halfSec = predictFromEffort(half, MARATHON_M).predictedSec;
+		const fiveSec = predictFromEffort(five, MARATHON_M).predictedSec;
+		expect(Math.abs(out.predictedSec - halfSec)).toBeLessThan(Math.abs(out.predictedSec - fiveSec));
 	});
 });
 

--- a/netlify/functions/_shared/training/recommend.js
+++ b/netlify/functions/_shared/training/recommend.js
@@ -420,7 +420,7 @@ export function recommendations(metrics) {
 					"goal-behind",
 					"info",
 					`Projecting about ${duration(Math.abs(delta))} short of goal`,
-					`Current form projects ${duration(prediction.predictedSec)} against your ${duration(goal.goalTimeSec)} target — which needs ${pace(goal.goalPaceSecPerKm)}. The projection is based on your best recent effort and assumes the endurance work continues, so treat it as a floor rather than a verdict.`,
+					`Current form projects ${duration(prediction.predictedSec)} against your ${duration(goal.goalTimeSec)} target — which needs ${pace(goal.goalPaceSecPerKm)}. The projection starts from recent race performances and then discounts for how marathon-ready the current training actually is.`,
 					prediction.predictedSec,
 					goal.goalTimeSec,
 					"duration",

--- a/netlify/functions/_shared/training/shape.js
+++ b/netlify/functions/_shared/training/shape.js
@@ -364,7 +364,13 @@ export function shapeActivities(rawActivities, options = {}) {
 export function collectBestEfforts(activities) {
 	const efforts = [];
 	for (const a of activities || []) {
-		for (const e of a.bestEfforts || []) efforts.push(e);
+		for (const e of a.bestEfforts || []) {
+			efforts.push({
+				...e,
+				activityDistanceM: Number(a.distanceM) || e.activityDistanceM,
+				workoutType: Number.isFinite(a.workoutType) ? a.workoutType : (e.workoutType ?? null),
+			});
+		}
 	}
 	return efforts.sort((a, b) => String(b.date).localeCompare(String(a.date)));
 }

--- a/netlify/functions/_shared/training/shape.test.js
+++ b/netlify/functions/_shared/training/shape.test.js
@@ -237,6 +237,18 @@ describe("collectBestEfforts", () => {
 	it("handles activities with no efforts", () => {
 		expect(collectBestEfforts([{}, { bestEfforts: [] }])).toEqual([]);
 	});
+
+	it("tags each effort with the parent activity distance and workout type", () => {
+		const out = collectBestEfforts([
+			{
+				distanceM: 23000,
+				workoutType: 2,
+				bestEfforts: [{ name: "Half-Marathon", distanceM: 21097, timeSec: 6563, date: "2026-08-23" }],
+			},
+		]);
+		expect(out[0].activityDistanceM).toBe(23000);
+		expect(out[0].workoutType).toBe(2);
+	});
 });
 
 function rawRide(overrides = {}) {

--- a/netlify/functions/_shared/training/today.js
+++ b/netlify/functions/_shared/training/today.js
@@ -61,9 +61,9 @@ function sessionFrom(day) {
 	};
 }
 
-function predictionOf({ efforts, targetDistanceM, date, ranToday }) {
+function predictionOf({ efforts, targetDistanceM, date, ranToday, projectedSec }) {
 	const after = predictRace(efforts, targetDistanceM);
-	if (!after) return null;
+	if (!after && !Number.isFinite(projectedSec)) return null;
 	// Re-predict without today's efforts rather than trusting basis.date:
 	// an easy 6k still has a 5k split, and that split is "today" even when
 	// it did not beat the existing basis. The number this cell exists to
@@ -72,10 +72,10 @@ function predictionOf({ efforts, targetDistanceM, date, ranToday }) {
 		(efforts || []).filter((effort) => effort?.date !== date),
 		targetDistanceM,
 	);
-	const predictedSec = after.predictedSec;
+	const predictedSec = Number.isFinite(projectedSec) ? projectedSec : after.predictedSec;
 	let sessionDeltaSec = null;
 	if (ranToday) {
-		sessionDeltaSec = prior ? Math.round(predictedSec - prior.predictedSec) : 0;
+		sessionDeltaSec = prior ? Math.round((after?.predictedSec ?? predictedSec) - prior.predictedSec) : 0;
 	}
 	return {
 		predictedSec,
@@ -103,6 +103,7 @@ export function todayBriefing({
 	recovery = null,
 	efforts = [],
 	targetDistanceM = 42195,
+	projectedSec = null,
 } = {}) {
 	const training = trainingOf(series, date);
 	const session = sessionFrom(day);
@@ -116,6 +117,7 @@ export function todayBriefing({
 			targetDistanceM,
 			date,
 			ranToday: session.actualKm > 0,
+			projectedSec,
 		}),
 	};
 }

--- a/netlify/functions/_shared/training/today.test.js
+++ b/netlify/functions/_shared/training/today.test.js
@@ -57,6 +57,7 @@ describe("todayBriefing", () => {
 			recovery: extra.recovery ?? null,
 			efforts: extra.efforts,
 			targetDistanceM: extra.targetDistanceM,
+			projectedSec: extra.projectedSec,
 		});
 	}
 
@@ -147,6 +148,19 @@ describe("todayBriefing", () => {
 		expect(out.prediction.sessionDeltaSec).toBe(Math.round(after.predictedSec - before.predictedSec));
 		expect(out.prediction.sessionDeltaSec).toBeLessThan(0);
 		expect(out.prediction.predictedSec).toBe(after.predictedSec);
+	});
+
+	it("uses the dashboard projection when one is provided", () => {
+		const out = briefing(
+			{ [today]: 0 },
+			{
+				efforts: [{ date: yesterday, distanceM: 10000, timeSec: 2580, name: "10K" }],
+				targetDistanceM: 42195,
+				projectedSec: 12300,
+			},
+		);
+		expect(out.prediction.predictedSec).toBe(12300);
+		expect(out.prediction.sessionDeltaSec).toBeNull();
 	});
 
 	it("leaves training null on the first day of the series rather than inventing a yesterday", () => {

--- a/src/components/Training/lib/format.js
+++ b/src/components/Training/lib/format.js
@@ -74,6 +74,23 @@ export function clock(sec) {
 }
 
 /**
+ * A race time rounded to the minute, as h:mm.
+ *
+ * Marathon projections are not precise to the second. The headline and the
+ * likely range use this so the page does not pretend they are.
+ *
+ * @param {number} sec
+ * @returns {string}
+ */
+export function clockMinutes(sec) {
+	if (!(sec > 0)) return "—";
+	const total = Math.round(sec / 60);
+	const h = Math.floor(total / 60);
+	const m = total % 60;
+	return h > 0 ? `${h}:${pad(m)}` : `${m} min`;
+}
+
+/**
  * A signed duration, for "4:32 ahead of goal" style deltas.
  *
  * @param {number} sec

--- a/src/components/Training/lib/format.test.js
+++ b/src/components/Training/lib/format.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { weekRange, pace, clock, km, pct, shortDate, daysAgo, signed, speed, readout, splitLead, timeTaken } from "./format.js";
+import { weekRange, pace, clock, clockMinutes, km, pct, shortDate, daysAgo, signed, speed, readout, splitLead, timeTaken } from "./format.js";
 
 describe("readout", () => {
 	it("binds symbols to both numbers and says words once", () => {
@@ -151,6 +151,12 @@ describe("training formatters", () => {
 	it("prints a race time with hours only when there are any", () => {
 		expect(clock(13200)).toBe("3:40:00");
 		expect(clock(1800)).toBe("30:00");
+	});
+
+	it("rounds a projection to the minute rather than the second", () => {
+		expect(clockMinutes(12420)).toBe("3:27");
+		expect(clockMinutes(12450)).toBe("3:28");
+		expect(clockMinutes(null)).toBe("—");
 	});
 
 	it("spells a headline duration so it can't be read as metres", () => {

--- a/src/components/Training/lib/glossary.js
+++ b/src/components/Training/lib/glossary.js
@@ -94,13 +94,15 @@ export const GLOSSARY = {
 	prediction: {
 		title: "Projected finish",
 		body: [
-			"What your recent hard efforts imply for the marathon, using two standard models. They disagree, and by how much is informative, so both are shown; the headline takes the slower of the two.",
-			"Both assume you keep doing the endurance work, so treat this as a floor for a well-executed race rather than a verdict on today.",
+			"What the current training supports for the marathon, not a finish time to the second. Riegel and VDOT estimate aerobic potential from shorter races; marathon readiness then asks how much of that potential the long runs, volume, and consistency can actually hold.",
+			"The headline is the readiness-adjusted projection. The likely range is a spread from how much marathon-specific evidence there is — not a statistical confidence interval. Excellent marathon prep approaches the aerobic baseline; incomplete prep opens a wider gap.",
 		],
 		terms: [
+			{ term: "Aerobic potential", definition: "What Riegel and VDOT imply from recent shorter races. This is the optimistic ceiling, not a promise that the endurance work is already done." },
+			{ term: "Marathon readiness", definition: "How much of that aerobic potential the last 8–10 weeks of running actually support over 42.2 km. Training data can close the gap; it does not mint a faster marathon than the baseline." },
+			{ term: "Likely range", definition: "A projection spread from the amount and quality of marathon-specific evidence. Wider when the projection leans on a 5k, missing long runs, or broken training; tighter when long runs, volume, and decoupling agree." },
 			{ term: "Riegel", definition: "Scales a known race time up to the marathon distance using a fixed fatigue exponent. Simple, and optimistic for anyone under-trained for the distance." },
 			{ term: "VDOT", definition: "Daniels' method: turns an effort into an estimate of aerobic power, then reads the equivalent marathon time off that." },
-			{ term: "Goal pace", definition: "The average pace per kilometre your goal time requires, start to finish." },
 		],
 	},
 

--- a/src/components/Training/sections/RaceHeader.svelte
+++ b/src/components/Training/sections/RaceHeader.svelte
@@ -3,7 +3,7 @@
     training is in, and whether current fitness projects to the goal.
 -->
 <script>
-    import { clock, km, pace, signed, signedClock } from "../lib/format.js";
+    import { clock, clockMinutes, km, pace, signed, signedClock } from "../lib/format.js";
 
     let { summary } = $props();
 
@@ -70,7 +70,7 @@
     <div class="stat">
         <span class="stat-label">Projected</span>
         <strong class="stat-value" class:ahead={prediction?.onTrack} class:behind={prediction && !prediction.onTrack}>
-            {prediction ? clock(prediction.predictedSec) : "—"}
+            {prediction ? clockMinutes(prediction.predictedSec) : "—"}
         </strong>
         <span class="stat-note">
             {prediction ? signedClock(prediction.deltaSec) : "needs a hard effort to project from"}

--- a/src/components/Training/sections/RacePrediction.svelte
+++ b/src/components/Training/sections/RacePrediction.svelte
@@ -1,14 +1,14 @@
 <!--
     Projected finish against the goal.
 
-    Both models are shown rather than just the headline number: they disagree,
-    and by how much is informative. The headline takes the slower of the two,
-    since both assume the endurance work has been done and therefore flatter a
-    marathon projection made from a shorter effort.
+    The headline is a readiness-adjusted marathon time, rounded to the minute.
+    Riegel and VDOT stay visible as aerobic potential — the optimistic ceiling
+    from shorter races — and a handful of deterministic factors explain why
+    the two diverge.
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
-    import { clock, km, pace, shortDate, signedClock } from "../lib/format.js";
+    import { clockMinutes, km, pace, shortDate, signedClock } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { summary = null } = $props();
@@ -16,6 +16,29 @@
     const prediction = $derived(summary?.prediction || null);
     const race = $derived(summary?.race || {});
     const basis = $derived(prediction?.basis || null);
+    const range = $derived(prediction?.projectionRange || null);
+    const explanations = $derived(prediction?.explanations || []);
+    const readinessPct = $derived(
+        Number.isFinite(prediction?.marathonReadiness)
+            ? Math.round(prediction.marathonReadiness * 100)
+            : null,
+    );
+    const factorRows = $derived.by(() => {
+        const scores = prediction?.factors;
+        if (!scores) return [];
+        const labels = {
+            volume: "Sustained volume",
+            longRuns: "Long-run development",
+            decoupling: "Aerobic stability",
+            consistency: "Training consistency",
+            frequency: "Run frequency",
+            fitnessTrend: "Fitness trend",
+            recovery: "Recovery",
+        };
+        return Object.entries(labels)
+            .filter(([key]) => Number.isFinite(scores[key]))
+            .map(([key, label]) => ({ key, label, pct: Math.round(scores[key] * 100) }));
+    });
 </script>
 
 <Card title="Projected finish" info={GLOSSARY.prediction}>
@@ -27,7 +50,7 @@
     {:else}
         <div class="headline">
             <div class="projected" class:ahead={prediction.onTrack}>
-                <strong>{clock(prediction.predictedSec)}</strong>
+                <strong>{clockMinutes(prediction.predictedSec)}</strong>
                 <span>projected</span>
             </div>
             <div class="delta" class:ahead={prediction.onTrack}>
@@ -35,17 +58,26 @@
             </div>
         </div>
 
+        {#if range}
+            <p class="range">
+                Likely range {clockMinutes(range.fastSec)}–{clockMinutes(range.slowSec)}
+            </p>
+        {/if}
+
         <div class="models">
             <div class="model">
-                <span class="model-label">Riegel</span>
-                <strong>{clock(prediction.riegelSec)}</strong>
+                <span class="model-label">Aerobic potential</span>
+                <strong>{clockMinutes(Number.isFinite(prediction.aerobicPotentialSeconds) ? prediction.aerobicPotentialSeconds : prediction.predictedSec)}</strong>
+                <span class="model-note">
+                    VDOT {clockMinutes(prediction.vdotSec)} · Riegel {clockMinutes(prediction.riegelSec)}
+                </span>
             </div>
             <div class="model">
-                <span class="model-label">VDOT</span>
-                <strong>{clock(prediction.vdotSec)}</strong>
-                {#if Number.isFinite(prediction.vdot)}
-                    <span class="model-note">{prediction.vdot.toFixed(1)}</span>
-                {/if}
+                <span class="model-label">Marathon readiness</span>
+                <strong>{readinessPct !== null ? `${readinessPct}%` : "—"}</strong>
+                <span class="model-note">
+                    {prediction.confidenceLabel ? `${prediction.confidenceLabel} confidence` : "from completed training"}
+                </span>
             </div>
             <div class="model">
                 <span class="model-label">Goal pace</span>
@@ -53,11 +85,47 @@
             </div>
         </div>
 
-        {#if basis}
+        {#if prediction.raceDay}
+            <p class="raceday">
+                If remaining planned training is completed conservatively:
+                {clockMinutes(prediction.raceDay.predictedSec)}
+                ({Math.round(prediction.raceDay.marathonReadiness * 100)}% readiness).
+            </p>
+        {/if}
+
+        {#if explanations.length}
+            <ul class="factors">
+                {#each explanations as item}
+                    <li class={item.direction}>
+                        <span>{item.direction === "limiting" ? "Limiting" : "Positive"}</span>
+                        {item.text}
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+
+        {#if factorRows.length}
+            <details class="breakdown">
+                <summary>How readiness was scored</summary>
+                <ul>
+                    {#each factorRows as row}
+                        <li>
+                            <span>{row.label}</span>
+                            <strong>{row.pct}%</strong>
+                        </li>
+                    {/each}
+                </ul>
+                {#if basis}
+                    <p>
+                        Aerobic potential from your {km(basis.distanceM)} best effort of {clockMinutes(basis.timeSec)}
+                        {#if basis.date}on {shortDate(basis.date)}{/if}.
+                    </p>
+                {/if}
+            </details>
+        {:else if basis}
             <p class="basis">
-                Projected from your {km(basis.distanceM)} best effort of {clock(basis.timeSec)}
-                {#if basis.date}on {shortDate(basis.date)}{/if}. Both models assume the endurance
-                work continues, so treat this as a floor rather than a verdict.
+                Projected from your {km(basis.distanceM)} best effort of {clockMinutes(basis.timeSec)}
+                {#if basis.date}on {shortDate(basis.date)}{/if}.
             </p>
         {/if}
     {/if}
@@ -101,9 +169,16 @@
     }
     .delta.ahead { background: var(--tone-good-bg); color: var(--tone-good); }
 
+    .range {
+        margin: var(--space-3) 0 0 0;
+        font-size: var(--font-sm);
+        color: var(--paragraph-colour);
+        opacity: 0.8;
+    }
+
     .models {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
         gap: var(--space-3);
         margin-top: var(--space-5);
         padding-top: var(--space-4);
@@ -126,6 +201,74 @@
         font-size: var(--font-2xs);
         color: var(--paragraph-colour);
         opacity: 0.6;
+        line-height: 1.4;
+    }
+
+    .raceday {
+        margin: var(--space-4) 0 0 0;
+        font-size: var(--font-xs);
+        color: var(--paragraph-colour);
+        opacity: 0.75;
+        line-height: 1.5;
+    }
+
+    .factors {
+        list-style: none;
+        margin: var(--space-5) 0 0 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+    .factors li {
+        font-size: var(--font-xs);
+        line-height: 1.45;
+        color: var(--paragraph-colour);
+        padding-left: var(--space-3);
+        border-left: 3px solid var(--main-green-translucent);
+    }
+    .factors li span {
+        display: block;
+        font-size: var(--font-2xs);
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        margin-bottom: 1px;
+        color: var(--main-green);
+    }
+    .factors li.limiting { border-left-color: var(--tone-bad); }
+    .factors li.limiting span { color: var(--tone-bad); }
+    .factors li.positive { border-left-color: var(--tone-good); }
+    .factors li.positive span { color: var(--tone-good); }
+
+    .breakdown {
+        margin-top: var(--space-4);
+        font-size: var(--font-xs);
+        color: var(--paragraph-colour);
+    }
+    .breakdown summary {
+        cursor: pointer;
+        color: var(--main-green);
+        font-weight: 600;
+        letter-spacing: 0.04em;
+    }
+    .breakdown ul {
+        list-style: none;
+        margin: var(--space-3) 0 0 0;
+        padding: 0;
+        display: grid;
+        gap: var(--space-2);
+    }
+    .breakdown li {
+        display: flex;
+        justify-content: space-between;
+        gap: var(--space-3);
+        opacity: 0.85;
+    }
+    .breakdown p {
+        margin: var(--space-3) 0 0 0;
+        opacity: 0.7;
+        line-height: 1.5;
     }
 
     .basis, .empty {

--- a/src/components/Training/sections/Today.svelte
+++ b/src/components/Training/sections/Today.svelte
@@ -13,7 +13,7 @@
 -->
 <script>
     import Card from "../../../lib/ui/Card.svelte";
-    import { clock, signed, shortDate } from "../lib/format.js";
+    import { clock, clockMinutes, signed, shortDate } from "../lib/format.js";
     import { GLOSSARY } from "../lib/glossary.js";
 
     let { today = null } = $props();
@@ -67,14 +67,14 @@
         if (sessionDeltaSec === 0) {
             return {
                 title: "No change",
-                note: Number.isFinite(predictedSec) ? `still ${clock(predictedSec)}` : "today's run didn't move it",
+                note: Number.isFinite(predictedSec) ? `still ${clockMinutes(predictedSec)}` : "today's run didn't move it",
                 tone: null,
             };
         }
         const faster = sessionDeltaSec < 0;
         return {
             title: `${clock(Math.abs(sessionDeltaSec))} ${faster ? "faster" : "slower"}`,
-            note: Number.isFinite(predictedSec) ? `now ${clock(predictedSec)}` : "",
+            note: Number.isFinite(predictedSec) ? `now ${clockMinutes(predictedSec)}` : "",
             tone: faster ? "ahead" : "behind",
         };
     });


### PR DESCRIPTION
## Summary
- Keep Riegel/VDOT as the aerobic baseline (now a recency- and distance-weighted ensemble) and apply a deterministic marathon-readiness penalty from completed training.
- Show a minute-rounded projected finish, likely range, readiness %, confidence, and a few explainable factors instead of a time to the second.
- Training data can close the gap to aerobic potential but cannot make the headline faster; cycling never counts as running mileage.
- Follow-up: ignore easy/long-run best-effort *splits* (they are not races), score volume against the actual plan instead of an 85 km/wk curve, and stop treating a gap two months ago as a recent interruption. That is what made the first preview show 4:49.
- Follow-up: untagged training runs at long-run pace (the 15k that produced 4:07) no longer set aerobic potential. Peak VDOT / tagged races do, with only a small readiness tax, so the headline sits near Garmin (~3:25) rather than 4:07. Today uses the same number as the card.

## Test plan
- [ ] Confirm unit tests around volume, long runs, decoupling, consistency, and the monotonic cases still pass (`npx vitest run netlify/functions/_shared/training`).
- [ ] Open `/training` and check the Projected finish card: `h:mm` headline, likely range, aerobic potential, readiness, and 2–4 factors.
- [ ] Confirm the headline is near ~3:25 (Garmin-like), aerobic potential is the 5k not a training 15k, and Today matches the card.
- [ ] Expand “How readiness was scored” and confirm the debug fields on `trainingData` (`prediction.debug`) match the card.
- [ ] Verify a ride does not change the projection, and that completing a long run tightens the gap toward aerobic potential rather than beating it.